### PR TITLE
Improve low stock check

### DIFF
--- a/inventory/templates/inventory/home.html
+++ b/inventory/templates/inventory/home.html
@@ -5,22 +5,25 @@
 {% block content %}
 <div class="section">
 
-  {% if low_stock_products %}
+{% if low_stock_by_product %}
   <div class="row">
     <div class="col s12">
       <div class="card red lighten-4">
         <div class="card-content">
           <span class="card-title">Low Stock Alert</span>
-          <ul>
-            {% for v in low_stock_products %}
-            <li>{{ v.variant_code }} ({{ v.latest_inventory }} left)</li>
-            {% endfor %}
-          </ul>
+          {% for product, variants in low_stock_by_product.items %}
+            <p><strong>{{ product.product_name }}</strong></p>
+            <ul>
+              {% for v in variants %}
+              <li>{{ v.variant_code }} ({{ v.latest_inventory }} left)</li>
+              {% endfor %}
+            </ul>
+          {% endfor %}
         </div>
       </div>
     </div>
   </div>
-  {% endif %}
+{% endif %}
 
   <div class="row">
 

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1,15 +1,25 @@
 from datetime import date
+from dateutil.relativedelta import relativedelta
 from django.test import TestCase
 
-from .models import Product, ProductVariant, InventorySnapshot, Sale
+from .models import (
+    Product,
+    ProductVariant,
+    InventorySnapshot,
+    Sale,
+    Group,
+)
 from .utils import get_low_stock_products
 
 
 class LowStockProductsTests(TestCase):
     def setUp(self):
+        self.core_group = Group.objects.create(name="core")
+        self.other_group = Group.objects.create(name="other")
         self.product1 = Product.objects.create(
             product_id="P1", product_name="Prod1"
         )
+        self.product1.groups.add(self.core_group)
         self.variant1 = ProductVariant.objects.create(
             product=self.product1,
             variant_code="V1",
@@ -32,6 +42,7 @@ class LowStockProductsTests(TestCase):
         self.product2 = Product.objects.create(
             product_id="P2", product_name="Prod2"
         )
+        self.product2.groups.add(self.core_group)
         self.variant2 = ProductVariant.objects.create(
             product=self.product2,
             variant_code="V2",
@@ -51,14 +62,98 @@ class LowStockProductsTests(TestCase):
                 sold_value=50,
             )
 
+        # Variant that sold out quickly then restocked recently
+        self.product3 = Product.objects.create(
+            product_id="P3", product_name="Prod3"
+        )
+        self.product3.groups.add(self.core_group)
+        self.variant3 = ProductVariant.objects.create(
+            product=self.product3,
+            variant_code="V3",
+            primary_color="#000000",
+        )
+        six_months_ago = date.today().replace(day=1) - relativedelta(months=6)
+        InventorySnapshot.objects.create(
+            product_variant=self.variant3,
+            date=six_months_ago,
+            inventory_count=10,
+        )
+        # sold everything five months ago
+        Sale.objects.create(
+            order_number="O3", 
+            date=six_months_ago + relativedelta(months=1),
+            variant=self.variant3,
+            sold_quantity=10,
+            sold_value=200,
+        )
+        # restocked at current month with 5 on hand
+        InventorySnapshot.objects.create(
+            product_variant=self.variant3,
+            date=date.today(),
+            inventory_count=5,
+        )
+
+        # Low stock product not in core group
+        self.product4 = Product.objects.create(
+            product_id="P4", product_name="Prod4"
+        )
+        self.product4.groups.add(self.other_group)
+        self.variant4 = ProductVariant.objects.create(
+            product=self.product4,
+            variant_code="V4",
+            primary_color="#000000",
+        )
+        InventorySnapshot.objects.create(
+            product_variant=self.variant4,
+            date=date.today(),
+            inventory_count=2,
+        )
+        Sale.objects.create(
+            order_number="O4",
+            date=date.today(),
+            variant=self.variant4,
+            sold_quantity=5,
+            sold_value=60,
+        )
+
+        # Decommissioned product should be ignored even if low stock
+        self.product5 = Product.objects.create(
+            product_id="P5", product_name="Prod5", decommissioned=True
+        )
+        self.product5.groups.add(self.core_group)
+        self.variant5 = ProductVariant.objects.create(
+            product=self.product5,
+            variant_code="V5",
+            primary_color="#000000",
+        )
+        InventorySnapshot.objects.create(
+            product_variant=self.variant5,
+            date=date.today(),
+            inventory_count=1,
+        )
+        Sale.objects.create(
+            order_number="O5",
+            date=date.today(),
+            variant=self.variant5,
+            sold_quantity=3,
+            sold_value=30,
+        )
+
     def test_low_stock_variants(self):
         qs = ProductVariant.objects.all()
         low = list(get_low_stock_products(qs))
+
         self.assertIn(self.variant1, low)
+        self.assertIn(self.variant3, low)
         self.assertNotIn(self.variant2, low)
+        self.assertNotIn(self.variant4, low)
+        self.assertNotIn(self.variant5, low)
 
     def test_low_stock_products(self):
         qs = Product.objects.all()
         low = list(get_low_stock_products(qs))
         self.assertIn(self.product1, low)
+        self.assertIn(self.product3, low)
         self.assertNotIn(self.product2, low)
+        self.assertNotIn(self.product4, low)
+        self.assertNotIn(self.product5, low)

--- a/inventory/utils.py
+++ b/inventory/utils.py
@@ -3,7 +3,7 @@ import math
 import json
 
 from collections import defaultdict
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import List, Optional, Sequence, Dict, Any, Iterable
 from decimal import Decimal
 
@@ -882,58 +882,97 @@ def compute_product_health(product, variants, simplify_type):
 
 
 def get_low_stock_products(queryset):
-    """Return items with less than 3 months of stock remaining."""
+    """Return items with less than 3 months of stock remaining.
+
+    This uses an adjusted sales speed that ignores months where the variant was
+    completely out of stock.  It averages the speed over the last 12, 6 and
+    3 months and compares current stock against that average.
+    """
 
     today = date.today()
-    six_months_ago = today - relativedelta(months=6)
 
     if queryset.model == ProductVariant:
-        variant_qs = queryset
+        variant_qs = queryset.filter(
+            product__decommissioned=False,
+            product__groups__name="core",
+        )
         return_products = False
     elif queryset.model == Product:
-        variant_qs = ProductVariant.objects.filter(product__in=queryset)
+        product_qs = queryset.filter(
+            decommissioned=False,
+            groups__name="core",
+        ).distinct()
+        variant_qs = ProductVariant.objects.filter(product__in=product_qs)
         return_products = True
     else:
         raise ValueError("Queryset must be for Product or ProductVariant")
 
-    latest_inv = (
-        InventorySnapshot.objects.filter(product_variant=OuterRef("pk"))
-        .order_by("-date")
-        .values("inventory_count")[:1]
+    # Prefetch related objects so all calculations happen in Python without
+    # triggering additional queries.
+    variants = list(
+        variant_qs.select_related("product").prefetch_related("sales", "snapshots")
     )
 
-    variant_qs = variant_qs.annotate(
-        latest_inventory=Coalesce(Subquery(latest_inv), Value(0)),
-        sold_6=Coalesce(
-            Sum(
-                "sales__sold_quantity",
-                filter=Q(sales__date__gte=six_months_ago),
-            ),
-            Value(0),
-            output_field=IntegerField(),
-        ),
-    ).annotate(
-        avg_monthly_sales=ExpressionWrapper(
-            F("sold_6") / Value(6.0), output_field=FloatField()
-        )
-    ).annotate(
-        months_left=Case(
-            When(
-                avg_monthly_sales__gt=0,
-                then=ExpressionWrapper(
-                    F("latest_inventory") / F("avg_monthly_sales"),
-                    output_field=FloatField(),
-                ),
-            ),
-            default=Value(None),
-            output_field=FloatField(),
-        )
-    )
+    month_start = today.replace(day=1)
 
-    low_stock_variants = variant_qs.filter(
-        avg_monthly_sales__gt=0, months_left__lt=3
-    )
+    low_variants = []
+    for v in variants:
+        # Determine the latest inventory count from snapshots
+        latest_inv = 0
+        latest_dt = None
+        for snap in v.snapshots.all():
+            if latest_dt is None or snap.date > latest_dt:
+                latest_dt = snap.date
+                latest_inv = snap.inventory_count
+        v.latest_inventory = latest_inv
+
+        # Build per-month sales totals and stock levels
+        sales_by_month = {}
+        events = []
+        for snap in v.snapshots.all():
+            events.append((snap.date, 'snapshot', snap.inventory_count))
+        for sale in v.sales.all():
+            events.append((sale.date, 'sale', sale.sold_quantity))
+            m = sale.date.replace(day=1)
+            sales_by_month[m] = sales_by_month.get(m, 0) + (sale.sold_quantity or 0)
+        events.sort(key=lambda x: x[0])
+
+        inventory_by_month = {}
+        idx = 0
+        current_inv = 0
+        months = [month_start - relativedelta(months=i) for i in reversed(range(12))]
+        for m in months:
+            month_end = (m + relativedelta(months=1)) - timedelta(days=1)
+            while idx < len(events) and events[idx][0] <= month_end:
+                dt, typ, qty = events[idx]
+                if typ == 'snapshot':
+                    current_inv = qty
+                else:  # sale
+                    current_inv -= qty
+                idx += 1
+            inventory_by_month[m] = current_inv
+
+        def _avg_speed(months):
+            total = 0
+            periods = 0
+            for i in range(months):
+                m = month_start - relativedelta(months=i)
+                sold = sales_by_month.get(m, 0)
+                had_stock = inventory_by_month.get(m, 0) > 0
+                if sold or had_stock:
+                    periods += 1
+                    total += sold
+            return (total / periods) if periods else 0.0
+
+        avg12 = _avg_speed(12)
+        avg6 = _avg_speed(6)
+        avg3 = _avg_speed(3)
+        avg_speed = (avg12 + avg6 + avg3) / 3.0
+
+        v.months_left = (v.latest_inventory / avg_speed) if avg_speed > 0 else None
+        if v.months_left is not None and v.months_left < 3:
+            low_variants.append(v)
 
     if return_products:
-        return queryset.filter(variants__in=low_stock_variants).distinct()
-    return low_stock_variants
+        return list({v.product for v in low_variants})
+    return low_variants

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -254,8 +254,12 @@ def home(request):
         }
     )
 
-    low_stock_products = get_low_stock_products(ProductVariant.objects.all())
-    context["low_stock_products"] = low_stock_products
+    low_stock_variants = get_low_stock_products(Product.objects.all())
+    grouped = defaultdict(list)
+    for v in low_stock_variants:
+        grouped[v.product].append(v)
+    # Convert to a regular dict so Django templates can iterate over .items
+    context["low_stock_by_product"] = dict(grouped)
 
     return render(request, "inventory/home.html", context)
 


### PR DESCRIPTION
## Summary
- refine `get_low_stock_products` to only analyse non-decommissioned core products
- display low stock results on the homepage using the filtered product list
- extend tests with product groups and decommissioned items

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68741a1bd294832cb500ec8fd0befda0