### PR TITLE
Add speed stats per product type

### DIFF
--- a/inventory/templates/inventory/product_detail.html
+++ b/inventory/templates/inventory/product_detail.html
@@ -42,6 +42,13 @@ table#restock tr#totals {
             {% endif %}
           </p>
           <p><strong>Total Sold:</strong> {{ total_qty }} units (¥{{ total_value|floatformat:"0" }})</p>
+          <p><strong>Category Avg Speed:</strong> {{ category_avg_speed }} / month</p>
+          <p>
+            <strong>Size Avg Speeds:</strong>
+            {% for sz, val in size_avg_speed_map.items %}
+              {{ sz }}: {{ val }}{% if not forloop.last %}, {% endif %}
+            {% endfor %} / month
+          </p>
 
         </div>
       </div>
@@ -73,6 +80,8 @@ table#restock tr#totals {
             <th>Variant</th>
             <th>Last Order</th>
             <th>Sales / month</th>
+            <th>Type Avg</th>
+            <th>Size Avg</th>
             <th>6 Months Stock</th>
             <th>Current Stock</th>
             <th>Stock at time restock lands</th>
@@ -102,6 +111,8 @@ table#restock tr#totals {
                 &#8212;
               {% endif %}
             </td>
+            <td>{{ row.type_avg_speed }}</td>
+            <td>{{ row.size_avg_speed }}</td>
             <td>
               {% if row.six_month_stock %}{{ row.six_month_stock }}{% else %}-{% endif %}
 
@@ -113,12 +124,14 @@ table#restock tr#totals {
             <td>{% if row.on_order_qty > 0 %}{{ row.on_order_qty }}{% else %}-{% endif %}</td>
           </tr>
           {% empty %}
-          <tr><td colspan="8">No data available.</td></tr>
+          <tr><td colspan="10">No data available.</td></tr>
           {% endfor %}
           <tr id="totals">
             <td><strong>TOTALS</strong></td>
             <td>{{ product_safe_summary.total_last_order_qty }} </td>
             <td>{{ product_safe_summary.avg_speed }} / month</td>
+            <td>{{ category_avg_speed }} / month</td>
+            <td>&mdash;</td>
             <td>{{ product_safe_summary.total_six_month_stock }}</td>
             <td>{{ product_safe_summary.total_current_stock }}</td>
             <td>{{ product_safe_summary.total_stock_at_restock }}</td>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -70,6 +70,7 @@ from .utils import (
     get_restock_alerts,
     calculate_variant_sales_speed,
     get_variant_speed_map,
+    get_category_speed_stats,
 )
 
 
@@ -913,6 +914,15 @@ def product_detail(request, product_id):
         six = row.get("six_month_stock") or 0
         row["six_month_stock_pct"] = round((six / total_six_month_stock) * 100, 1) if total_six_month_stock else 0
 
+    # --- Category and size average sales speeds ---
+    speed_stats = get_category_speed_stats(product.type)
+    category_avg_speed = speed_stats["overall_avg"]
+    size_avg_map = speed_stats["size_avgs"]
+
+    for row in safe_stock["safe_stock_data"]:
+        row["type_avg_speed"] = category_avg_speed
+        row["size_avg_speed"] = size_avg_map.get(row["variant_size"], 0)
+
     threshold_value = safe_stock["product_safe_summary"]["avg_speed"] * 2
 
     variant_proj_key = f"variant_proj_{product_id}"
@@ -1113,6 +1123,8 @@ def product_detail(request, product_id):
         "lifetime_profit": lifetime_profit,
         "current_inventory": current_inventory,
         "similar_products": similar_products,
+        "category_avg_speed": category_avg_speed,
+        "size_avg_speed_map": size_avg_map,
     }
 
     return render(request, "inventory/product_detail.html", context)


### PR DESCRIPTION
## Summary
- compute average sales speed by product type and size
- surface type/size averages on product detail page
- include helpers in views and templates
- test new speed calculation

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68790d1a12ec832c91575d3af80a23fe