### PR TITLE
Add percentage columns to restock table

### DIFF
--- a/inventory/templates/inventory/product_detail.html
+++ b/inventory/templates/inventory/product_detail.html
@@ -86,8 +86,8 @@ table#restock tr#totals {
             <td>{{ row.variant_code }}</td>
             <td>
               {% if row.last_order_qty %}{{ row.last_order_qty }}{% else %}-{% endif %}
-              | 
-              %
+              |
+              {{ row.last_order_qty_pct }}%
             </td>
             <td>
               {% if row.avg_speed > 0 %}{{ row.avg_speed }}{% endif %}
@@ -99,7 +99,11 @@ table#restock tr#totals {
                 &#8212;
               {% endif %}
             </td>
-            <td>{% if row.six_month_stock %}{{ row.six_month_stock }}{% else %}-{% endif %}</td>
+            <td>
+              {% if row.six_month_stock %}{{ row.six_month_stock }}{% else %}-{% endif %}
+              |
+              {{ row.six_month_stock_pct }}%
+            </td>
             <td>{{ row.current_stock }} <span class="stock-dot {{ row.stock_status }}"></span></td>
 
 

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -900,10 +900,19 @@ def product_detail(request, product_id):
         v = variant_map.get(row["variant_code"])
         qty = getattr(v, "last_order_qty", 0) if v else 0
         row["last_order_qty"] = qty
+        row["last_order_date"] = getattr(v, "last_order_date", None) if v else None
         if qty:
             total_last_order_qty += qty
 
     safe_stock["product_safe_summary"]["total_last_order_qty"] = total_last_order_qty
+
+    total_six_month_stock = safe_stock["product_safe_summary"].get("total_six_month_stock", 0)
+
+    for row in safe_stock["safe_stock_data"]:
+        lo = row.get("last_order_qty") or 0
+        row["last_order_qty_pct"] = round((lo / total_last_order_qty) * 100, 1) if total_last_order_qty else 0
+        six = row.get("six_month_stock") or 0
+        row["six_month_stock_pct"] = round((six / total_six_month_stock) * 100, 1) if total_six_month_stock else 0
 
     threshold_value = safe_stock["product_safe_summary"]["avg_speed"] * 2
 


### PR DESCRIPTION
## Summary
- display what portion of the total each variant's last order and six‑month stock comprise
- compute these percentages in `product_detail` view

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6878b02ee7d8832cb6096cdea6cb7752