### PR TITLE
Add last order qty column

### DIFF
--- a/inventory/templates/inventory/product_detail.html
+++ b/inventory/templates/inventory/product_detail.html
@@ -56,6 +56,7 @@
         <thead>
           <tr>
             <th>Variant</th>
+            <th>Last Order</th>
             <th>Sales / month</th>
             <th>Current Stock</th>
             <th>6 Months Stock</th>
@@ -69,6 +70,7 @@
           {% for row in safe_stock_data %}
           <tr>
             <td>{{ row.variant_code }}</td>
+            <td>{{ row.last_order_qty }}</td>
             <td>
               {{ row.avg_speed }}
               {% if row.trend == 'up' %}
@@ -86,12 +88,13 @@
             <td>{{ row.on_order_qty }}</td>
           </tr>
           {% empty %}
-          <tr><td colspan="6">No data available.</td></tr>
+          <tr><td colspan="7">No data available.</td></tr>
           {% endfor %}
           <tr class="product-summary">
             <td><strong>TOTALS</strong></td>
-            <td>{{ product_safe_summary.total_current_stock }} items</td>
+            <td>&ndash;</td>
             <td>{{ product_safe_summary.avg_speed }} / month</td>
+            <td>{{ product_safe_summary.total_current_stock }} items</td>
             <td>{{ product_safe_summary.total_six_month_stock }}</td>
             <td>{{ product_safe_summary.total_restock_needed }}</td>
             <td>{{ product_safe_summary.total_on_order_qty }}</td>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -845,12 +845,21 @@ def product_detail(request, product_id):
         queryset=OrderItem.objects.filter(date_arrived__isnull=True),
     )
 
+    # Subquery to fetch quantity from the most recent order item for each variant
+    last_qty_sq = (
+        OrderItem.objects.filter(product_variant=OuterRef("pk"))
+        .annotate(qty=Coalesce("actual_quantity", "quantity"))
+        .order_by("-order__order_date")
+        .values("qty")[:1]
+    )
+
     variants = (
         ProductVariant.objects.filter(product=product)
         .annotate(
             latest_inventory=Coalesce(
                 Subquery(latest_snapshot_sq), Value(0), output_field=IntegerField()
-            )
+            ),
+            last_order_qty=Subquery(last_qty_sq, output_field=IntegerField()),
         )
         .prefetch_related("sales", "snapshots", order_items_prefetch)
     )
@@ -863,6 +872,12 @@ def product_detail(request, product_id):
     if safe_stock is None:
         safe_stock = compute_safe_stock(variants)
         cache.set(safe_stock_key, safe_stock, cache_ttl)
+
+    # Map last order quantity to each variant's safe stock row
+    variant_map = {v.variant_code: v for v in variants}
+    for row in safe_stock["safe_stock_data"]:
+        v = variant_map.get(row["variant_code"])
+        row["last_order_qty"] = getattr(v, "last_order_qty", 0) if v else 0
 
     threshold_value = safe_stock["product_safe_summary"]["avg_speed"] * 2
 


### PR DESCRIPTION
## Summary
- show last order qty per variant in product detail restock table
- annotate variants with latest order info
- include placeholder in totals row

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68778dbb10f4832cba48aa8bccf77684