### PR TITLE
Highlight returned sales and improve referrer selection

### DIFF
--- a/inventory/templates/inventory/sales_bucket_detail.html
+++ b/inventory/templates/inventory/sales_bucket_detail.html
@@ -111,15 +111,25 @@
                     <td>
                       ¥{{ item.actual_unit_price|floatformat:2 }}
                     </td>
-                    <td>¥{{ item.actual_total|floatformat:2 }}</td>
-                    <td>
-                      {% if item.returned %}
-                        <span class="red-text text-darken-1">Returned</span>
-                      {% else %}
-                        &mdash;
-                      {% endif %}
-                    </td>
-                  </tr>
+                  <td>¥{{ item.actual_total|floatformat:2 }}</td>
+                  <td>
+                    {% if item.returned %}
+                      <span class="chip return-chip red lighten-5 red-text text-darken-2">
+                        {% if item.return_quantity and item.return_value %}
+                          Returned · {{ item.return_quantity }} item{{ item.return_quantity|pluralize }} · ¥{{ item.return_value|floatformat:2 }}
+                        {% elif item.return_quantity %}
+                          Returned · {{ item.return_quantity }} item{{ item.return_quantity|pluralize }}
+                        {% elif item.return_value %}
+                          Refunded · ¥{{ item.return_value|floatformat:2 }}
+                        {% else %}
+                          Returned
+                        {% endif %}
+                      </span>
+                    {% else %}
+                      &mdash;
+                    {% endif %}
+                  </td>
+                </tr>
                 {% endfor %}
                 <tr>
                   <td></td>
@@ -148,32 +158,43 @@
                 {% endif %}
                 <div class="modal-content">
                   <h4>Assign referrer</h4>
+                  <input
+                    type="hidden"
+                    name="referrer_id"
+                    value="{% if order.referrer %}{{ order.referrer.id }}{% endif %}"
+                  />
                   {% if referrers %}
-                    <div class="input-field">
-                      <select name="referrer_id" class="referrer-select">
-                        <option value="" {% if not order.referrer %}selected{% endif %}>No referrer</option>
-                        {% for referrer in referrers %}
-                          <option
-                            value="{{ referrer.id }}"
-                            {% if order.referrer and order.referrer.id == referrer.id %}selected{% endif %}
-                          >
-                            {{ referrer.name }}
-                          </option>
-                        {% endfor %}
-                      </select>
-                      <label>Select a referrer</label>
-                    </div>
+                    <p class="grey-text text-darken-1 modal-helper-text" style="margin-bottom: 0.75rem;">
+                      Select a referrer below.
+                    </p>
                   {% else %}
-                    <p class="grey-text text-darken-1" style="margin-bottom: 0;">
+                    <p class="grey-text text-darken-1 modal-helper-text" style="margin-bottom: 0.75rem;">
                       No referrers available yet. Add one from the admin to get started.
                     </p>
                   {% endif %}
+                  <div class="referrer-chip-group">
+                    <div
+                      class="chip referrer-chip {% if not order.referrer %}selected{% endif %}"
+                      data-referrer-id=""
+                      tabindex="0"
+                    >
+                      No referrer
+                    </div>
+                    {% for referrer in referrers %}
+                      <div
+                        class="chip referrer-chip {% if order.referrer and order.referrer.id == referrer.id %}selected{% endif %}"
+                        data-referrer-id="{{ referrer.id }}"
+                        tabindex="0"
+                      >
+                        {{ referrer.name }}
+                      </div>
+                    {% endfor %}
+                  </div>
                 </div>
                 <div class="modal-footer">
                   <button
                     type="submit"
                     class="btn waves-effect waves-light"
-                    {% if not referrers %}disabled{% endif %}
                   >
                     Save
                   </button>
@@ -237,6 +258,14 @@
     text-decoration: underline;
   }
 
+  .return-chip {
+    font-weight: 600;
+  }
+
+  .modal-helper-text {
+    font-size: 0.95rem;
+  }
+
   .order-items-table th,
   .order-items-table td {
     vertical-align: middle;
@@ -280,6 +309,31 @@
     font-weight: 600;
     margin-bottom: 0.25rem;
   }
+
+  .referrer-chip-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .referrer-chip {
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .referrer-chip.selected {
+    background-color: #00897b;
+    color: #ffffff;
+  }
+
+  .referrer-chip.selected:focus {
+    outline: none;
+  }
+
+  .referrer-chip:focus {
+    outline: 2px solid #00897b;
+    outline-offset: 2px;
+  }
 </style>
 {% endblock %}
 
@@ -290,8 +344,44 @@
       var modalElems = document.querySelectorAll('.modal');
       M.Modal.init(modalElems);
 
-      var selectElems = document.querySelectorAll('select.referrer-select');
-      M.FormSelect.init(selectElems);
+      var chipGroups = document.querySelectorAll('.referrer-chip-group');
+      chipGroups.forEach(function(group) {
+        var chips = group.querySelectorAll('.referrer-chip');
+        if (!chips.length) {
+          return;
+        }
+
+        var form = group.closest('form');
+        if (!form) {
+          return;
+        }
+
+        var hiddenInput = form.querySelector('input[name="referrer_id"]');
+        var setActiveChip = function(targetChip) {
+          chips.forEach(function(chip) {
+            chip.classList.remove('selected');
+          });
+
+          targetChip.classList.add('selected');
+
+          if (hiddenInput) {
+            hiddenInput.value = targetChip.dataset.referrerId || '';
+          }
+        };
+
+        chips.forEach(function(chip) {
+          chip.addEventListener('click', function() {
+            setActiveChip(chip);
+          });
+
+          chip.addEventListener('keydown', function(event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              setActiveChip(chip);
+            }
+          });
+        });
+      });
     });
   </script>
 {% endblock %}

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -893,4 +893,70 @@ class SalesBucketDetailViewTests(TestCase):
         self.assertEqual(bucket_totals["retail_value"], Decimal("100.00"))
         self.assertEqual(bucket_totals["actual_value"], Decimal("0.00"))
 
+    def test_returned_items_include_return_details(self):
+        Sale.objects.create(
+            order_number="ORDER-RETURN",
+            date=date(2024, 4, 4),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("100.00"),
+        )
+        returned_sale = Sale.objects.create(
+            order_number="ORDER-RETURN",
+            date=date(2024, 4, 6),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("0.00"),
+            return_quantity=1,
+            return_value=Decimal("100.00"),
+        )
+
+        response = self.client.get(
+            reverse("sales_bucket_detail", args=["full_price"]),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        orders = response.context["orders"]
+        self.assertEqual(len(orders), 1)
+
+        order = orders[0]
+        self.assertEqual(order["order_number"], "ORDER-RETURN")
+        self.assertEqual(order["returns_value"], Decimal("100.00"))
+
+        returned_item = next(
+            item for item in order["items"] if item["sale"].pk == returned_sale.pk
+        )
+        self.assertTrue(returned_item["returned"])
+        self.assertEqual(returned_item["return_quantity"], 1)
+        self.assertEqual(returned_item["return_value"], Decimal("100.00"))
+
+    def test_refunded_sale_without_quantity_highlighted(self):
+        refund_sale = Sale.objects.create(
+            order_number="ORDER-REFUND",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("0.00"),
+            return_quantity=0,
+            return_value=Decimal("100.00"),
+        )
+
+        response = self.client.get(
+            reverse("sales_bucket_detail", args=["full_price"]),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        orders = response.context["orders"]
+        self.assertEqual(len(orders), 1)
+
+        order = orders[0]
+        refund_item = order["items"][0]
+
+        self.assertTrue(refund_item["returned"])
+        self.assertEqual(refund_item["sale"].pk, refund_sale.pk)
+        self.assertEqual(refund_item["return_quantity"], 0)
+        self.assertEqual(refund_item["return_value"], Decimal("100.00"))
+
 

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1693,6 +1693,7 @@ def sales_bucket_detail(request, bucket_key: str):
                 sold_quantity = sale.sold_quantity or 0
                 actual_total = sale.sold_value or Decimal("0")
                 return_value = sale.return_value or Decimal("0")
+                return_quantity = sale.return_quantity or 0
 
                 actual_unit_price = (
                     actual_total / sold_quantity if sold_quantity else Decimal("0")
@@ -1709,7 +1710,9 @@ def sales_bucket_detail(request, bucket_key: str):
                         "actual_unit_price": actual_unit_price,
                         "actual_total": actual_total,
                         "sold_quantity": sold_quantity,
-                        "returned": bool(sale.return_quantity),
+                        "returned": bool(return_quantity) or bool(return_value),
+                        "return_quantity": return_quantity,
+                        "return_value": return_value,
                         "is_bucket_item": sale.pk in bucket_sale_ids,
                     }
                 )


### PR DESCRIPTION
## Summary
- surface return quantity/value data for bucket detail items and flag returned or refunded sales in the status column
- replace the referrer dropdown in the assignment modal with Materialize chips and add styling/JS to manage chip selection
- extend SalesBucketDetailView tests to cover refunded and returned sales metadata

## Testing
- python manage.py test inventory.tests.SalesBucketDetailViewTests

------
https://chatgpt.com/codex/tasks/task_e_68cbcc8d8a50832c916b6e316042b1ed