### PR TITLE
Improve low stock check

### DIFF
--- a/inventory/templates/inventory/home.html
+++ b/inventory/templates/inventory/home.html
@@ -5,22 +5,25 @@
 {% block content %}
 <div class="section">
 
-  {% if low_stock_products %}
+{% if low_stock_by_product %}
   <div class="row">
     <div class="col s12">
       <div class="card red lighten-4">
         <div class="card-content">
           <span class="card-title">Low Stock Alert</span>
-          <ul>
-            {% for v in low_stock_products %}
-            <li>{{ v.variant_code }} ({{ v.latest_inventory }} left)</li>
-            {% endfor %}
-          </ul>
+          {% for product, variants in low_stock_by_product.items %}
+            <p><strong>{{ product.product_name }}</strong></p>
+            <ul>
+              {% for v in variants %}
+              <li>{{ v.variant_code }} ({{ v.latest_inventory }} left)</li>
+              {% endfor %}
+            </ul>
+          {% endfor %}
         </div>
       </div>
     </div>
   </div>
-  {% endif %}
+{% endif %}
 
   <div class="row">
 

--- a/inventory/utils.py
+++ b/inventory/utils.py
@@ -882,10 +882,14 @@ def compute_product_health(product, variants, simplify_type):
 
 
 def get_low_stock_products(queryset):
-    """Return items with less than 3 months of stock remaining."""
+    """Return items with less than 3 months of stock remaining.
+
+    This uses an adjusted sales speed that ignores months where the variant was
+    completely out of stock.  It averages the speed over the last 12, 6 and
+    3 months and compares current stock against that average.
+    """
 
     today = date.today()
-    six_months_ago = today - relativedelta(months=6)
 
     if queryset.model == ProductVariant:
         variant_qs = queryset
@@ -896,44 +900,56 @@ def get_low_stock_products(queryset):
     else:
         raise ValueError("Queryset must be for Product or ProductVariant")
 
-    latest_inv = (
-        InventorySnapshot.objects.filter(product_variant=OuterRef("pk"))
-        .order_by("-date")
-        .values("inventory_count")[:1]
+    # Prefetch related objects so all calculations happen in Python without
+    # triggering additional queries.
+    variants = list(
+        variant_qs.prefetch_related("sales", "snapshots", "product")
     )
 
-    variant_qs = variant_qs.annotate(
-        latest_inventory=Coalesce(Subquery(latest_inv), Value(0)),
-        sold_6=Coalesce(
-            Sum(
-                "sales__sold_quantity",
-                filter=Q(sales__date__gte=six_months_ago),
-            ),
-            Value(0),
-            output_field=IntegerField(),
-        ),
-    ).annotate(
-        avg_monthly_sales=ExpressionWrapper(
-            F("sold_6") / Value(6.0), output_field=FloatField()
-        )
-    ).annotate(
-        months_left=Case(
-            When(
-                avg_monthly_sales__gt=0,
-                then=ExpressionWrapper(
-                    F("latest_inventory") / F("avg_monthly_sales"),
-                    output_field=FloatField(),
-                ),
-            ),
-            default=Value(None),
-            output_field=FloatField(),
-        )
-    )
+    month_start = today.replace(day=1)
 
-    low_stock_variants = variant_qs.filter(
-        avg_monthly_sales__gt=0, months_left__lt=3
-    )
+    low_variants = []
+    for v in variants:
+        # Determine the latest inventory count from snapshots
+        latest_inv = 0
+        latest_dt = None
+        for snap in v.snapshots.all():
+            if latest_dt is None or snap.date > latest_dt:
+                latest_dt = snap.date
+                latest_inv = snap.inventory_count
+        v.latest_inventory = latest_inv
+
+        # Build per-month sales totals and record months with stock available
+        sales_by_month = {}
+        stock_months = set()
+        for sale in v.sales.all():
+            m = sale.date.replace(day=1)
+            sales_by_month[m] = sales_by_month.get(m, 0) + (sale.sold_quantity or 0)
+        for snap in v.snapshots.all():
+            if snap.inventory_count > 0:
+                stock_months.add(snap.date.replace(day=1))
+
+        def _avg_speed(months):
+            total = 0
+            periods = 0
+            for i in range(months):
+                m = month_start - relativedelta(months=i)
+                sold = sales_by_month.get(m, 0)
+                had_stock = m in stock_months
+                if sold or had_stock:
+                    periods += 1
+                    total += sold
+            return (total / periods) if periods else 0.0
+
+        avg12 = _avg_speed(12)
+        avg6 = _avg_speed(6)
+        avg3 = _avg_speed(3)
+        avg_speed = (avg12 + avg6 + avg3) / 3.0
+
+        v.months_left = (v.latest_inventory / avg_speed) if avg_speed > 0 else None
+        if v.months_left is not None and v.months_left < 3:
+            low_variants.append(v)
 
     if return_products:
-        return queryset.filter(variants__in=low_stock_variants).distinct()
-    return low_stock_variants
+        return list({v.product for v in low_variants})
+    return low_variants

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -254,8 +254,13 @@ def home(request):
         }
     )
 
-    low_stock_products = get_low_stock_products(ProductVariant.objects.all())
-    context["low_stock_products"] = low_stock_products
+    low_stock_variants = get_low_stock_products(
+        ProductVariant.objects.select_related("product").all()
+    )
+    grouped = defaultdict(list)
+    for v in low_stock_variants:
+        grouped[v.product].append(v)
+    context["low_stock_by_product"] = grouped
 
     return render(request, "inventory/home.html", context)
 


### PR DESCRIPTION
## Summary
- refine `get_low_stock_products` to prefetch data and compute months remaining faster
- group low stock alerts by product on the homepage

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68741a1bd294832cb500ec8fd0befda0