### PR TITLE
Enhance order admin variant selection

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -23,7 +23,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 from django.utils.safestring import mark_safe
-from django.contrib.admin.widgets import FilteredSelectMultiple
 
 
 class ProductAdminForm(forms.ModelForm):
@@ -56,6 +55,19 @@ class ProductAdminForm(forms.ModelForm):
         return product
 
 
+class ProductVariantInline(admin.TabularInline):
+    """Inline for editing variants directly on the Product page."""
+    model = ProductVariant
+    extra = 1
+    fields = (
+        "variant_code",
+        "size",
+        "gender",
+        "primary_color",
+        "secondary_color",
+    )
+
+
 
 @admin.register(Product)
 class ProductAdmin(admin.ModelAdmin):
@@ -70,6 +82,7 @@ class ProductAdmin(admin.ModelAdmin):
         "age",
     )
     list_filter = ("groups", "series", "type", "style", "age")
+    inlines = [ProductVariantInline]
 
     class Media:
         js = ("admin/js/product_admin.js",)
@@ -185,12 +198,11 @@ class OrderAdmin(admin.ModelAdmin):
             logger.debug("add_products_view POST called")
             form = AddProductsForm(request.POST)
             if form.is_valid():
-                products = form.cleaned_data["products"]
+                variants = form.cleaned_data["product_variants"]
                 cost_price = form.cleaned_data["item_cost_price"]
                 date_expected = form.cleaned_data["date_expected"]
-                product_variants = ProductVariant.objects.filter(product__in=products)
                 # Create an order item for each variant
-                for variant in product_variants:
+                for variant in variants:
                     OrderItem.objects.create(
                         order=order,
                         product_variant=variant,
@@ -209,6 +221,7 @@ class OrderAdmin(admin.ModelAdmin):
         context = {
             "order": order,
             "form": form,
+            "products": Product.objects.prefetch_related("variants").all(),
             "opts": self.model._meta,
             "app_label": self.model._meta.app_label,
         }
@@ -226,11 +239,11 @@ class OrderAdmin(admin.ModelAdmin):
 
 
 class AddProductsForm(forms.Form):
-    products = forms.ModelMultipleChoiceField(
-        queryset=Product.objects.all(),
-        widget=FilteredSelectMultiple("Products", is_stacked=False),
+    product_variants = forms.ModelMultipleChoiceField(
+        queryset=ProductVariant.objects.select_related("product"),
+        widget=forms.CheckboxSelectMultiple,
         required=True,
-        help_text="Select one or more products to add their variants as order items.",
+        help_text="Select the variants to add as order items.",
     )
     item_cost_price = forms.DecimalField(
         required=True,
@@ -244,6 +257,13 @@ class AddProductsForm(forms.Form):
         initial=date.today,  # or you can set a calculated default
         help_text="Set the expected date for the order items.",
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["product_variants"].queryset = (
+            ProductVariant.objects.select_related("product")
+            .order_by("product__product_name", "variant_code")
+        )
 
 
 @admin.register(OrderItem)

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -350,3 +350,10 @@ class ProductAdminFormTests(TestCase):
         self.assertEqual(codes, {"PG123-XS", "PG123-M"})
         genders = set(variants.values_list("gender", flat=True))
         self.assertEqual(genders, {"male"})
+
+    def test_product_admin_includes_variant_inline(self):
+        from inventory.admin import ProductAdmin, ProductVariantInline
+        from django.contrib.admin.sites import AdminSite
+
+        admin = ProductAdmin(Product, admin_site=AdminSite())
+        self.assertIn(ProductVariantInline, admin.inlines)

--- a/templates/admin/add_products.html
+++ b/templates/admin/add_products.html
@@ -6,8 +6,38 @@
 <h1>Add Variants to Order #{{ order.id }}</h1>
 <form method="post">{% csrf_token %}
   {{ form.media }}
+  {{ form.non_field_errors }}
+
+  <div class="product-groups">
+    {% for product in products %}
+      <fieldset class="module aligned">
+        <legend>
+          {% if product.product_photo %}
+            <img src="{{ product.product_photo.url }}" alt="{{ product.product_name }}" style="max-height:100px;" />
+          {% endif %}
+          {{ product.product_name }}
+        </legend>
+        <div class="form-row">
+          {% for variant in product.variants.all %}
+            <label style="margin-right:10px;">
+              <input type="checkbox" name="product_variants" value="{{ variant.id }}" {% if form.product_variants.value and variant.id|stringformat:'s' in form.product_variants.value %}checked{% endif %}>
+              {{ variant.variant_code }}
+            </label>
+          {% endfor %}
+        </div>
+      </fieldset>
+    {% endfor %}
+  </div>
+
   <table>
-    {{ form.as_table }}
+    <tr>
+      <th>{{ form.item_cost_price.label_tag }}</th>
+      <td>{{ form.item_cost_price }}</td>
+    </tr>
+    <tr>
+      <th>{{ form.date_expected.label_tag }}</th>
+      <td>{{ form.date_expected }}</td>
+    </tr>
   </table>
   <button type="submit" class="default">Add Products</button>
 </form>


### PR DESCRIPTION
## Summary
- allow selecting product variants directly when adding to an Order
- group variants by product and show product photo on the add products page
- support editing product variants inline on the Product admin page

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687a173265b8832c969e6f446cba7c7b