### PR TITLE
Enhance order admin variant selection

### DIFF
--- a/templates/admin/add_products.html
+++ b/templates/admin/add_products.html
@@ -6,8 +6,38 @@
 <h1>Add Variants to Order #{{ order.id }}</h1>
 <form method="post">{% csrf_token %}
   {{ form.media }}
+  {{ form.non_field_errors }}
+
+  <div class="product-groups">
+    {% for product in products %}
+      <fieldset class="module aligned">
+        <legend>
+          {% if product.product_photo %}
+            <img src="{{ product.product_photo.url }}" alt="{{ product.product_name }}" style="max-height:100px;" />
+          {% endif %}
+          {{ product.product_name }}
+        </legend>
+        <div class="form-row">
+          {% for variant in product.variants.all %}
+            <label style="margin-right:10px;">
+              <input type="checkbox" name="product_variants" value="{{ variant.id }}" {% if form.product_variants.value and variant.id|stringformat:'s' in form.product_variants.value %}checked{% endif %}>
+              {{ variant.variant_code }}
+            </label>
+          {% endfor %}
+        </div>
+      </fieldset>
+    {% endfor %}
+  </div>
+
   <table>
-    {{ form.as_table }}
+    <tr>
+      <th>{{ form.item_cost_price.label_tag }}</th>
+      <td>{{ form.item_cost_price }}</td>
+    </tr>
+    <tr>
+      <th>{{ form.date_expected.label_tag }}</th>
+      <td>{{ form.date_expected }}</td>
+    </tr>
   </table>
   <button type="submit" class="default">Add Products</button>
 </form>


### PR DESCRIPTION
## Summary
- allow selecting product variants directly when adding to an Order
- group variants by product and show product photo on the add products page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687a173265b8832c969e6f446cba7c7b