### PR TITLE
Display last order date in restock table

### DIFF
--- a/inventory/templates/inventory/product_detail.html
+++ b/inventory/templates/inventory/product_detail.html
@@ -83,7 +83,11 @@ table#restock tr#totals {
           {% for row in safe_stock_data %}
           <tr>
             <td>{{ row.variant_code }}</td>
-            <td>{% if row.last_order_qty %}{{ row.last_order_qty }}{% else %}-{% endif %}</td>
+            <td>
+              {% if row.last_order_qty %}{{ row.last_order_qty }}{% else %}-{% endif %}
+              {% if row.last_order_date %}<br/>
+              <span class="small">{{ row.last_order_date }}</span>{% endif %}
+            </td>
             <td>
               {% if row.avg_speed > 0 %}{{ row.avg_speed }}{% endif %}
               {% if row.trend == 'up' %}

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -202,3 +202,4 @@ class LastOrderQtyTests(TestCase):
         response = self.client.get(url)
         rows = response.context["safe_stock_data"]
         self.assertEqual(rows[0]["last_order_qty"], 5)
+        self.assertEqual(rows[0]["last_order_date"], delivered_order.order_date)


### PR DESCRIPTION
## Summary
- include variant last order date in product detail context
- show last order date under last order quantity in restock table
- test variant last order date presence

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6877b5f7d41c832cbf430142c83f5594