### PR TITLE
Remove stray prints, use logging

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -18,6 +18,9 @@ from django.contrib import messages
 from django.shortcuts import redirect, get_object_or_404, render
 from django.urls import path
 from django.http import JsonResponse
+import logging
+
+logger = logging.getLogger(__name__)
 from django.utils.safestring import mark_safe
 from django.contrib.admin.widgets import FilteredSelectMultiple
 
@@ -124,7 +127,7 @@ class OrderAdmin(admin.ModelAdmin):
     def add_products_view(self, request, order_id):
         order = get_object_or_404(Order, pk=order_id)
         if request.method == "POST":
-            print("here")
+            logger.debug("add_products_view POST called")
             form = AddProductsForm(request.POST)
             if form.is_valid():
                 products = form.cleaned_data["products"]

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -7,6 +7,9 @@ import calendar
 import statistics
 import math
 from urllib.parse import urlencode
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 from decimal import Decimal
@@ -1195,7 +1198,7 @@ def inventory_snapshots(request):
     size_order = ["XS", "S", "M", "L", "XL", "XXL"]
 
     size_mix = calculate_size_order_mix(category=selected_type, months=6)
-    print(size_mix)
+    logger.debug(size_mix)
 
     # ——— 5) Render template —————————————————————————————————————
     return render(

--- a/scripts/delete_all_sales.py
+++ b/scripts/delete_all_sales.py
@@ -1,6 +1,7 @@
 import os
 import django
 import sys
+import logging
 
 # ----------------------------------------------------------------
 #  Adjust these paths/settings to point at your project correctly
@@ -14,23 +15,26 @@ django.setup()
 from django.db import transaction
 from inventory.models import Sale
 
+logger = logging.getLogger(__name__)
+
 def delete_all_sales(dry_run=True):
     """
     If dry_run is True, just print how many would be deleted.
     Otherwise, delete all Sale records.
     """
     total = Sale.objects.count()
-    print(f"Found {total} Sale records.")
+    logger.info("Found %s Sale records.", total)
     if dry_run:
-        print("Dry run mode – no records have been deleted.")
+        logger.info("Dry run mode – no records have been deleted.")
     else:
         with transaction.atomic():
             deleted, _ = Sale.objects.all().delete()
-        print(f"Deleted {deleted} Sale records.")
+        logger.info("Deleted %s Sale records.", deleted)
 
 if __name__ == "__main__":
     # Pass "go" as first arg to actually delete
     go = len(sys.argv) > 1 and sys.argv[1].lower() == "go"
+    logging.basicConfig(level=logging.INFO)
     delete_all_sales(dry_run=not go)
     if not go:
-        print("\nTo really delete, run:\n    python delete_sales.py go")
+        logger.info("\nTo really delete, run:\n    python delete_sales.py go")

--- a/scripts/delete_snapshots.py
+++ b/scripts/delete_snapshots.py
@@ -1,6 +1,7 @@
 import os
 import django
 import sys
+import logging
 
 # Set the path to the project root (where manage.py is located)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -13,15 +14,20 @@ django.setup()
 # Import the InventorySnapshot model
 from inventory.models import InventorySnapshot
 
+logger = logging.getLogger(__name__)
+
 def delete_all_snapshots():
-    confirm = input("Are you sure you want to delete all InventorySnapshot records? (yes/no): ").strip().lower()
-    if confirm != 'yes':
-        print("Aborted.")
+    confirm = input(
+        "Are you sure you want to delete all InventorySnapshot records? (yes/no): "
+    ).strip().lower()
+    if confirm != "yes":
+        logger.info("Aborted.")
         return
 
     # Delete all snapshots
     deleted_count, _ = InventorySnapshot.objects.all().delete()
-    print(f"Deleted {deleted_count} InventorySnapshot records.")
+    logger.info("Deleted %s InventorySnapshot records.", deleted_count)
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     delete_all_snapshots()

--- a/scripts/initial_products_uploader.py
+++ b/scripts/initial_products_uploader.py
@@ -1,6 +1,7 @@
 import os
 import django
 import sys
+import logging
 
 # Set the path to the project root (where manage.py is located)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -12,6 +13,8 @@ django.setup()
 
 import csv
 from inventory.models import Product
+
+logger = logging.getLogger(__name__)
 
 # Define the path to your CSV file
 CSV_FILE_PATH = 'data/initialdata/product_list.csv'
@@ -30,14 +33,16 @@ def import_products():
             )
 
             if created:
-                print(f"Created: {product.product_name} ({product.product_id})")
+                logger.info("Created: %s (%s)", product.product_name, product.product_id)
             else:
-                print(f"Updated: {product.product_name} ({product.product_id})")
+                logger.info("Updated: %s (%s)", product.product_name, product.product_id)
 
 if __name__ == "__main__":
     import django
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'myproject.settings')  # Update with your project name
     django.setup()
 
+    logging.basicConfig(level=logging.INFO)
+
     import_products()
-    print("Product import completed!")
+    logger.info("Product import completed!")


### PR DESCRIPTION
## Summary
- switch debug prints to logging calls throughout inventory admin and views
- convert scripts to use logging instead of `print`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687422bd71a8832ca1cd6d6dc59f57db