### PR TITLE
Fix stockChart future restock data

### DIFF
--- a/inventory/utils.py
+++ b/inventory/utils.py
@@ -328,8 +328,8 @@ def compute_variant_projection(variants, speed_map=None):
     Returns dict with key 'stock_chart_data' (a JSON string).
     """
     # 1) Define your date boundaries here
-    today = datetime.today()
-    current_month = today.replace(day=1)
+    today_dt = datetime.today().date()
+    current_month = today_dt.replace(day=1)
 
     # 2) Build your 12-month projection exactly as on inventory page
     next_12 = [current_month + relativedelta(months=i) for i in range(13)]
@@ -339,12 +339,20 @@ def compute_variant_projection(variants, speed_map=None):
     }
     for v in variants:
         curr = v.latest_inventory
-        speed = speed_map.get(v.id) if speed_map is not None else calculate_variant_sales_speed(v, today=current_month.date())
+        speed = speed_map.get(v.id) if speed_map is not None else calculate_variant_sales_speed(
+            v, today=current_month
+        )
 
         # collect future restocks from prefetched order_items
         restocks = {}
         for oi in v.order_items.all():
-            mon = oi.date_expected.replace(day=1)
+            if oi.date_arrived is not None:
+                continue
+            if oi.date_expected and oi.date_expected >= today_dt:
+                effective_date = oi.date_expected
+            else:
+                effective_date = today_dt + relativedelta(months=1)
+            mon = effective_date.replace(day=1)
             restocks[mon] = restocks.get(mon, 0) + oi.quantity
 
         # simulate month-by-month

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -842,7 +842,7 @@ def product_detail(request, product_id):
     current_month = today.replace(day=1)
     order_items_prefetch = Prefetch(
         "order_items",
-        queryset=OrderItem.objects.filter(date_expected__gte=current_month),
+        queryset=OrderItem.objects.filter(date_arrived__isnull=True),
     )
 
     variants = (


### PR DESCRIPTION
## Summary
- update prefetch query in `product_detail` to include only undelivered order items
- handle delayed restocks when building variant projection chart data

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68778890f738832caff3f6c3c121df53