### PR TITLE
Add async month navigation for sales stats

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -472,3 +472,12 @@ label.hide {
   font-weight: bold;
   pointer-events: none;
 }
+
+/* arrows for month navigation */
+.month-arrow {
+  color: #555;
+  padding: 4px;
+}
+@media (hover: hover) {
+  .month-arrow:hover { color: #000; }
+}

--- a/inventory/templates/inventory/home.html
+++ b/inventory/templates/inventory/home.html
@@ -177,10 +177,17 @@
 
     <!-- SALES INFORMATION SECTION -->
     <div class="col s12">
-      <div class="card z-depth-2" style="overflow: hidden;">
+      <div id="sales-info-card" class="card z-depth-2" style="overflow: hidden; position: relative;">
+        <a href="#" id="prevMonth" class="month-arrow" style="position:absolute; left:0; top:50%; transform:translate(-50%,-50%);">
+          <i class="material-icons">chevron_left</i>
+        </a>
+        <a href="#" id="nextMonth" class="month-arrow" style="position:absolute; right:0; top:50%; transform:translate(50%,-50%);">
+          <i class="material-icons">chevron_right</i>
+        </a>
 
           <!-- Bottom: White section with donut chart + legend -->
           <div class="card-content white">
+            <h6 id="salesMonthLabel" class="center-align">{{ last_month_name }}</h6>
             <div class="row" style="margin: 0;">
 
               <!-- Left: Donut Chart (1/3) -->
@@ -188,7 +195,7 @@
                 <div style="position: relative; width: 150px; height: 150px;">
                   <canvas id="categoryDonutChart" width="150" height="150"></canvas>
                   <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">
-                    <span style="font-size: 1.4rem; font-weight: bold;">{{ total_items_sold }}</span><br>
+                    <span id="totalItemsSold" style="font-size: 1.4rem; font-weight: bold;">{{ total_items_sold }}</span><br>
                     <span style="font-size: 0.9rem;">Items Sold</span>
                   </div>
                 </div>
@@ -213,7 +220,7 @@
                     <div class="card green lighten-2 z-depth-1" style="margin-bottom: 10px;">
                       <div class="card-content white-text center-align">
                         <span class="green-text text-darken-4"  style="font-size: 1.1rem; font-weight: 600;">Gross Sales</span>
-                        <h5 style="margin: 0px; font-weight: 500;">¥{{ total_sales|floatformat:0 }}</h5>
+                        <h5 id="totalSales" style="margin: 0px; font-weight: 500;">¥{{ total_sales|floatformat:0 }}</h5>
                       </div>
                       <div class="green lighten-1 center-align" style="padding: 8px; ">
                         <a href="#" class="white-text" style="font-weight: 500;">View Details</a>
@@ -226,7 +233,7 @@
                     <div class="card red lighten-2 z-depth-1" style="margin-bottom: 10px;">
                       <div class="card-content white-text center-align">
                         <span class="red-text text-darken-4" style="font-size: 1.1rem; font-weight: 600;">Returns</span>
-                        <h5 style="margin: 0px; font-weight: 500;">¥{{ total_returns|floatformat:0 }}</h5>
+                        <h5 id="totalReturns" style="margin: 0px; font-weight: 500;">¥{{ total_returns|floatformat:0 }}</h5>
                       </div>
                       <div class="red lighten-1 center-align" style="padding: 8px; ">
                         <a href="{% url 'returns' %}" class="white-text" style="font-weight: 500;">View Details</a>
@@ -239,7 +246,7 @@
                     <div class="card blue lighten-2 z-depth-1">
                       <div class="card-content white-text center-align">
                         <span class="blue-text text-darken-4" style="font-size: 1.1rem; font-weight: 600;">Net Sales</span>
-                        <h5 style="margin: 0px; font-weight: 500;">¥{{ net_sales|floatformat:0 }}</h5>
+                        <h5 id="netSales" style="margin: 0px; font-weight: 500;">¥{{ net_sales|floatformat:0 }}</h5>
                       </div>
                       <div class="blue lighten-1 center-align" style="padding: 8px; ">
                         <a href="#" class="white-text" style="font-weight: 500;">View Details</a>
@@ -396,8 +403,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
 <script>
   const donutCtx = document.getElementById('categoryDonutChart').getContext('2d');
-
-  new Chart(donutCtx, {
+  var donutChart = new Chart(donutCtx, {
     type: 'doughnut',
     data: {
       labels: {{ category_labels|safe }},
@@ -424,6 +430,39 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     }
   });
+
+  let currentMonth = '{{ current_month_slug }}';
+
+  function updateSalesSection(data) {
+    document.getElementById('salesMonthLabel').textContent = data.month_label;
+    document.getElementById('totalItemsSold').textContent = data.total_items_sold;
+    document.getElementById('totalSales').textContent = '¥' + Math.round(data.total_sales).toLocaleString();
+    document.getElementById('totalReturns').textContent = '¥' + Math.round(data.total_returns).toLocaleString();
+    document.getElementById('netSales').textContent = '¥' + Math.round(data.net_sales).toLocaleString();
+
+    donutChart.data.labels = data.category_labels;
+    donutChart.data.datasets[0].data = data.category_values;
+    donutChart.data.datasets[0].backgroundColor = data.category_colors;
+    donutChart.update();
+  }
+
+  function fetchMonth(y, m) {
+    fetch(`/sales-data/?year=${y}&month=${m}`)
+      .then(r => r.json())
+      .then(d => { currentMonth = d.current_month_slug; updateSalesSection(d); });
+  }
+
+  function adjustMonth(off) {
+    const parts = currentMonth.split('-');
+    let y = parseInt(parts[0]);
+    let m = parseInt(parts[1]) + off;
+    if (m < 1) { m = 12; y--; }
+    if (m > 12) { m = 1; y++; }
+    fetchMonth(y, m);
+  }
+
+  document.getElementById('prevMonth').addEventListener('click', function(e){ e.preventDefault(); adjustMonth(-1); });
+  document.getElementById('nextMonth').addEventListener('click', function(e){ e.preventDefault(); adjustMonth(1); });
 </script>
 
 

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path('products/<int:product_id>/', views.product_detail, name='product_detail'),  # New route
     path('orders/', views.order_list, name='order_list'),  # Order List View
     path('orders/<int:order_id>/', views.order_detail, name='order_detail'),  # Order Detail View
-    path('returns/', views.returns, name='returns'), 
+    path('returns/', views.returns, name='returns'),
+    path('sales-data/', views.sales_data, name='sales_data'),
 ]


### PR DESCRIPTION
## Summary
- enable month navigation in sales section on homepage
- serve sales info via new `/sales-data/` endpoint
- update charts and cards using AJAX
- style navigation arrows

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688cfcc6c394832cbe659a258e53c2a1