### PR TITLE
Add low stock notification

### DIFF
--- a/inventory/templates/inventory/home.html
+++ b/inventory/templates/inventory/home.html
@@ -4,6 +4,24 @@
 
 {% block content %}
 <div class="section">
+
+  {% if low_stock_products %}
+  <div class="row">
+    <div class="col s12">
+      <div class="card red lighten-4">
+        <div class="card-content">
+          <span class="card-title">Low Stock Alert</span>
+          <ul>
+            {% for v in low_stock_products %}
+            <li>{{ v.variant_code }} ({{ v.latest_inventory }} left)</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   <div class="row">
 
     <!-- Left Column: Line Chart -->

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1,3 +1,64 @@
+from datetime import date
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Product, ProductVariant, InventorySnapshot, Sale
+from .utils import get_low_stock_products
+
+
+class LowStockProductsTests(TestCase):
+    def setUp(self):
+        self.product1 = Product.objects.create(
+            product_id="P1", product_name="Prod1"
+        )
+        self.variant1 = ProductVariant.objects.create(
+            product=self.product1,
+            variant_code="V1",
+            primary_color="#000000",
+        )
+        InventorySnapshot.objects.create(
+            product_variant=self.variant1,
+            date=date.today(),
+            inventory_count=5,
+        )
+        for m in range(6):
+            Sale.objects.create(
+                order_number=f"O{m}",
+                date=date.today(),
+                variant=self.variant1,
+                sold_quantity=2,
+                sold_value=100,
+            )
+
+        self.product2 = Product.objects.create(
+            product_id="P2", product_name="Prod2"
+        )
+        self.variant2 = ProductVariant.objects.create(
+            product=self.product2,
+            variant_code="V2",
+            primary_color="#000000",
+        )
+        InventorySnapshot.objects.create(
+            product_variant=self.variant2,
+            date=date.today(),
+            inventory_count=50,
+        )
+        for m in range(6):
+            Sale.objects.create(
+                order_number=f"O2-{m}",
+                date=date.today(),
+                variant=self.variant2,
+                sold_quantity=1,
+                sold_value=50,
+            )
+
+    def test_low_stock_variants(self):
+        qs = ProductVariant.objects.all()
+        low = list(get_low_stock_products(qs))
+        self.assertIn(self.variant1, low)
+        self.assertNotIn(self.variant2, low)
+
+    def test_low_stock_products(self):
+        qs = Product.objects.all()
+        low = list(get_low_stock_products(qs))
+        self.assertIn(self.product1, low)
+        self.assertNotIn(self.product2, low)

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -61,6 +61,7 @@ from .utils import (
     get_product_health_metrics,
     calculate_dynamic_product_score,
     compute_product_health,
+    get_low_stock_products,
 )
 
 
@@ -252,6 +253,9 @@ def home(request):
             "on_paper_value": on_paper_value,
         }
     )
+
+    low_stock_products = get_low_stock_products(ProductVariant.objects.all())
+    context["low_stock_products"] = low_stock_products
 
     return render(request, "inventory/home.html", context)
 


### PR DESCRIPTION
## Summary
- implement `get_low_stock_products` helper
- display low stock items on home page
- connect helper in the home view
- test low stock logic

## Testing
- `python manage.py test inventory.tests.LowStockProductsTests --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_68742494e4dc832ca4229b712265ddfe