### PR TITLE
Add last order qty column

### DIFF
--- a/inventory/templates/inventory/product_detail.html
+++ b/inventory/templates/inventory/product_detail.html
@@ -56,6 +56,7 @@
         <thead>
           <tr>
             <th>Variant</th>
+            <th>Last Order</th>
             <th>Sales / month</th>
             <th>Current Stock</th>
             <th>6 Months Stock</th>
@@ -69,6 +70,7 @@
           {% for row in safe_stock_data %}
           <tr>
             <td>{{ row.variant_code }}</td>
+            <td>{{ row.last_order_qty }}</td>
             <td>
               {{ row.avg_speed }}
               {% if row.trend == 'up' %}
@@ -86,12 +88,13 @@
             <td>{{ row.on_order_qty }}</td>
           </tr>
           {% empty %}
-          <tr><td colspan="6">No data available.</td></tr>
+          <tr><td colspan="7">No data available.</td></tr>
           {% endfor %}
           <tr class="product-summary">
             <td><strong>TOTALS</strong></td>
-            <td>{{ product_safe_summary.total_current_stock }} items</td>
+            <td>{{ product_safe_summary.total_last_order_qty }} items</td>
             <td>{{ product_safe_summary.avg_speed }} / month</td>
+            <td>{{ product_safe_summary.total_current_stock }} items</td>
             <td>{{ product_safe_summary.total_six_month_stock }}</td>
             <td>{{ product_safe_summary.total_restock_needed }}</td>
             <td>{{ product_safe_summary.total_on_order_qty }}</td>

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -7,11 +7,13 @@ from .models import (
     ProductVariant,
     InventorySnapshot,
     Sale,
+    Order,
+    OrderItem,
     Group,
     RestockSetting,
 )
+from django.urls import reverse
 from .utils import get_low_stock_products, get_restock_alerts
-
 
 
 class LowStockProductsTests(TestCase):
@@ -21,9 +23,7 @@ class LowStockProductsTests(TestCase):
         restock = RestockSetting.objects.create()
         restock.groups.add(self.core_group)
 
-        self.product1 = Product.objects.create(
-            product_id="P1", product_name="Prod1"
-        )
+        self.product1 = Product.objects.create(product_id="P1", product_name="Prod1")
         self.product1.groups.add(self.core_group)
         self.variant1 = ProductVariant.objects.create(
             product=self.product1,
@@ -44,9 +44,7 @@ class LowStockProductsTests(TestCase):
                 sold_value=100,
             )
 
-        self.product2 = Product.objects.create(
-            product_id="P2", product_name="Prod2"
-        )
+        self.product2 = Product.objects.create(product_id="P2", product_name="Prod2")
         self.product2.groups.add(self.core_group)
         self.variant2 = ProductVariant.objects.create(
             product=self.product2,
@@ -68,9 +66,7 @@ class LowStockProductsTests(TestCase):
             )
 
         # Variant that sold out quickly then restocked recently
-        self.product3 = Product.objects.create(
-            product_id="P3", product_name="Prod3"
-        )
+        self.product3 = Product.objects.create(product_id="P3", product_name="Prod3")
         self.product3.groups.add(self.core_group)
 
         self.variant3 = ProductVariant.objects.create(
@@ -86,7 +82,7 @@ class LowStockProductsTests(TestCase):
         )
         # sold everything five months ago
         Sale.objects.create(
-            order_number="O3", 
+            order_number="O3",
             date=six_months_ago + relativedelta(months=1),
             variant=self.variant3,
             sold_quantity=10,
@@ -100,9 +96,7 @@ class LowStockProductsTests(TestCase):
         )
 
         # Low stock product not in core group
-        self.product4 = Product.objects.create(
-            product_id="P4", product_name="Prod4"
-        )
+        self.product4 = Product.objects.create(product_id="P4", product_name="Prod4")
         self.product4.groups.add(self.other_group)
         self.variant4 = ProductVariant.objects.create(
             product=self.product4,
@@ -173,3 +167,38 @@ class LowStockProductsTests(TestCase):
         self.assertNotIn(self.product4, products)
         self.assertNotIn(self.product5, products)
 
+
+class LastOrderQtyTests(TestCase):
+    def test_last_order_ignores_undelivered(self):
+        product = Product.objects.create(product_id="P10", product_name="Prod10")
+        variant = ProductVariant.objects.create(
+            product=product, variant_code="V10", primary_color="#000000"
+        )
+
+        delivered_order = Order.objects.create(
+            order_date=date.today() - relativedelta(months=2)
+        )
+        OrderItem.objects.create(
+            product_variant=variant,
+            order=delivered_order,
+            quantity=5,
+            item_cost_price=1.0,
+            date_expected=date.today() - relativedelta(months=2, days=-10),
+            date_arrived=delivered_order.order_date,
+        )
+
+        open_order = Order.objects.create(
+            order_date=date.today() - relativedelta(months=1)
+        )
+        OrderItem.objects.create(
+            product_variant=variant,
+            order=open_order,
+            quantity=9,
+            item_cost_price=1.0,
+            date_expected=date.today(),
+        )
+
+        url = reverse("product_detail", args=[product.id])
+        response = self.client.get(url)
+        rows = response.context["safe_stock_data"]
+        self.assertEqual(rows[0]["last_order_qty"], 5)


### PR DESCRIPTION
## Summary
- show last order qty per variant in product detail restock table
- annotate variants with latest delivered order info only
- include totals for last order column in summary
- test that undelivered orders are ignored

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68778dbb10f4832cba48aa8bccf77684