### PR TITLE
Enhance order admin variant grouping

### DIFF
--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -350,3 +350,10 @@ class ProductAdminFormTests(TestCase):
         self.assertEqual(codes, {"PG123-XS", "PG123-M"})
         genders = set(variants.values_list("gender", flat=True))
         self.assertEqual(genders, {"male"})
+
+    def test_product_admin_includes_variant_inline(self):
+        from inventory.admin import ProductAdmin, ProductVariantInline
+        from django.contrib.admin.sites import AdminSite
+
+        admin = ProductAdmin(Product, admin_site=AdminSite())
+        self.assertIn(ProductVariantInline, admin.inlines)

--- a/templates/admin/add_products.html
+++ b/templates/admin/add_products.html
@@ -6,8 +6,38 @@
 <h1>Add Variants to Order #{{ order.id }}</h1>
 <form method="post">{% csrf_token %}
   {{ form.media }}
+  {{ form.non_field_errors }}
+
+  <div class="product-groups">
+    {% for product in products %}
+      <fieldset class="module aligned">
+        <legend>
+          {% if product.product_photo %}
+            <img src="{{ product.product_photo.url }}" alt="{{ product.product_name }}" style="max-height:100px;" />
+          {% endif %}
+          {{ product.product_name }}
+        </legend>
+        <div class="form-row">
+          {% for variant in product.variants.all %}
+            <label style="margin-right:10px;">
+              <input type="checkbox" name="product_variants" value="{{ variant.id }}" {% if form.product_variants.value and variant.id|stringformat:'s' in form.product_variants.value %}checked{% endif %}>
+              {{ variant.variant_code }}
+            </label>
+          {% endfor %}
+        </div>
+      </fieldset>
+    {% endfor %}
+  </div>
+
   <table>
-    {{ form.as_table }}
+    <tr>
+      <th>{{ form.item_cost_price.label_tag }}</th>
+      <td>{{ form.item_cost_price }}</td>
+    </tr>
+    <tr>
+      <th>{{ form.date_expected.label_tag }}</th>
+      <td>{{ form.date_expected }}</td>
+    </tr>
   </table>
   <button type="submit" class="default">Add Products</button>
 </form>

--- a/templates/admin/orderitem_inline_grouped.html
+++ b/templates/admin/orderitem_inline_grouped.html
@@ -1,0 +1,81 @@
+{% load i18n admin_urls static admin_modify %}
+<div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group"
+     data-inline-type="tabular"
+     data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
+  <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
+{{ inline_admin_formset.formset.management_form }}
+<fieldset class="module {{ inline_admin_formset.classes }}" aria-labelledby="{{ inline_admin_formset.formset.prefix }}-heading">
+  {% if inline_admin_formset.is_collapsible %}<details><summary>{% endif %}
+  <h2 id="{{ inline_admin_formset.formset.prefix }}-heading" class="inline-heading">
+  {% if inline_admin_formset.formset.max_num == 1 %}
+    {{ inline_admin_formset.opts.verbose_name|capfirst }}
+  {% else %}
+    {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
+  {% endif %}
+  </h2>
+  {% if inline_admin_formset.is_collapsible %}</summary>{% endif %}
+   {{ inline_admin_formset.formset.non_form_errors }}
+   <table>
+     <thead><tr>
+       <th class="original"></th>
+     {% for field in inline_admin_formset.fields %}
+       <th class="column-{{ field.name }}{% if field.required %} required{% endif %}{% if field.widget.is_hidden %} hidden{% endif %}">{{ field.label|capfirst }}
+       {% if field.help_text %}<img src="{% static 'admin/img/icon-unknown.svg' %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
+       </th>
+     {% endfor %}
+     <th>{% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}{% translate "Delete?" %}{% endif %}</th>
+     </tr></thead>
+
+     <tbody>
+     {% for inline_admin_form in inline_admin_formset %}
+        {% if inline_admin_form.form.non_field_errors %}
+        <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
+        {% endif %}
+        {% ifchanged inline_admin_form.form.instance.product_variant.product_id %}
+        <tr class="group-row">
+          <th colspan="{{ inline_admin_form|cell_count }}">
+            {% with product=inline_admin_form.form.instance.product_variant.product %}
+              {% if product.product_photo %}
+                <img src="{{ product.product_photo.url }}" style="max-height:100px; margin-right:10px;" alt="{{ product.product_name }}">
+              {% endif %}
+              {{ product.product_name }}
+            {% endwith %}
+          </th>
+        </tr>
+        {% endifchanged %}
+        <tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
+             id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
+        <td class="original">
+          {% if inline_admin_form.original or inline_admin_form.show_url %}<p>
+          {% if inline_admin_form.original %}
+          {{ inline_admin_form.original }}
+          {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}<a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
+          {% endif %}
+          {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
+            </p>{% endif %}
+          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+          {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
+        </td>
+        {% for fieldset in inline_admin_form %}
+          {% for line in fieldset %}
+            {% for field in line %}
+              <td class="{% if field.field.name %}field-{{ field.field.name }}{% endif %}{% if field.field.is_hidden %} hidden{% endif %}">
+              {% if field.is_readonly %}
+                  <p>{{ field.contents }}</p>
+              {% else %}
+                  {{ field.field.errors.as_ul }}
+                  {{ field.field }}
+              {% endif %}
+              </td>
+            {% endfor %}
+          {% endfor %}
+        {% endfor %}
+        <td class="delete">{% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission and inline_admin_form.original %}{{ inline_admin_form.deletion_field.field }}{% endif %}</td>
+        </tr>
+     {% endfor %}
+     </tbody>
+   </table>
+  {% if inline_admin_formset.is_collapsible %}</details>{% endif %}
+</fieldset>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- sort OrderItem inline queryset by product
- display a product header with image when rendering OrderItem inlines

## Testing
- `python3 manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_687a173265b8832c969e6f446cba7c7b