### PR TITLE
Improve admin variant creation

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -26,8 +26,48 @@ from django.utils.safestring import mark_safe
 from django.contrib.admin.widgets import FilteredSelectMultiple
 
 
+class ProductAdminForm(forms.ModelForm):
+    """Form used for creating/editing Products with variant suggestions."""
+
+    variant_sizes = forms.MultipleChoiceField(
+        choices=ProductVariant.SIZE_CHOICES,
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        help_text="Select sizes to create variants for.",
+    )
+
+    class Meta:
+        model = Product
+        fields = "__all__"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            existing = list(
+                self.instance.variants.values_list("size", flat=True)
+            )
+            self.fields["variant_sizes"].initial = existing
+
+    def save(self, commit=True):
+        product = super().save(commit=commit)
+        if commit:
+            sizes = self.cleaned_data.get("variant_sizes", [])
+            for size in sizes:
+                code = f"{product.product_id}-{size}"
+                ProductVariant.objects.get_or_create(
+                    product=product,
+                    variant_code=code,
+                    defaults={"size": size, "gender": "male"},
+                )
+        else:
+            self._pending_sizes = self.cleaned_data.get("variant_sizes", [])
+        return product
+
+
+
 @admin.register(Product)
 class ProductAdmin(admin.ModelAdmin):
+    form = ProductAdminForm
     list_display = (
         "product_id",
         "product_name",
@@ -38,6 +78,10 @@ class ProductAdmin(admin.ModelAdmin):
         "age",
     )
     list_filter = ("groups", "series", "type", "style", "age")
+
+    class Media:
+        js = ("admin/js/product_admin.js",)
+
 
 
 @admin.register(ProductVariant)

--- a/inventory/static/admin/js/product_admin.js
+++ b/inventory/static/admin/js/product_admin.js
@@ -1,0 +1,25 @@
+// Suggest variant sizes based on selected product type
+
+document.addEventListener('DOMContentLoaded', function () {
+    const typeField = document.querySelector('#id_type');
+    const sizeInputs = document.querySelectorAll("input[name='variant_sizes']");
+
+    const recommendations = {
+        'gi': ['A0','A1','A1L','A2','A2L','A3','A3L','A4'],
+        'rg': ['XS','S','M','L','XL'],
+        'dk': ['XS','S','M','L','XL'],
+        'ck': ['XS','S','M','L','XL']
+    };
+
+    function applyRecommendations() {
+        const rec = recommendations[typeField.value] || [];
+        sizeInputs.forEach(cb => {
+            cb.checked = rec.includes(cb.value);
+        });
+    }
+
+    if (typeField) {
+        typeField.addEventListener('change', applyRecommendations);
+        applyRecommendations();
+    }
+});

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -320,3 +320,26 @@ class CategorySpeedStatsTests(TestCase):
         self.assertIn("S", stats["size_avgs"])
         self.assertGreater(stats["overall_avg"], 0)
         self.assertGreater(stats["size_avgs"]["S"], 0)
+
+
+class ProductAdminFormTests(TestCase):
+    def test_variant_creation_from_form(self):
+        from inventory.admin import ProductAdminForm
+
+        form_data = {
+            "product_id": "PG123",
+            "product_name": "Prod",
+            "type": "rg",
+            "restock_time": 0,
+            "variant_sizes": ["XS", "M"],
+        }
+        form = ProductAdminForm(data=form_data)
+        self.assertTrue(form.is_valid(), form.errors)
+        product = form.save()
+
+        variants = product.variants.all()
+        self.assertEqual(variants.count(), 2)
+        codes = set(variants.values_list("variant_code", flat=True))
+        self.assertEqual(codes, {"PG123-XS", "PG123-M"})
+        genders = set(variants.values_list("gender", flat=True))
+        self.assertEqual(genders, {"male"})


### PR DESCRIPTION
## Summary
- help admins create product variants directly from the Product page
- suggest sizes with new JS helper and auto-generate variant codes
- test product form variant creation

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6879153f3524832c8b127882e05cdde2