### PR TITLE
Add similar products section

### DIFF
--- a/inventory/templates/inventory/product_detail.html
+++ b/inventory/templates/inventory/product_detail.html
@@ -47,6 +47,7 @@ table#restock tr#totals {
       </div>
     </div>
 
+
     <!-- Product-level Stock Forecast -->
     <div class="col s9">
       <div class="card z-depth-2" style="overflow: hidden;">
@@ -59,6 +60,7 @@ table#restock tr#totals {
       </div>
     </div>
   </div>
+{% include 'inventory/snippets/similar_product_cards.html' %}
 
 
   <!-- Safe Stock & Sales Speed -->

--- a/inventory/templates/inventory/snippets/similar_product_cards.html
+++ b/inventory/templates/inventory/snippets/similar_product_cards.html
@@ -1,0 +1,93 @@
+{% load inventory_extras %}
+<style>
+  .product-cards-container {
+    text-align: left;
+  }
+  .product-card {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    margin: 10px;
+    float: left;
+  }
+  .product-card .card {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+  }
+  .product-card .card-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .stock-badge {
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    background: rgba(33, 150, 243, 0.8);
+    color: white;
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-size: 0.75em;
+    z-index: 10;
+  }
+  .on-order-badge {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: red;
+    color: white;
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-size: 0.75em;
+    z-index: 10;
+  }
+  .product-card .product-details {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.8);
+    color: #fff;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    padding: 5px;
+    font-size: 0.8em;
+  }
+  .product-card:hover .product-details {
+    opacity: 1;
+  }
+</style>
+<div class="row">
+  <div class="col s12">
+    <h5>Similar Products</h5>
+    <div class="product-cards-container">
+      {% for p in similar_products %}
+        <div class="product-card">
+          <div class="card">
+            <div class="card-image">
+              <div class="stock-badge">{{ p.total_inventory|default:"0" }}</div>
+              {% if p.on_order_qty > 0 %}<div class="on-order-badge">{{ p.on_order_qty }}</div>{% endif %}
+              {% if p.product_photo %}
+                <img src="{{ p.product_photo.url }}" alt="{{ p.product_name }}">
+              {% else %}
+                <img src="https://via.placeholder.com/100" alt="No Image">
+              {% endif %}
+            </div>
+            <div class="product-details">
+              <span class="card-title" style="font-size:1em;">
+                <a href="{% url 'product_detail' p.id %}">{{ p.product_name }}</a>
+              </span>
+              <p>Stock: {{ p.total_inventory|default:"0" }}</p>
+              <p>On Order: {{ p.on_order_qty|default:"0" }}</p>
+            </div>
+          </div>
+        </div>
+      {% empty %}
+        <p>No similar products found.</p>
+      {% endfor %}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- show similar products on product detail
- display stock and on-order counts for similar products

## Testing
- `python manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_e_687907ba5b28832c9a4713c89325c48d