### PR TITLE
Add pricing breakdown to sales page

### DIFF
--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -7,7 +7,97 @@
   <div class="card">
     <div class="card-content">
       <span class="card-title">Sales Overview</span>
-      <p>Sales insights will appear here soon.</p>
+
+      <form method="get" class="row" novalidate>
+        <div class="col s12 m5">
+          <label for="start_date" class="active">Start date</label>
+          <input
+            type="date"
+            id="start_date"
+            name="start_date"
+            value="{{ start_date|date:'Y-m-d' }}"
+            class="browser-default"
+          />
+        </div>
+        <div class="col s12 m5">
+          <label for="end_date" class="active">End date</label>
+          <input
+            type="date"
+            id="end_date"
+            name="end_date"
+            value="{{ end_date|date:'Y-m-d' }}"
+            class="browser-default"
+          />
+        </div>
+        <div class="col s12 m2" style="display: flex; align-items: flex-end;">
+          <button type="submit" class="btn waves-effect waves-light" style="width: 100%;">
+            Update
+          </button>
+        </div>
+      </form>
+
+      <p class="grey-text text-darken-1" style="margin-top: 0.5rem;">
+        Showing sales from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}.
+      </p>
+
+      {% if has_sales_data %}
+        <div class="row" style="margin-top: 1.5rem;">
+          <div class="col s12 m6">
+            <div class="card-panel teal lighten-5" style="margin: 0;">
+              <h6 class="grey-text text-darken-2" style="margin-top: 0;">Orders</h6>
+              <p style="font-size: 2.5rem; margin: 0; font-weight: 500;">{{ orders_count }}</p>
+              <p class="grey-text text-darken-1" style="margin-bottom: 0;">Unique order numbers</p>
+            </div>
+          </div>
+          <div class="col s12 m6" style="margin-top: 1rem;">
+            <div class="card-panel amber lighten-5" style="margin: 0;">
+              <h6 class="grey-text text-darken-2" style="margin-top: 0;">Items sold</h6>
+              <p style="font-size: 2.5rem; margin: 0; font-weight: 500;">{{ items_count }}</p>
+              <p class="grey-text text-darken-1" style="margin-bottom: 0;">Net quantity (sales minus returns)</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="row" style="margin-top: 1.5rem;">
+          <div class="col s12">
+            <div class="card-panel blue lighten-5" style="margin: 0;">
+              <h6 class="grey-text text-darken-2" style="margin-top: 0;">Pricing breakdown</h6>
+              <p class="grey-text text-darken-1" style="margin-top: 0;">
+                Counts exclude returned sales and lines with zero quantity.
+              </p>
+              <table class="striped" style="margin-top: 1rem;">
+                <thead>
+                  <tr>
+                    <th>Category</th>
+                    <th>Sale lines</th>
+                    <th>Items sold</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for bucket in price_breakdown %}
+                    <tr>
+                      <td>{{ bucket.label }}</td>
+                      <td>{{ bucket.sales_count }}</td>
+                      <td>{{ bucket.items_count }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <th>Total</th>
+                    <th>{{ pricing_total_sales }}</th>
+                    <th>{{ pricing_total_items }}</th>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+        </div>
+      {% else %}
+        <p class="grey-text text-darken-1" style="margin-top: 1.5rem;">
+          No sales recorded for this date range.
+        </p>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1,6 +1,9 @@
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
+from decimal import Decimal
+from unittest.mock import patch
 from dateutil.relativedelta import relativedelta
 from django.test import TestCase, RequestFactory
+from django.utils import timezone
 
 from .models import (
     Product,
@@ -520,3 +523,169 @@ class SalesDataInventoryTests(TestCase):
         self.assertFalse(data["snapshot_warning"])
         self.assertEqual(data["snapshot_date"], "2024-04-01")
 
+
+class SalesViewTests(TestCase):
+    def setUp(self):
+        self.product = Product.objects.create(
+            product_id="SP1", product_name="Sales Product", retail_price=10
+        )
+        self.variant = ProductVariant.objects.create(
+            product=self.product,
+            variant_code="SP1-V1",
+            primary_color="#000000",
+        )
+
+    def test_default_last_month_range_and_metrics(self):
+        # Sales in April 2024
+        Sale.objects.create(
+            order_number="A100",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            sold_quantity=3,
+            return_quantity=1,
+            sold_value=100,
+        )
+        Sale.objects.create(
+            order_number="A100",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            sold_quantity=2,
+            sold_value=70,
+        )
+        Sale.objects.create(
+            order_number="B200",
+            date=date(2024, 4, 20),
+            variant=self.variant,
+            sold_quantity=5,
+            return_quantity=2,
+            sold_value=120,
+        )
+        # Outside the default range
+        Sale.objects.create(
+            order_number="C300",
+            date=date(2024, 3, 15),
+            variant=self.variant,
+            sold_quantity=4,
+            sold_value=50,
+        )
+
+        with patch("inventory.views.now") as mock_now:
+            mock_now.return_value = timezone.make_aware(datetime(2024, 5, 15))
+            response = self.client.get(reverse("sales"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["start_date"], date(2024, 4, 1))
+        self.assertEqual(response.context["end_date"], date(2024, 4, 30))
+        self.assertEqual(response.context["orders_count"], 2)
+        self.assertEqual(response.context["items_count"], 7)
+        self.assertTrue(response.context["has_sales_data"])
+
+    def test_custom_range_filters_sales(self):
+        Sale.objects.create(
+            order_number="X1",
+            date=date(2024, 1, 5),
+            variant=self.variant,
+            sold_quantity=4,
+            sold_value=80,
+        )
+        Sale.objects.create(
+            order_number="X2",
+            date=date(2024, 2, 10),
+            variant=self.variant,
+            sold_quantity=6,
+            return_quantity=1,
+            sold_value=90,
+        )
+        Sale.objects.create(
+            order_number="X3",
+            date=date(2024, 3, 1),
+            variant=self.variant,
+            sold_quantity=8,
+            sold_value=110,
+        )
+
+        with patch("inventory.views.now") as mock_now:
+            mock_now.return_value = timezone.make_aware(datetime(2024, 4, 10))
+            response = self.client.get(
+                reverse("sales"),
+                {"start_date": "2024-02-28", "end_date": "2024-02-01"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["start_date"], date(2024, 2, 1))
+        self.assertEqual(response.context["end_date"], date(2024, 2, 28))
+        self.assertEqual(response.context["orders_count"], 1)
+        self.assertEqual(response.context["items_count"], 5)
+        self.assertTrue(response.context["has_sales_data"])
+
+    def test_price_breakdown_categorises_sales(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+
+        Sale.objects.create(
+            order_number="F001",
+            date=date(2024, 4, 2),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("100.00"),
+        )
+        Sale.objects.create(
+            order_number="S001",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            sold_quantity=2,
+            sold_value=Decimal("192.00"),
+        )
+        Sale.objects.create(
+            order_number="D001",
+            date=date(2024, 4, 12),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("90.00"),
+        )
+        Sale.objects.create(
+            order_number="W001",
+            date=date(2024, 4, 18),
+            variant=self.variant,
+            sold_quantity=4,
+            sold_value=Decimal("300.00"),
+        )
+        Sale.objects.create(
+            order_number="G001",
+            date=date(2024, 4, 25),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("0.00"),
+        )
+        # Returned sale should be excluded from breakdown counts
+        Sale.objects.create(
+            order_number="R001",
+            date=date(2024, 4, 27),
+            variant=self.variant,
+            sold_quantity=2,
+            return_quantity=1,
+            sold_value=Decimal("150.00"),
+        )
+
+        with patch("inventory.views.now") as mock_now:
+            mock_now.return_value = timezone.make_aware(datetime(2024, 5, 15))
+            response = self.client.get(reverse("sales"))
+
+        self.assertEqual(response.status_code, 200)
+
+        breakdown = response.context["price_breakdown"]
+        breakdown_by_label = {entry["label"]: entry for entry in breakdown}
+
+        self.assertEqual(breakdown_by_label["Full price"]["sales_count"], 1)
+        self.assertEqual(breakdown_by_label["Full price"]["items_count"], 1)
+        self.assertEqual(breakdown_by_label["Small discount"]["sales_count"], 1)
+        self.assertEqual(breakdown_by_label["Small discount"]["items_count"], 2)
+        self.assertEqual(breakdown_by_label["Discount"]["sales_count"], 1)
+        self.assertEqual(breakdown_by_label["Discount"]["items_count"], 1)
+        self.assertEqual(breakdown_by_label["Wholesale"]["sales_count"], 1)
+        self.assertEqual(breakdown_by_label["Wholesale"]["items_count"], 4)
+        self.assertEqual(breakdown_by_label["Gifted"]["sales_count"], 1)
+        self.assertEqual(breakdown_by_label["Gifted"]["items_count"], 1)
+
+        self.assertEqual(response.context["pricing_total_sales"], 5)
+        self.assertEqual(response.context["pricing_total_items"], 9)


### PR DESCRIPTION
## Summary
- bucket sales by retail vs actual price in the sales view while ignoring returned lines
- expose the pricing breakdown on the sales template with totals for line count and quantity
- cover the price categorisation logic with a dedicated sales view test

## Testing
- python manage.py test *(fails: Django not installed in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c967099bc8832c8ff7ba6a9ac5c4df