### PR TITLE
Add basic sales metrics with date range filter

### DIFF
--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -7,7 +7,61 @@
   <div class="card">
     <div class="card-content">
       <span class="card-title">Sales Overview</span>
-      <p>Sales insights will appear here soon.</p>
+
+      <form method="get" class="row" novalidate>
+        <div class="col s12 m5">
+          <label for="start_date" class="active">Start date</label>
+          <input
+            type="date"
+            id="start_date"
+            name="start_date"
+            value="{{ start_date|date:'Y-m-d' }}"
+            class="browser-default"
+          />
+        </div>
+        <div class="col s12 m5">
+          <label for="end_date" class="active">End date</label>
+          <input
+            type="date"
+            id="end_date"
+            name="end_date"
+            value="{{ end_date|date:'Y-m-d' }}"
+            class="browser-default"
+          />
+        </div>
+        <div class="col s12 m2" style="display: flex; align-items: flex-end;">
+          <button type="submit" class="btn waves-effect waves-light" style="width: 100%;">
+            Update
+          </button>
+        </div>
+      </form>
+
+      <p class="grey-text text-darken-1" style="margin-top: 0.5rem;">
+        Showing sales from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}.
+      </p>
+
+      {% if has_sales_data %}
+        <div class="row" style="margin-top: 1.5rem;">
+          <div class="col s12 m6">
+            <div class="card-panel teal lighten-5" style="margin: 0;">
+              <h6 class="grey-text text-darken-2" style="margin-top: 0;">Orders</h6>
+              <p style="font-size: 2.5rem; margin: 0; font-weight: 500;">{{ orders_count }}</p>
+              <p class="grey-text text-darken-1" style="margin-bottom: 0;">Unique order numbers</p>
+            </div>
+          </div>
+          <div class="col s12 m6" style="margin-top: 1rem;">
+            <div class="card-panel amber lighten-5" style="margin: 0;">
+              <h6 class="grey-text text-darken-2" style="margin-top: 0;">Items sold</h6>
+              <p style="font-size: 2.5rem; margin: 0; font-weight: 500;">{{ items_count }}</p>
+              <p class="grey-text text-darken-1" style="margin-bottom: 0;">Net quantity (sales minus returns)</p>
+            </div>
+          </div>
+        </div>
+      {% else %}
+        <p class="grey-text text-darken-1" style="margin-top: 1.5rem;">
+          No sales recorded for this date range.
+        </p>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1,6 +1,8 @@
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
+from unittest.mock import patch
 from dateutil.relativedelta import relativedelta
 from django.test import TestCase, RequestFactory
+from django.utils import timezone
 
 from .models import (
     Product,
@@ -520,3 +522,97 @@ class SalesDataInventoryTests(TestCase):
         self.assertFalse(data["snapshot_warning"])
         self.assertEqual(data["snapshot_date"], "2024-04-01")
 
+
+class SalesViewTests(TestCase):
+    def setUp(self):
+        self.product = Product.objects.create(
+            product_id="SP1", product_name="Sales Product", retail_price=10
+        )
+        self.variant = ProductVariant.objects.create(
+            product=self.product,
+            variant_code="SP1-V1",
+            primary_color="#000000",
+        )
+
+    def test_default_last_month_range_and_metrics(self):
+        # Sales in April 2024
+        Sale.objects.create(
+            order_number="A100",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            sold_quantity=3,
+            return_quantity=1,
+            sold_value=100,
+        )
+        Sale.objects.create(
+            order_number="A100",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            sold_quantity=2,
+            sold_value=70,
+        )
+        Sale.objects.create(
+            order_number="B200",
+            date=date(2024, 4, 20),
+            variant=self.variant,
+            sold_quantity=5,
+            return_quantity=2,
+            sold_value=120,
+        )
+        # Outside the default range
+        Sale.objects.create(
+            order_number="C300",
+            date=date(2024, 3, 15),
+            variant=self.variant,
+            sold_quantity=4,
+            sold_value=50,
+        )
+
+        with patch("inventory.views.now") as mock_now:
+            mock_now.return_value = timezone.make_aware(datetime(2024, 5, 15))
+            response = self.client.get(reverse("sales"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["start_date"], date(2024, 4, 1))
+        self.assertEqual(response.context["end_date"], date(2024, 4, 30))
+        self.assertEqual(response.context["orders_count"], 2)
+        self.assertEqual(response.context["items_count"], 7)
+        self.assertTrue(response.context["has_sales_data"])
+
+    def test_custom_range_filters_sales(self):
+        Sale.objects.create(
+            order_number="X1",
+            date=date(2024, 1, 5),
+            variant=self.variant,
+            sold_quantity=4,
+            sold_value=80,
+        )
+        Sale.objects.create(
+            order_number="X2",
+            date=date(2024, 2, 10),
+            variant=self.variant,
+            sold_quantity=6,
+            return_quantity=1,
+            sold_value=90,
+        )
+        Sale.objects.create(
+            order_number="X3",
+            date=date(2024, 3, 1),
+            variant=self.variant,
+            sold_quantity=8,
+            sold_value=110,
+        )
+
+        with patch("inventory.views.now") as mock_now:
+            mock_now.return_value = timezone.make_aware(datetime(2024, 4, 10))
+            response = self.client.get(
+                reverse("sales"),
+                {"start_date": "2024-02-28", "end_date": "2024-02-01"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["start_date"], date(2024, 2, 1))
+        self.assertEqual(response.context["end_date"], date(2024, 2, 28))
+        self.assertEqual(response.context["orders_count"], 1)
+        self.assertEqual(response.context["items_count"], 5)
+        self.assertTrue(response.context["has_sales_data"])

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1382,9 +1382,52 @@ def order_detail(request, order_id):
 
 
 def sales(request):
-    """Render the placeholder sales page."""
+    """Render the sales page with basic order metrics for a date range."""
 
-    return render(request, "inventory/sales.html")
+    today = now().date()
+    first_day_this_month = today.replace(day=1)
+    default_end = first_day_this_month - timedelta(days=1)
+    default_start = default_end.replace(day=1)
+
+    def _parse_date(param: str | None):
+        if not param:
+            return None
+        try:
+            return datetime.strptime(param, "%Y-%m-%d").date()
+        except (ValueError, TypeError):
+            return None
+
+    requested_start = _parse_date(request.GET.get("start_date"))
+    requested_end = _parse_date(request.GET.get("end_date"))
+
+    start_date = requested_start or default_start
+    end_date = requested_end or default_end
+
+    if start_date > end_date:
+        start_date, end_date = end_date, start_date
+
+    sales_qs = Sale.objects.filter(date__range=(start_date, end_date))
+
+    orders_count = sales_qs.values("order_number").distinct().count()
+
+    net_quantity_expr = ExpressionWrapper(
+        F("sold_quantity")
+        - Coalesce(F("return_quantity"), Value(0, output_field=IntegerField())),
+        output_field=IntegerField(),
+    )
+    total_items = sales_qs.aggregate(
+        total_items=Coalesce(Sum(net_quantity_expr), Value(0, output_field=IntegerField()))
+    )["total_items"] or 0
+
+    context = {
+        "start_date": start_date,
+        "end_date": end_date,
+        "orders_count": orders_count,
+        "items_count": int(total_items),
+        "has_sales_data": orders_count > 0,
+    }
+
+    return render(request, "inventory/sales.html", context)
 
 
 # a small helper to keep (date, change) pairs


### PR DESCRIPTION
## Summary
- add a last-month default date range filter to the sales view and compute order/item metrics
- update the sales page with a date range selector and metric cards
- cover the sales view behaviour with unit tests for default and custom ranges

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68c967099bc8832c8ff7ba6a9ac5c4df