### PR TITLE
Convert group/series filters to checkboxes

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -431,6 +431,15 @@ label.hide {
   margin-right: 20px;
 }
 
+#productFilterForm .checkbox-set {
+  display: flex;
+  align-items: center;
+}
+
+#productFilterForm .checkbox-set > span {
+  margin-right: 10px;
+}
+
 #productFilterForm .input-field {
   margin: 0;
   min-width: 150px;

--- a/inventory/templates/inventory/product_list.html
+++ b/inventory/templates/inventory/product_list.html
@@ -92,22 +92,38 @@
           <label>Age</label>
         </div>
 
-        <div class="input-field">
-          <select name="group_filter" multiple onchange="this.form.submit()">
-            {% for group in group_choices %}
-              <option value="{{ group.id }}" {% if group.id|stringformat:'s' in group_filters %}selected{% endif %}>{{ group.name }}</option>
-            {% endfor %}
-          </select>
-          <label>Group</label>
+        <div class="checkbox-set">
+          <span>Group:</span>
+          {% for group in group_choices %}
+            <label class="checkbox-field">
+              <input
+                type="checkbox"
+                name="group_filter"
+                value="{{ group.id }}"
+                class="filled-in"
+                {% if group.id|stringformat:'s' in group_filters %}checked{% endif %}
+                onchange="this.form.submit()"
+              />
+              <span>{{ group.name }}</span>
+            </label>
+          {% endfor %}
         </div>
 
-        <div class="input-field">
-          <select name="series_filter" multiple onchange="this.form.submit()">
-            {% for ser in series_choices %}
-              <option value="{{ ser.id }}" {% if ser.id|stringformat:'s' in series_filters %}selected{% endif %}>{{ ser.name }}</option>
-            {% endfor %}
-          </select>
-          <label>Series</label>
+        <div class="checkbox-set">
+          <span>Series:</span>
+          {% for ser in series_choices %}
+            <label class="checkbox-field">
+              <input
+                type="checkbox"
+                name="series_filter"
+                value="{{ ser.id }}"
+                class="filled-in"
+                {% if ser.id|stringformat:'s' in series_filters %}checked{% endif %}
+                onchange="this.form.submit()"
+              />
+              <span>{{ ser.name }}</span>
+            </label>
+          {% endfor %}
         </div>
 
         <input type="hidden" name="view_mode" value="{{ view_mode }}" />


### PR DESCRIPTION
## Summary
- show checkboxes for Group and Series filters
- style checkbox sets in filter form

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6872a8717424832cb5b3715053928cb8