### PR TITLE
Display gross and net sales totals

### DIFF
--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -72,7 +72,7 @@
             <div class="card blue lighten-2 z-depth-1">
               <div class="card-content white-text center-align">
                 <span class="blue-text text-darken-4" style="font-size: 1.1rem; font-weight: 600;">Gross Sales</span>
-                <h5 id="netSales" style="margin: 0px; font-weight: 500;"></h5>
+                <h5 id="netSales" style="margin: 0px; font-weight: 500;">¥{{ gross_sales_value|floatformat:0 }}</h5>
               </div>
               <div class="blue lighten-1 center-align" style="padding: 8px; ">
                 <a href="#" class="white-text" style="font-weight: 500;">View Details</a>
@@ -84,7 +84,7 @@
             <div class="card blue lighten-2 z-depth-1">
               <div class="card-content white-text center-align">
                 <span class="blue-text text-darken-4" style="font-size: 1.1rem; font-weight: 600;">Net Sales</span>
-                <h5 id="netSales" style="margin: 0px; font-weight: 500;"></h5>
+                <h5 id="netSales" style="margin: 0px; font-weight: 500;">¥{{ net_sales_value|floatformat:0 }}</h5>
               </div>
               <div class="blue lighten-1 center-align" style="padding: 8px; ">
                 <a href="#" class="white-text" style="font-weight: 500;">View Details</a>

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -545,6 +545,7 @@ class SalesViewTests(TestCase):
             sold_quantity=3,
             return_quantity=1,
             sold_value=100,
+            return_value=30,
         )
         Sale.objects.create(
             order_number="A100",
@@ -560,6 +561,7 @@ class SalesViewTests(TestCase):
             sold_quantity=5,
             return_quantity=2,
             sold_value=120,
+            return_value=40,
         )
         # Outside the default range
         Sale.objects.create(
@@ -579,6 +581,8 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.context["end_date"], date(2024, 4, 30))
         self.assertEqual(response.context["orders_count"], 2)
         self.assertEqual(response.context["items_count"], 7)
+        self.assertEqual(response.context["gross_sales_value"], Decimal("290"))
+        self.assertEqual(response.context["net_sales_value"], Decimal("220"))
         self.assertTrue(response.context["has_sales_data"])
 
     def test_custom_range_filters_sales(self):
@@ -596,6 +600,7 @@ class SalesViewTests(TestCase):
             sold_quantity=6,
             return_quantity=1,
             sold_value=90,
+            return_value=15,
         )
         Sale.objects.create(
             order_number="X3",
@@ -617,6 +622,8 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.context["end_date"], date(2024, 2, 28))
         self.assertEqual(response.context["orders_count"], 1)
         self.assertEqual(response.context["items_count"], 5)
+        self.assertEqual(response.context["gross_sales_value"], Decimal("90"))
+        self.assertEqual(response.context["net_sales_value"], Decimal("75"))
         self.assertTrue(response.context["has_sales_data"])
 
     def test_price_breakdown_categorises_sales(self):

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1481,6 +1481,14 @@ def sales(request):
         bucket["actual_value"] for bucket in price_breakdown
     )
 
+    value_aggregates = sales_qs.aggregate(
+        gross_sales=Sum("sold_value"),
+        returns_total=Sum("return_value"),
+    )
+    gross_sales_value = value_aggregates["gross_sales"] or Decimal("0")
+    returns_total_value = value_aggregates["returns_total"] or Decimal("0")
+    net_sales_value = gross_sales_value - returns_total_value
+
     if pricing_total_actual_value:
         for bucket in price_breakdown:
             percentage = (
@@ -1506,6 +1514,8 @@ def sales(request):
         "pricing_total_items": int(pricing_total_items),
         "pricing_total_retail_value": pricing_total_retail_value,
         "pricing_total_actual_value": pricing_total_actual_value,
+        "gross_sales_value": gross_sales_value,
+        "net_sales_value": net_sales_value,
 
     }
 


### PR DESCRIPTION
## Summary
- compute gross and net sales totals for the requested date range
- display the computed totals in the sales overview cards
- extend the sales view tests to verify the new aggregates

## Testing
- python manage.py test inventory.tests.SalesViewTests *(fails: Django not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca75262d80832c80c09c5f6c91618b