### PR TITLE
Add detailed sales pricing bucket view

### DIFF
--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -105,7 +105,7 @@
                 Counts and totals exclude returned sales and lines with zero quantity.
 
               </p>
-              <table class="striped" style="margin-top: 1rem;">
+              <table class="striped price-breakdown-table" style="margin-top: 1rem;">
                 <thead>
                   <tr>
                     <th>Category</th>
@@ -118,8 +118,19 @@
                 </thead>
                 <tbody>
                   {% for bucket in price_breakdown %}
-                    <tr>
-                      <td>{{ bucket.label }}</td>
+                    {% url 'sales_bucket_detail' bucket.key as bucket_url %}
+                    <tr
+                      class="clickable-row"
+                      data-href="{{ bucket_url }}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+                    >
+                      <td>
+                        <a
+                          href="{{ bucket_url }}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+                          class="price-breakdown-link"
+                        >
+                          {{ bucket.label }}
+                        </a>
+                      </td>
                       <td>{{ bucket.items_count }}</td>
                       <td>¥{{ bucket.retail_value|floatformat:2 }}</td>
                       <td>¥{{ bucket.actual_value|floatformat:2 }}</td>
@@ -148,6 +159,55 @@
             </div>
           </div>
         </div>
+
+        <style>
+          .price-breakdown-table tr.clickable-row {
+            cursor: pointer;
+          }
+
+          .price-breakdown-table tr.clickable-row:hover {
+            background-color: rgba(33, 150, 243, 0.08);
+          }
+
+          .price-breakdown-link {
+            color: inherit;
+            display: inline-block;
+            text-decoration: none;
+            width: 100%;
+          }
+
+          .price-breakdown-link:hover {
+            text-decoration: underline;
+          }
+        </style>
+
+        <script>
+          document.addEventListener("DOMContentLoaded", function () {
+            document
+              .querySelectorAll(".price-breakdown-table tr.clickable-row")
+              .forEach(function (row) {
+                row.setAttribute("tabindex", "0");
+                row.addEventListener("click", function (event) {
+                  if (event.target.tagName && event.target.tagName.toLowerCase() === "a") {
+                    return;
+                  }
+                  const anchor = row.querySelector("a.price-breakdown-link");
+                  if (anchor) {
+                    window.location.href = anchor.getAttribute("href");
+                  }
+                });
+                row.addEventListener("keyup", function (event) {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    const anchor = row.querySelector("a.price-breakdown-link");
+                    if (anchor) {
+                      anchor.click();
+                    }
+                  }
+                });
+              });
+          });
+        </script>
 
       {% else %}
         <p class="grey-text text-darken-1" style="margin-top: 1.5rem;">

--- a/inventory/templates/inventory/sales_bucket_detail.html
+++ b/inventory/templates/inventory/sales_bucket_detail.html
@@ -1,0 +1,170 @@
+{% extends 'inventory/base.html' %}
+
+{% block title %}{{ bucket_label }} Sales{% endblock %}
+
+{% block content %}
+<div class="section">
+  <div class="card">
+    <div class="card-content">
+      <span class="card-title">{{ bucket_label }} sales</span>
+      <p class="grey-text text-darken-1" style="margin-bottom: 1.5rem;">
+        Showing sales from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}.
+      </p>
+
+      <div style="display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; margin-bottom: 1.5rem;">
+        <a
+          href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+          class="btn-flat waves-effect"
+        >
+          ← Back to sales overview
+        </a>
+        <div class="grey lighten-4" style="padding: 0.75rem 1rem; border-radius: 6px;">
+          <strong>{{ orders_count }}</strong> order{{ orders_count|pluralize }} ·
+          <strong>{{ bucket_totals.items_count }}</strong> item{{ bucket_totals.items_count|pluralize }} ·
+          Retail: ¥{{ bucket_totals.retail_value|floatformat:2 }} ·
+          Actual: ¥{{ bucket_totals.actual_value|floatformat:2 }}
+          {% if bucket_totals.returns_value %}
+            · <span class="red-text text-darken-1">Returns: ¥{{ bucket_totals.returns_value|floatformat:2 }}</span>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if orders %}
+        {% for order in orders %}
+          <div class="order-block z-depth-1">
+            <div class="order-header">
+              <div>
+                <span class="order-number">Order {{ order.order_number }}</span>
+                <span class="order-date">· {{ order.date|date:"F j, Y" }}</span>
+              </div>
+              <div class="order-values">
+                <span class="order-total">Actual total: ¥{{ order.total_value|floatformat:2 }}</span>
+                {% if order.returns_value %}
+                  <span class="order-returns red-text text-darken-1">Returns: ¥{{ order.returns_value|floatformat:2 }}</span>
+                {% endif %}
+              </div>
+            </div>
+
+            <table class="highlight order-items-table">
+              <thead>
+                <tr>
+                  <th>Item</th>
+                  <th>Retail price</th>
+                  <th>Actual price paid</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for item in order.items %}
+                  <tr>
+                    <td>
+                      <div class="order-item-product">
+                        {% if item.sale.variant.product.product_photo %}
+                          <img
+                            src="{{ item.sale.variant.product.product_photo.url }}"
+                            alt="{{ item.sale.variant.product.product_name }}"
+                          />
+                        {% else %}
+                          <div class="order-item-placeholder">No photo</div>
+                        {% endif %}
+                        <div>
+                          <div class="variant-code">{{ item.sale.variant.variant_code }}</div>
+                          <div class="quantity grey-text text-darken-1">Qty: {{ item.sold_quantity }}</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      ¥{{ item.retail_price|floatformat:2 }}
+                      <div class="grey-text text-darken-1">per item</div>
+                    </td>
+                    <td>
+                      ¥{{ item.actual_unit_price|floatformat:2 }}
+                      <div class="grey-text text-darken-1">
+                        Total: ¥{{ item.actual_total|floatformat:2 }}
+                      </div>
+                    </td>
+                    <td>
+                      {% if item.returned %}
+                        <span class="red-text text-darken-1">Returned</span>
+                      {% else %}
+                        &mdash;
+                      {% endif %}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% endfor %}
+      {% else %}
+        <p class="grey-text text-darken-1" style="margin-top: 2rem;">
+          No sales matched this pricing group for the selected date range.
+        </p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+<style>
+  .order-block {
+    background-color: #ffffff;
+    border-radius: 8px;
+    margin-bottom: 1.5rem;
+    padding: 1.25rem;
+  }
+
+  .order-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .order-number {
+    font-weight: 600;
+  }
+
+  .order-values {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+  }
+
+  .order-items-table th,
+  .order-items-table td {
+    vertical-align: middle;
+  }
+
+  .order-item-product {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .order-item-product img {
+    width: 64px;
+    height: 64px;
+    object-fit: cover;
+    border-radius: 6px;
+  }
+
+  .order-item-placeholder {
+    align-items: center;
+    background-color: #e0e0e0;
+    border-radius: 6px;
+    color: #616161;
+    display: flex;
+    font-size: 0.8rem;
+    height: 64px;
+    justify-content: center;
+    width: 64px;
+  }
+
+  .variant-code {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+</style>
+{% endblock %}

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('orders/', views.order_list, name='order_list'),  # Order List View
     path('orders/<int:order_id>/', views.order_detail, name='order_detail'),  # Order Detail View
     path('sales/', views.sales, name='sales'),
+    path('sales/price-group/<str:bucket_key>/', views.sales_bucket_detail, name='sales_bucket_detail'),
     path('returns/', views.returns, name='returns'),
     path('sales-data/', views.sales_data, name='sales_data'),
 ]

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1,5 +1,5 @@
 from datetime import datetime, date, timedelta
-from typing import Optional
+from typing import Optional, Tuple
 from django.utils.timezone import now
 from dateutil.relativedelta import relativedelta
 import json
@@ -38,7 +38,7 @@ from django.db.models import (
     DateField,
 )
 from django.db.models.functions import Coalesce
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, JsonResponse, Http404
 from django.db.models.functions import TruncMonth
 
 from .models import (
@@ -81,6 +81,69 @@ CATEGORY_COLOR_MAP = {
     "dk": "#fb8c00",  # Orange
     "other": "#9e9e9e",  # Grey
 }
+
+PRICE_CATEGORIES = [
+    ("full_price", "Full price"),
+    ("small_discount", "Small discount"),
+    ("discount", "Discount"),
+    ("wholesale", "Wholesale"),
+    ("gifted", "Gifted"),
+]
+
+PRICE_CATEGORY_LABELS = {key: label for key, label in PRICE_CATEGORIES}
+
+PRICE_BUCKET_TOLERANCE = Decimal("0.005")
+SMALL_DISCOUNT_THRESHOLD = Decimal("0.05")
+DISCOUNT_THRESHOLD = Decimal("0.20")
+
+
+def _parse_sales_date(param: Optional[str]) -> Optional[date]:
+    if not param:
+        return None
+    try:
+        return datetime.strptime(param, "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return None
+
+
+def _get_sales_date_range(request) -> Tuple[date, date]:
+    today = now().date()
+    first_day_this_month = today.replace(day=1)
+    default_end = first_day_this_month - timedelta(days=1)
+    default_start = default_end.replace(day=1)
+
+    start_date = _parse_sales_date(request.GET.get("start_date")) or default_start
+    end_date = _parse_sales_date(request.GET.get("end_date")) or default_end
+
+    if start_date > end_date:
+        start_date, end_date = end_date, start_date
+
+    return start_date, end_date
+
+
+def _determine_price_bucket(sale) -> Optional[str]:
+    sold_quantity = sale.sold_quantity or 0
+    if sold_quantity <= 0:
+        return None
+
+    retail_price = sale.variant.product.retail_price or Decimal("0")
+    actual_total = sale.sold_value or Decimal("0")
+    actual_price = actual_total / sold_quantity if sold_quantity else Decimal("0")
+
+    if actual_price == 0:
+        return "gifted"
+    if retail_price <= 0:
+        return "full_price"
+
+    diff_ratio = (retail_price - actual_price) / retail_price
+
+    if diff_ratio <= PRICE_BUCKET_TOLERANCE:
+        return "full_price"
+    if diff_ratio < SMALL_DISCOUNT_THRESHOLD:
+        return "small_discount"
+    if diff_ratio < DISCOUNT_THRESHOLD:
+        return "discount"
+    return "wholesale"
 
 
 # — Helper to bucket types into our four categories —
@@ -1381,28 +1444,7 @@ def order_detail(request, order_id):
 def sales(request):
     """Render the sales page with basic order metrics for a date range."""
 
-    today = now().date()
-    first_day_this_month = today.replace(day=1)
-    default_end = first_day_this_month - timedelta(days=1)
-    default_start = default_end.replace(day=1)
-
-    def _parse_date(param: Optional[str]):
-
-        if not param:
-            return None
-        try:
-            return datetime.strptime(param, "%Y-%m-%d").date()
-        except (ValueError, TypeError):
-            return None
-
-    requested_start = _parse_date(request.GET.get("start_date"))
-    requested_end = _parse_date(request.GET.get("end_date"))
-
-    start_date = requested_start or default_start
-    end_date = requested_end or default_end
-
-    if start_date > end_date:
-        start_date, end_date = end_date, start_date
+    start_date, end_date = _get_sales_date_range(request)
 
     sales_qs = Sale.objects.filter(date__range=(start_date, end_date))
 
@@ -1413,31 +1455,25 @@ def sales(request):
         - Coalesce(F("return_quantity"), Value(0, output_field=IntegerField())),
         output_field=IntegerField(),
     )
-    total_items = sales_qs.aggregate(
-        total_items=Coalesce(Sum(net_quantity_expr), Value(0, output_field=IntegerField()))
-    )["total_items"] or 0
+    total_items = (
+        sales_qs.aggregate(
+            total_items=Coalesce(
+                Sum(net_quantity_expr), Value(0, output_field=IntegerField())
+            )
+        )["total_items"]
+        or 0
+    )
 
-    price_categories = [
-        ("full_price", "Full price"),
-        ("small_discount", "Small discount"),
-        ("discount", "Discount"),
-        ("wholesale", "Wholesale"),
-        ("gifted", "Gifted"),
-    ]
     price_buckets = {
         key: {
+            "key": key,
             "label": label,
             "items_count": 0,
             "retail_value": Decimal("0"),
             "actual_value": Decimal("0"),
         }
-
-        for key, label in price_categories
+        for key, label in PRICE_CATEGORIES
     }
-
-    tolerance = Decimal("0.005")
-    small_discount_threshold = Decimal("0.05")
-    discount_threshold = Decimal("0.20")
 
     eligible_sales = (
         sales_qs.filter(Q(return_quantity__isnull=True) | Q(return_quantity=0))
@@ -1446,33 +1482,18 @@ def sales(request):
     )
 
     for sale in eligible_sales:
+        bucket_key = _determine_price_bucket(sale)
+        if not bucket_key:
+            continue
+
         retail_price = sale.variant.product.retail_price or Decimal("0")
-        actual_price = (sale.sold_value or Decimal("0")) / sale.sold_quantity
-
-        if actual_price == 0:
-            bucket_key = "gifted"
-        elif retail_price <= 0:
-            bucket_key = "full_price"
-        else:
-            diff_ratio = (retail_price - actual_price) / retail_price
-            if diff_ratio <= tolerance:
-                bucket_key = "full_price"
-            elif diff_ratio < small_discount_threshold:
-                bucket_key = "small_discount"
-            elif diff_ratio < discount_threshold:
-                bucket_key = "discount"
-            else:
-                bucket_key = "wholesale"
-
-        price_buckets[bucket_key]["items_count"] += sale.sold_quantity
-
-        retail_value = retail_price * sale.sold_quantity
         actual_value = sale.sold_value or Decimal("0")
 
-        price_buckets[bucket_key]["retail_value"] += retail_value
+        price_buckets[bucket_key]["items_count"] += sale.sold_quantity
+        price_buckets[bucket_key]["retail_value"] += retail_price * sale.sold_quantity
         price_buckets[bucket_key]["actual_value"] += actual_value
 
-    price_breakdown = [price_buckets[key] for key, _ in price_categories]
+    price_breakdown = [price_buckets[key] for key, _ in PRICE_CATEGORIES]
     pricing_total_items = sum(bucket["items_count"] for bucket in price_breakdown)
     pricing_total_retail_value = sum(
         bucket["retail_value"] for bucket in price_breakdown
@@ -1503,6 +1524,12 @@ def sales(request):
         for bucket in price_breakdown:
             bucket["actual_percentage"] = Decimal("0")
 
+    date_querystring = urlencode(
+        {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+        }
+    )
 
     context = {
         "start_date": start_date,
@@ -1516,10 +1543,118 @@ def sales(request):
         "pricing_total_actual_value": pricing_total_actual_value,
         "gross_sales_value": gross_sales_value,
         "net_sales_value": net_sales_value,
-
+        "date_querystring": date_querystring,
     }
 
     return render(request, "inventory/sales.html", context)
+
+
+def sales_bucket_detail(request, bucket_key: str):
+    bucket_key = (bucket_key or "").lower()
+    if bucket_key not in PRICE_CATEGORY_LABELS:
+        raise Http404("Unknown pricing bucket")
+
+    start_date, end_date = _get_sales_date_range(request)
+
+    sales_qs = (
+        Sale.objects.filter(date__range=(start_date, end_date))
+        .select_related("variant__product")
+    )
+
+    eligible_sales = (
+        sales_qs.filter(Q(return_quantity__isnull=True) | Q(return_quantity=0))
+        .filter(sold_quantity__gt=0)
+    )
+
+    relevant_sales = []
+    for sale in eligible_sales:
+        bucket = _determine_price_bucket(sale)
+        if bucket == bucket_key:
+            relevant_sales.append(sale)
+
+    sorted_sales = sorted(
+        relevant_sales,
+        key=lambda s: (s.date, s.order_number, s.sale_id),
+        reverse=True,
+    )
+
+    orders_map = OrderedDict()
+    total_items = 0
+    total_retail_value = Decimal("0")
+    total_actual_value = Decimal("0")
+    total_returns_value = Decimal("0")
+
+    for sale in sorted_sales:
+        order_info = orders_map.get(sale.order_number)
+        if not order_info:
+            order_info = {
+                "order_number": sale.order_number,
+                "date": sale.date,
+                "total_value": Decimal("0"),
+                "returns_value": Decimal("0"),
+                "retail_total": Decimal("0"),
+                "items": [],
+            }
+            orders_map[sale.order_number] = order_info
+        else:
+            if sale.date and sale.date > order_info["date"]:
+                order_info["date"] = sale.date
+
+        retail_price = sale.variant.product.retail_price or Decimal("0")
+        sold_quantity = sale.sold_quantity or 0
+        actual_total = sale.sold_value or Decimal("0")
+        return_value = sale.return_value or Decimal("0")
+
+        actual_unit_price = (
+            actual_total / sold_quantity if sold_quantity else Decimal("0")
+        )
+
+        order_info["items"].append(
+            {
+                "sale": sale,
+                "retail_price": retail_price,
+                "actual_unit_price": actual_unit_price,
+                "actual_total": actual_total,
+                "sold_quantity": sold_quantity,
+                "returned": bool(sale.return_quantity),
+            }
+        )
+        order_info["total_value"] += actual_total
+        order_info["returns_value"] += return_value
+        order_info["retail_total"] += retail_price * sold_quantity
+
+        total_items += sold_quantity
+        total_retail_value += retail_price * sold_quantity
+        total_actual_value += actual_total
+        total_returns_value += return_value
+
+    orders = list(orders_map.values())
+    orders.sort(key=lambda o: (o["date"], o["order_number"]), reverse=True)
+
+    date_querystring = urlencode(
+        {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+        }
+    )
+
+    context = {
+        "bucket_key": bucket_key,
+        "bucket_label": PRICE_CATEGORY_LABELS[bucket_key],
+        "start_date": start_date,
+        "end_date": end_date,
+        "orders": orders,
+        "orders_count": len(orders),
+        "bucket_totals": {
+            "items_count": total_items,
+            "retail_value": total_retail_value,
+            "actual_value": total_actual_value,
+            "returns_value": total_returns_value,
+        },
+        "date_querystring": date_querystring,
+    }
+
+    return render(request, "inventory/sales_bucket_detail.html", context)
 
 
 # a small helper to keep (date, change) pairs


### PR DESCRIPTION
## Summary
- extract shared helpers for sales date parsing and bucket classification
- add price bucket detail view grouped by order with totals and item information
- make pricing breakdown rows link to the new detailed sales bucket page

## Testing
- `python manage.py test` *(fails: Missing Django dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca79fb4cc8832c8e1bb609d0ef5547