### PR TITLE
Add initial sales page and navigation entry

### DIFF
--- a/inventory/templates/inventory/base.html
+++ b/inventory/templates/inventory/base.html
@@ -36,6 +36,7 @@
         <li class="{% if request.resolver_match.url_name == 'product_list' %}active{% endif %}"><a href="{% url 'product_list' %}">Products</a></li>
         <li class="{% if request.resolver_match.url_name == 'inventory_snapshots' %}active{% endif %}"><a href="{% url 'inventory_snapshots' %}">Inventory</a></li>
         <li class="{% if request.resolver_match.url_name == 'order_list' %}active{% endif %}"><a href="{% url 'order_list' %}">Orders</a></li>
+        <li class="{% if request.resolver_match.url_name == 'sales' %}active{% endif %}"><a href="{% url 'sales' %}">Sales</a></li>
         <li class=""><a href="{% url 'admin:index' %}" class="active">Admin</a></li>
       </ul>
     </div>

--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -1,0 +1,14 @@
+{% extends 'inventory/base.html' %}
+
+{% block title %}Sales{% endblock %}
+
+{% block content %}
+<div class="section">
+  <div class="card">
+    <div class="card-content">
+      <span class="card-title">Sales Overview</span>
+      <p>Sales insights will appear here soon.</p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('products/<int:product_id>/', views.product_detail, name='product_detail'),  # New route
     path('orders/', views.order_list, name='order_list'),  # Order List View
     path('orders/<int:order_id>/', views.order_detail, name='order_detail'),  # Order Detail View
+    path('sales/', views.sales, name='sales'),
     path('returns/', views.returns, name='returns'),
     path('sales-data/', views.sales_data, name='sales_data'),
 ]

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1381,6 +1381,12 @@ def order_detail(request, order_id):
     return render(request, "inventory/order_detail.html", context)
 
 
+def sales(request):
+    """Render the placeholder sales page."""
+
+    return render(request, "inventory/sales.html")
+
+
 # a small helper to keep (date, change) pairs
 Event = namedtuple("Event", ["date", "delta"])
 


### PR DESCRIPTION
## Summary
- add a Sales link to the main navigation
- create a placeholder Sales view and template that extend the base layout
- register the new sales route so the page is reachable

## Testing
- python manage.py test *(fails: Django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95d45a8e4832c8d5489426958afaa