### PR TITLE
Refactor product_detail context

### DIFF
--- a/inventory/views.py
+++ b/inventory/views.py
@@ -927,6 +927,7 @@ def product_detail(request, product_id):
 
     prev_orders.sort(key=lambda x: x["date_ordered"], reverse=True)
 
+    # Consolidate context in one dictionary so each key appears only once
     context = {
         "product": product,
         **safe_stock,
@@ -938,19 +939,12 @@ def product_detail(request, product_id):
         "prod_score": prod_score,
         "health": health,
         "prev_orders": prev_orders,
+        "lifetime_sold_qty": lifetime_sold_qty,
+        "lifetime_sold_val": lifetime_sold_val,
+        "total_order_cost": total_order_cost,
+        "lifetime_profit": lifetime_profit,
+        "current_inventory": current_inventory,
     }
-
-    # — Now inject all of it into context separately —
-    context.update(
-        {
-            "prev_orders": prev_orders,
-            "lifetime_sold_qty": lifetime_sold_qty,
-            "lifetime_sold_val": lifetime_sold_val,
-            "total_order_cost": total_order_cost,
-            "lifetime_profit": lifetime_profit,
-            "current_inventory": current_inventory,
-        }
-    )
 
     return render(request, "inventory/product_detail.html", context)
 


### PR DESCRIPTION
## Summary
- consolidate context construction in `product_detail`
- avoid duplicate keys so lifetime and inventory fields show only once

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6873fcf1649c832c974af1eff64341f5