### PR TITLE
Convert group/series filters to checkboxes

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -431,6 +431,15 @@ label.hide {
   margin-right: 20px;
 }
 
+#productFilterForm .checkbox-set {
+  display: flex;
+  align-items: center;
+}
+
+#productFilterForm .checkbox-set > span {
+  margin-right: 10px;
+}
+
 #productFilterForm .input-field {
   margin: 0;
   min-width: 150px;

--- a/inventory/templates/inventory/product_list.html
+++ b/inventory/templates/inventory/product_list.html
@@ -10,25 +10,11 @@
   <div id="controls" class="row grey lighten-3">
     <div class="col s1">
       <div class="view-toggle">
-        <a href="?view_mode=list
-                 {% if show_retired %}&show_retired=true{% endif %}
-                 {% if type_filter  %}&type_filter={{ type_filter }}{% endif %}
-                 {% if style_filter %}&style_filter={{ style_filter }}{% endif %}
-                 {% if age_filter   %}&age_filter={{ age_filter }}{% endif %}
-                 {% for gid in group_filters %}&group_filter={{ gid }}{% endfor %}
-                 {% for sid in series_filters %}&series_filter={{ sid }}{% endfor %}
-                 {% if zero_inventory %}&zero_inventory=true{% endif %}"
+        <a href="?{{ list_query }}"
            class="view-icon {% if view_mode == 'list' %}active{% endif %}">
           <i class="material-icons">view_list</i>
         </a>
-        <a href="?view_mode=card
-                 {% if show_retired %}&show_retired=true{% endif %}
-                 {% if type_filter  %}&type_filter={{ type_filter }}{% endif %}
-                 {% if style_filter %}&style_filter={{ style_filter }}{% endif %}
-                 {% if age_filter   %}&age_filter={{ age_filter }}{% endif %}
-                 {% for gid in group_filters %}&group_filter={{ gid }}{% endfor %}
-                 {% for sid in series_filters %}&series_filter={{ sid }}{% endfor %}
-                 {% if zero_inventory %}&zero_inventory=true{% endif %}"
+        <a href="?{{ card_query }}"
            class="view-icon {% if view_mode == 'card' %}active{% endif %}">
           <i class="material-icons">view_module</i>
         </a>
@@ -92,22 +78,38 @@
           <label>Age</label>
         </div>
 
-        <div class="input-field">
-          <select name="group_filter" multiple onchange="this.form.submit()">
-            {% for group in group_choices %}
-              <option value="{{ group.id }}" {% if group.id|stringformat:'s' in group_filters %}selected{% endif %}>{{ group.name }}</option>
-            {% endfor %}
-          </select>
-          <label>Group</label>
+        <div class="checkbox-set">
+          <span>Group:</span>
+          {% for group in group_choices %}
+            <label class="checkbox-field">
+              <input
+                type="checkbox"
+                name="group_filter"
+                value="{{ group.id }}"
+                class="filled-in"
+                {% if group.id|stringformat:'s' in group_filters %}checked{% endif %}
+                onchange="this.form.submit()"
+              />
+              <span>{{ group.name }}</span>
+            </label>
+          {% endfor %}
         </div>
 
-        <div class="input-field">
-          <select name="series_filter" multiple onchange="this.form.submit()">
-            {% for ser in series_choices %}
-              <option value="{{ ser.id }}" {% if ser.id|stringformat:'s' in series_filters %}selected{% endif %}>{{ ser.name }}</option>
-            {% endfor %}
-          </select>
-          <label>Series</label>
+        <div class="checkbox-set">
+          <span>Series:</span>
+          {% for ser in series_choices %}
+            <label class="checkbox-field">
+              <input
+                type="checkbox"
+                name="series_filter"
+                value="{{ ser.id }}"
+                class="filled-in"
+                {% if ser.id|stringformat:'s' in series_filters %}checked{% endif %}
+                onchange="this.form.submit()"
+              />
+              <span>{{ ser.name }}</span>
+            </label>
+          {% endfor %}
         </div>
 
         <input type="hidden" name="view_mode" value="{{ view_mode }}" />

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -6,6 +6,7 @@ from collections import defaultdict, namedtuple, OrderedDict
 import calendar
 import statistics
 import math
+from urllib.parse import urlencode
 
 
 from decimal import Decimal
@@ -586,8 +587,8 @@ def product_list(request):
     type_filter = request.GET.get("type_filter", None)
     style_filter = request.GET.get("style_filter", None)
     age_filter = request.GET.get("age_filter", None)
-    group_filters = [gid for gid in request.GET.getlist("group_filter") if gid]
-    series_filters = [sid for sid in request.GET.getlist("series_filter") if sid]
+    group_filters = [gid.strip() for gid in request.GET.getlist("group_filter") if gid]
+    series_filters = [sid.strip() for sid in request.GET.getlist("series_filter") if sid]
     zero_inventory = request.GET.get("zero_inventory", "false").lower() == "true"
 
     # ─── Date ranges ────────────────────────────────────────────────────────────
@@ -726,7 +727,26 @@ def product_list(request):
         products = [p for p in products if p.total_inventory == 0]
 
     # ─── Prepare context & render ───────────────────────────────────────────────
-    view_mode = request.GET.get("view_mode", "list")
+    view_mode = request.GET.get("view_mode", "list").strip()
+
+    params = []
+    if show_retired:
+        params.append(("show_retired", "true"))
+    if type_filter:
+        params.append(("type_filter", type_filter))
+    if style_filter:
+        params.append(("style_filter", style_filter))
+    if age_filter:
+        params.append(("age_filter", age_filter))
+    for gid in group_filters:
+        params.append(("group_filter", gid))
+    for sid in series_filters:
+        params.append(("series_filter", sid))
+    if zero_inventory:
+        params.append(("zero_inventory", "true"))
+
+    list_query = urlencode(params + [("view_mode", "list")])
+    card_query = urlencode(params + [("view_mode", "card")])
 
     context = {
         "products": products,
@@ -743,6 +763,8 @@ def product_list(request):
         "group_choices": Group.objects.all(),
         "series_choices": Series.objects.all(),
         "view_mode": view_mode,
+        "list_query": list_query,
+        "card_query": card_query,
     }
 
     # optional groupings (discounted/current/on‐order)


### PR DESCRIPTION
## Summary
- show checkboxes for Group and Series filters
- style checkbox sets in filter form
- preserve view mode in query params using urlencoding

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6872a8717424832cb5b3715053928cb8