### PR TITLE
Add unified sales speed helper

### DIFF
--- a/inventory/views.py
+++ b/inventory/views.py
@@ -63,6 +63,7 @@ from .utils import (
     compute_product_health,
     get_low_stock_products,
     get_restock_alerts,
+    calculate_variant_sales_speed,
 )
 
 
@@ -461,14 +462,7 @@ def dashboard(request):
             .first()
         )
         current_stock = snapshot["inventory_count"] if snapshot else 0
-        six_months_ago = datetime.today() - relativedelta(months=6)
-        total_sales_last_6 = (
-            v.sales.filter(date__gte=six_months_ago).aggregate(
-                total_sold=Sum("sold_quantity")
-            )["total_sold"]
-            or 0
-        )
-        sales_speed = total_sales_last_6 / 6
+        sales_speed = calculate_variant_sales_speed(v)
         order_items = v.order_items.filter(date_expected__gte=chart_today).values(
             "date_expected", "quantity"
         )


### PR DESCRIPTION
## Summary
- add new `calculate_variant_sales_speed` helper using weekly data and ignoring out-of-stock weeks
- refactor `compute_safe_stock`, `_annotate_variant_stock`, and `compute_variant_projection` to use new helper
- update dashboard view to rely on the helper

## Testing
- `python -m py_compile inventory/utils.py inventory/views.py`


------
https://chatgpt.com/codex/tasks/task_e_687609587d64832cbf650e3af10a86bd