### PR TITLE
Add speed map helper for variant calculations

### DIFF
--- a/inventory/utils.py
+++ b/inventory/utils.py
@@ -235,8 +235,16 @@ def calculate_variant_sales_speed(
     avg_weekly = total / periods
     return avg_weekly * WEEKS_PER_MONTH
 
+def get_variant_speed_map(variants, *, weeks=26, today=None):
+    """Return a {variant_id: speed} map for the given variants."""
+    today = today or date.today()
+    return {
+        v.id: calculate_variant_sales_speed(v, weeks=weeks, today=today)
+        for v in variants
+    }
 
-def compute_safe_stock(variants):
+
+def compute_safe_stock(variants, speed_map=None):
     """
     Compute safe stock data and product-level summary for a list of variants.
     Returns (safe_stock_data, product_safe_summary).
@@ -246,7 +254,7 @@ def compute_safe_stock(variants):
 
     for v in variants:
         current = v.latest_inventory
-        avg_speed = calculate_variant_sales_speed(v, today=today)
+        avg_speed = speed_map.get(v.id) if speed_map is not None else calculate_variant_sales_speed(v, today=today)
         recent_speed = calculate_variant_sales_speed(v, weeks=13, today=today)
 
         min_threshold = avg_speed * 2
@@ -300,7 +308,7 @@ def compute_safe_stock(variants):
     }
 
 
-def compute_variant_projection(variants):
+def compute_variant_projection(variants, speed_map=None):
     """
     Compute variant-level stock projection data for Chart.js.
     Returns dict with key 'stock_chart_data' (a JSON string).
@@ -317,7 +325,7 @@ def compute_variant_projection(variants):
     }
     for v in variants:
         curr = v.latest_inventory
-        speed = calculate_variant_sales_speed(v, today=current_month.date())
+        speed = speed_map.get(v.id) if speed_map is not None else calculate_variant_sales_speed(v, today=current_month.date())
 
         # collect future restocks
         restocks = {}
@@ -823,7 +831,7 @@ def normalize(value, best, worst):
     return max(0, min(100, pct * 100))
 
 
-def compute_product_health(product, variants, simplify_type):
+def compute_product_health(product, variants, simplify_type, speed_map=None):
     """
     Returns a dict of sub-scores and the overall 0–100 health index.
     `variants` must be annotated with .latest_inventory

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -64,6 +64,7 @@ from .utils import (
     get_low_stock_products,
     get_restock_alerts,
     calculate_variant_sales_speed,
+    get_variant_speed_map,
 )
 
 
@@ -842,9 +843,10 @@ def product_detail(request, product_id):
     )
 
     # Compute all data via helpers
-    safe_stock = compute_safe_stock(variants)
+    speed_map = get_variant_speed_map(variants)
+    safe_stock = compute_safe_stock(variants, speed_map=speed_map)
     threshold_value = safe_stock["product_safe_summary"]["avg_speed"] * 2
-    variant_proj = compute_variant_projection(variants)
+    variant_proj = compute_variant_projection(variants, speed_map=speed_map)
     sales_data = get_product_sales_data(product)
 
     # ——— ACTUAL DATA FOR INVENTORY CHART ————————
@@ -912,7 +914,7 @@ def product_detail(request, product_id):
         running = sum(initial.values())
         forecast_data.append({"x": cursor.isoformat(), "y": running})
 
-    health = compute_product_health(product, variants, _simplify_type)
+    health = compute_product_health(product, variants, _simplify_type, speed_map=speed_map)
 
     # — Fetch and group all OrderItems for this product —
     all_items = (


### PR DESCRIPTION
## Summary
- compute variant speed map once with `get_variant_speed_map`
- pass precomputed speeds into `compute_safe_stock`, `compute_variant_projection`, and `compute_product_health`
- update `product_detail` to use the new speed map

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68777548a324832ca31cf5ec3ae7fdc0