### PR TITLE
Improve layout for sales views

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -36,6 +36,368 @@ div.metadata {
   padding: 0;
 }
 
+/* Sales pages */
+
+.filter-toolbar {
+  align-items: flex-end;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.5rem;
+}
+
+.filter-toolbar.card-panel {
+  margin: 0 0 1.5rem;
+  padding: 1rem 1.5rem;
+}
+
+.filter-toolbar__form {
+  align-items: flex-end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0;
+}
+
+.filter-toolbar__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 150px;
+}
+
+.filter-toolbar__field label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.filter-toolbar__actions {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.filter-toolbar__aside {
+  align-self: flex-start;
+  display: flex;
+  justify-content: flex-end;
+  min-width: 180px;
+}
+
+.filter-toolbar__link {
+  align-items: center;
+  color: #1565c0;
+  display: inline-flex;
+  font-weight: 600;
+  gap: 0.25rem;
+  text-decoration: none;
+}
+
+.filter-toolbar__link:hover,
+.filter-toolbar__link:focus {
+  text-decoration: underline;
+}
+
+.page-summary {
+  align-items: center;
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.5rem;
+}
+
+.page-summary.card-panel {
+  margin: 0 0 1.5rem;
+}
+
+.page-summary__primary {
+  flex: 1 1 auto;
+}
+
+.page-summary__back-link {
+  color: #1565c0;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.page-summary__back-link:hover,
+.page-summary__back-link:focus {
+  text-decoration: underline;
+}
+
+.page-summary__stats {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.page-summary__stat {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.page-summary__stat:not(:first-child)::before {
+  color: #9e9e9e;
+  content: "·";
+  display: inline-block;
+  margin-right: 0.75rem;
+}
+
+.sales-summary-card {
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+}
+
+.sales-summary-card .card-content {
+  padding: 1.5rem;
+}
+
+.sales-summary__net {
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.sales-summary__metric {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.sales-summary__metric + .sales-summary__metric {
+  margin-top: 0.25rem;
+}
+
+.pricing-breakdown-card {
+  border-radius: 8px;
+  margin: 0 0 2rem;
+  padding: 1.5rem;
+}
+
+.pricing-breakdown-card__title {
+  margin: 0 0 0.5rem;
+}
+
+.pricing-breakdown-card__note {
+  margin: 0;
+}
+
+.pricing-breakdown-table {
+  margin-top: 1rem;
+  width: 100%;
+}
+
+.pricing-breakdown-table tr.clickable-row {
+  cursor: pointer;
+}
+
+.pricing-breakdown-table tr.clickable-row:hover {
+  background-color: rgba(33, 150, 243, 0.08);
+}
+
+.price-breakdown-link {
+  color: inherit;
+  display: inline-block;
+  text-decoration: none;
+  width: 100%;
+}
+
+.price-breakdown-link:hover,
+.price-breakdown-link:focus {
+  text-decoration: underline;
+}
+
+.no-data-message {
+  margin-top: 1.5rem;
+}
+
+.order-block {
+  background-color: #ffffff;
+  border: 1px solid #e1e1e1;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  padding: 1.25rem;
+}
+
+.order-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.order-number {
+  font-weight: 600;
+}
+
+.order-values {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.price-with-discount {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.price-with-discount .actual-price {
+  font-weight: 600;
+}
+
+.discount-percentage {
+  font-size: 0.85rem;
+}
+
+.order-referrer {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.assign-referrer-link {
+  color: #00897b;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.assign-referrer-link:hover,
+.assign-referrer-link:focus {
+  text-decoration: underline;
+}
+
+.return-chip {
+  font-weight: 600;
+}
+
+.modal-helper-text {
+  font-size: 0.95rem;
+}
+
+.order-items-table th,
+.order-items-table td {
+  vertical-align: middle;
+}
+
+.order-item-product {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.order-item-badge {
+  border-radius: 12px;
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  margin-top: 0.3rem;
+  padding: 0.2rem 0.6rem;
+}
+
+.order-item-product img {
+  border-radius: 6px;
+  height: 64px;
+  object-fit: cover;
+  width: 64px;
+}
+
+.order-item-placeholder {
+  align-items: center;
+  background-color: #e0e0e0;
+  border-radius: 6px;
+  color: #616161;
+  display: flex;
+  font-size: 0.8rem;
+  height: 64px;
+  justify-content: center;
+  width: 64px;
+}
+
+.variant-code {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.variant-edit-link {
+  align-items: center;
+  color: #757575;
+  display: inline-flex;
+  margin-left: 0.35rem;
+  text-decoration: none;
+}
+
+.variant-edit-link .material-icons {
+  font-size: 1.05rem;
+}
+
+.variant-edit-link:hover,
+.variant-edit-link:focus {
+  color: #424242;
+}
+
+.referrer-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.referrer-chip {
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.referrer-chip.selected {
+  background-color: #00897b;
+  color: #ffffff;
+}
+
+.referrer-chip.selected:focus {
+  outline: none;
+}
+
+.referrer-chip:focus {
+  outline: 2px solid #00897b;
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .filter-toolbar,
+  .page-summary {
+    align-items: stretch;
+    padding: 1rem;
+  }
+
+  .filter-toolbar__form,
+  .filter-toolbar__aside,
+  .page-summary__stats {
+    width: 100%;
+  }
+
+  .filter-toolbar__field {
+    flex: 1 1 140px;
+  }
+
+  .filter-toolbar__aside {
+    justify-content: flex-start;
+  }
+}
+
 /* ORDER DETAIL PAGE */
 
 .order-table {

--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -3,177 +3,154 @@
 {% block title %}Sales{% endblock %}
 
 {% block content %}
+  <div class="section">
+    <h3>Sales</h3>
 
-  <h3>Sales</h3>
-
-  <div class="row filter-bar grey lighten-3">
-
-        <div class="col s5">
-        <form method="get" novalidate>
-            <label for="start_date" class="active">Showing sales from</label>
-            <input
-              type="date"
-              id="start_date"
-              name="start_date"
-              value="{{ start_date|date:'Y-m-d' }}"
-              class="browser-default"
-            />
-            <label for="end_date" class="active">to</label>
-            <input
-              type="date"
-              id="end_date"
-              name="end_date"
-              value="{{ end_date|date:'Y-m-d' }}"
-              class="browser-default"
-            />
-            <button type="submit" class="btn-small waves-effect waves-light">
-              Update
-            </button>
-        </form>
+    <div class="card-panel filter-toolbar">
+      <form method="get" novalidate class="filter-toolbar__form">
+        <div class="filter-toolbar__field">
+          <label for="start_date" class="active">From</label>
+          <input
+            type="date"
+            id="start_date"
+            name="start_date"
+            value="{{ start_date|date:'Y-m-d' }}"
+            class="browser-default"
+          />
         </div>
-
-        <div class="col s4 m4 right">
+        <div class="filter-toolbar__field">
+          <label for="end_date" class="active">To</label>
+          <input
+            type="date"
+            id="end_date"
+            name="end_date"
+            value="{{ end_date|date:'Y-m-d' }}"
+            class="browser-default"
+          />
+        </div>
+        <div class="filter-toolbar__actions">
+          <button type="submit" class="btn-small waves-effect waves-light">
+            Update
+          </button>
+        </div>
+      </form>
+      <div class="filter-toolbar__aside">
         <a
           href="{% url 'sales_referrers' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+          class="filter-toolbar__link"
         >
-          View sales by referrer →
+          View sales by referrer <span aria-hidden="true">→</span>
         </a>
+      </div>
+    </div>
+
+    {% if has_sales_data %}
+      <div class="card sales-summary-card z-depth-0">
+        <div class="card-content">
+          <h2 id="netSales" class="sales-summary__net blue-text">
+            ¥{{ net_sales_value|floatformat:0 }}
+          </h2>
+          <p class="sales-summary__metric grey-text text-darken-1">
+            ¥{{ gross_sales_value|floatformat:0 }} gross
+          </p>
+          <p class="sales-summary__metric red-text text-darken-4">
+            ¥{{ gross_sales_value|add:-net_sales_value|floatformat:0 }} returns
+          </p>
+          <p class="sales-summary__metric grey-text text-darken-2">
+            {{ items_count }} items in {{ orders_count }} orders
+          </p>
         </div>
       </div>
 
-
-
-      {% if has_sales_data %}
-
-            <div class="card white z-depth-0">
-              <div class="card-content">
-                <h2 id="netSales" class="blue-text">¥{{ net_sales_value|floatformat:0 }}</h2>
-                <p class="grey-text text-darken-1" style="font-size: 1.1rem; font-weight: 600;">¥{{ gross_sales_value|floatformat:0 }} gross</p>
-                <p class="red-text text-darken-4" style="font-size: 1.1rem; font-weight: 600;">¥{{ gross_sales_value|floatformat:0 }} returns</p>
-                <p class="grey-text text-darken-2" style="font-size: 1.1rem; font-weight: 600;">{{ items_count }} items in {{ orders_count }} orders</p>
-              </div>
-            </div>
-
-
-
-        <div class="row">
-          <div class="col s12">
-            <div class="card-panel blue lighten-5" style="margin: 0;">
-              <h6 class="grey-text text-darken-2" style="margin-top: 0;">Pricing breakdown</h6>
-              <p class="grey-text text-darken-1" style="margin-top: 0;">
-                Counts and totals exclude returned sales and lines with zero quantity.
-
-              </p>
-              <table class="striped price-breakdown-table" style="margin-top: 1rem;">
-                <thead>
-                  <tr>
-                    <th>Category</th>
-                    <th>Items sold</th>
-                    <th>Retail value</th>
-                    <th>Actual value</th>
-                    <th>% of sales</th>
-
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for bucket in price_breakdown %}
-                    {% url 'sales_bucket_detail' bucket.key as bucket_url %}
-                    <tr
-                      class="clickable-row"
-                      data-href="{{ bucket_url }}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
-                    >
-                      <td>
-                        <a
-                          href="{{ bucket_url }}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
-                          class="price-breakdown-link"
-                        >
-                          {{ bucket.label }}
-                        </a>
-                      </td>
-                      <td>{{ bucket.items_count }}</td>
-                      <td>¥{{ bucket.retail_value|floatformat:2 }}</td>
-                      <td>¥{{ bucket.actual_value|floatformat:2 }}</td>
-                      <td>{{ bucket.actual_percentage|floatformat:2 }}%</td>
-
-                    </tr>
-                  {% endfor %}
-                </tbody>
-                <tfoot>
-                  <tr>
-                    <th>Total</th>
-                    <th>{{ pricing_total_items }}</th>
-                    <th>¥{{ pricing_total_retail_value|floatformat:2 }}</th>
-                    <th>¥{{ pricing_total_actual_value|floatformat:2 }}</th>
-                    <th>
-                      {% if pricing_total_actual_value %}
-                        100%
-                      {% else %}
-                        &mdash;
-                      {% endif %}
-                    </th>
-
-                  </tr>
-                </tfoot>
-              </table>
-            </div>
-          </div>
-        </div>
-
-        <style>
-          .price-breakdown-table tr.clickable-row {
-            cursor: pointer;
-          }
-
-          .price-breakdown-table tr.clickable-row:hover {
-            background-color: rgba(33, 150, 243, 0.08);
-          }
-
-          .price-breakdown-link {
-            color: inherit;
-            display: inline-block;
-            text-decoration: none;
-            width: 100%;
-          }
-
-          .price-breakdown-link:hover {
-            text-decoration: underline;
-          }
-        </style>
-
-        <script>
-          document.addEventListener("DOMContentLoaded", function () {
-            document
-              .querySelectorAll(".price-breakdown-table tr.clickable-row")
-              .forEach(function (row) {
-                row.setAttribute("tabindex", "0");
-                row.addEventListener("click", function (event) {
-                  if (event.target.tagName && event.target.tagName.toLowerCase() === "a") {
-                    return;
-                  }
-                  const anchor = row.querySelector("a.price-breakdown-link");
-                  if (anchor) {
-                    window.location.href = anchor.getAttribute("href");
-                  }
-                });
-                row.addEventListener("keyup", function (event) {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    const anchor = row.querySelector("a.price-breakdown-link");
-                    if (anchor) {
-                      anchor.click();
-                    }
-                  }
-                });
-              });
-          });
-        </script>
-
-      {% else %}
-        <p class="grey-text text-darken-1" style="margin-top: 1.5rem;">
-          No sales recorded for this date range.
+      <div class="card-panel blue lighten-5 pricing-breakdown-card">
+        <h6 class="pricing-breakdown-card__title grey-text text-darken-2">Pricing breakdown</h6>
+        <p class="pricing-breakdown-card__note grey-text text-darken-1">
+          Counts and totals exclude returned sales and lines with zero quantity.
         </p>
-      {% endif %}
-    </div>
+        <table class="striped pricing-breakdown-table">
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Items sold</th>
+              <th>Retail value</th>
+              <th>Actual value</th>
+              <th>% of sales</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for bucket in price_breakdown %}
+              {% url 'sales_bucket_detail' bucket.key as bucket_url %}
+              <tr
+                class="clickable-row"
+                data-href="{{ bucket_url }}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+              >
+                <td>
+                  <a
+                    href="{{ bucket_url }}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+                    class="price-breakdown-link"
+                  >
+                    {{ bucket.label }}
+                  </a>
+                </td>
+                <td>{{ bucket.items_count }}</td>
+                <td>¥{{ bucket.retail_value|floatformat:2 }}</td>
+                <td>¥{{ bucket.actual_value|floatformat:2 }}</td>
+                <td>{{ bucket.actual_percentage|floatformat:2 }}%</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+          <tfoot>
+            <tr>
+              <th>Total</th>
+              <th>{{ pricing_total_items }}</th>
+              <th>¥{{ pricing_total_retail_value|floatformat:2 }}</th>
+              <th>¥{{ pricing_total_actual_value|floatformat:2 }}</th>
+              <th>
+                {% if pricing_total_actual_value %}
+                  100%
+                {% else %}
+                  &mdash;
+                {% endif %}
+              </th>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    {% else %}
+      <p class="grey-text text-darken-1 no-data-message">
+        No sales recorded for this date range.
+      </p>
+    {% endif %}
   </div>
-</div>
+{% endblock %}
+
+{% block extrajs %}
+  {{ block.super }}
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      document
+        .querySelectorAll(".pricing-breakdown-table tr.clickable-row")
+        .forEach(function (row) {
+          row.setAttribute("tabindex", "0");
+          row.addEventListener("click", function (event) {
+            if (event.target.tagName && event.target.tagName.toLowerCase() === "a") {
+              return;
+            }
+            const anchor = row.querySelector("a.price-breakdown-link");
+            if (anchor) {
+              window.location.href = anchor.getAttribute("href");
+            }
+          });
+          row.addEventListener("keyup", function (event) {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              const anchor = row.querySelector("a.price-breakdown-link");
+              if (anchor) {
+                anchor.click();
+              }
+            }
+          });
+        });
+    });
+  </script>
 {% endblock %}

--- a/inventory/templates/inventory/sales_bucket_detail.html
+++ b/inventory/templates/inventory/sales_bucket_detail.html
@@ -3,135 +3,132 @@
 {% block title %}{{ bucket_label }} Sales{% endblock %}
 
 {% block content %}
-<div class="section">
+  <div class="section">
+    <h3>
+      Sales
+      <span class="grey-text small">
+        | {{ bucket_label }} sales from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}
+      </span>
+    </h3>
 
-  <h3>Sales <span class="grey-text small">| {{ bucket_label }} sales from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}</span></h3>
-
-
-
-  <div style="display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; margin-bottom: 1.5rem;">
-
-    <div class="grey lighten-4" style="padding: 0.75rem 1rem; border-radius: 6px;">
-      <a
-        href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
-        class=""
-      >
-        ← Back to sales overview
-      </a> |
-      <strong>{{ orders_count }}</strong> order{{ orders_count|pluralize }} ·
-      <strong>{{ bucket_totals.items_count }}</strong> item{{ bucket_totals.items_count|pluralize }} ·
-      Retail: ¥{{ bucket_totals.retail_value|floatformat:2 }} ·
-      Actual: ¥{{ bucket_totals.actual_value|floatformat:2 }}
-      {% if bucket_totals.returns_value %}
-        · <span class="red-text text-darken-1">-¥{{ bucket_totals.returns_value|floatformat:2 }}</span>
-      {% endif %}
+    <div class="card-panel grey lighten-4 page-summary">
+      <div class="page-summary__primary">
+        <a
+          href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+          class="page-summary__back-link"
+        >
+          ← Back to sales overview
+        </a>
+      </div>
+      <div class="page-summary__stats">
+        <span class="page-summary__stat">
+          <strong>{{ orders_count }}</strong> order{{ orders_count|pluralize }}
+        </span>
+        <span class="page-summary__stat">
+          <strong>{{ bucket_totals.items_count }}</strong> item{{ bucket_totals.items_count|pluralize }}
+        </span>
+        <span class="page-summary__stat">Retail: ¥{{ bucket_totals.retail_value|floatformat:2 }}</span>
+        <span class="page-summary__stat">Actual: ¥{{ bucket_totals.actual_value|floatformat:2 }}</span>
+        {% if bucket_totals.returns_value %}
+          <span class="page-summary__stat red-text text-darken-1">
+            &minus;¥{{ bucket_totals.returns_value|floatformat:2 }}
+          </span>
+        {% endif %}
+      </div>
     </div>
-  </div>
 
-
-
-      {% if orders %}
-        {% for order in orders %}
-          <div class="order-block">
-            <div class="order-header">
-              <div class="left">
-                <span class="order-number">#{{ order.order_number }}</span>
-                <span class="order-date">· {{ order.date|date:"F j, Y" }}</span>
-              </div>
-
-              <div class="right">
-                <div class="order-referrer">
-                  {% if order.referrer %}
-
-                    <span class="chip teal lighten-5 teal-text text-darken-3">
-                      Referrer: {{ order.referrer.name }}
-                      <a
-                        href="#referrer-modal-{{ forloop.counter }}"
-                        class="modal-trigger assign-referrer-link"
-                      >
-                        <i class="material-icons tiny">edit</i>
-                      </a>
-                    </span>
-
-                  {% else %}
-                    <a
-                      href="#referrer-modal-{{ forloop.counter }}"
-                      class="chip white modal-trigger assign-referrer-link"
-                    >
-                      Assign referrer +
-                    </a>
-                  {% endif %}
-                </div>
-              </div>
-
+    {% if orders %}
+      {% for order in orders %}
+        <div class="order-block">
+          <div class="order-header">
+            <div class="left">
+              <span class="order-number">#{{ order.order_number }}</span>
+              <span class="order-date">· {{ order.date|date:"F j, Y" }}</span>
             </div>
 
+            <div class="right">
+              <div class="order-referrer">
+                {% if order.referrer %}
+                  <span class="chip teal lighten-5 teal-text text-darken-3">
+                    Referrer: {{ order.referrer.name }}
+                    <a
+                      href="#referrer-modal-{{ forloop.counter }}"
+                      class="modal-trigger assign-referrer-link"
+                    >
+                      <i class="material-icons tiny">edit</i>
+                    </a>
+                  </span>
+                {% else %}
+                  <a
+                    href="#referrer-modal-{{ forloop.counter }}"
+                    class="chip white modal-trigger assign-referrer-link"
+                  >
+                    Assign referrer +
+                  </a>
+                {% endif %}
+              </div>
+            </div>
+          </div>
 
-
-            <table class="highlight order-items-table">
-              <thead>
-                <tr>
-                  <th>Item</th>
-                  <th></th>
-                  <th>Original price</th>
-                  <th>Actual price</th>
-                  <th>Total paid</th>
-                  <th>Refunded</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for item in order.items %}
-                  <tr class="{% if not item.is_bucket_item %}grey-text text-lighten-1{% endif %}">
-                    <td>
-                      <div class="order-item-product">
-                        {% if item.sale.variant.product.product_photo %}
-                          <img
-                            src="{{ item.sale.variant.product.product_photo.url }}"
-                            alt="{{ item.sale.variant.product.product_name }}"
-                          />
-                        {% else %}
-                          <div class="order-item-placeholder">No photo</div>
-                        {% endif %}
-                        <div>
-                          <div class="variant-code">
-                            {{ item.sale.variant.variant_code }}
-                            <a
-                              href="{% url 'admin:inventory_sale_change' item.sale.pk %}"
-                              class="variant-edit-link"
-                              target="_blank"
-                              rel="noopener"
-                              title="Edit sale in admin"
-                              aria-label="Edit sale {{ item.sale.sale_id }} in admin"
-                            >
-                              <i class="material-icons tiny">edit</i>
-                            </a>
-                          </div>
-
+          <table class="highlight order-items-table">
+            <thead>
+              <tr>
+                <th>Item</th>
+                <th></th>
+                <th>Original price</th>
+                <th>Actual price</th>
+                <th>Total paid</th>
+                <th>Refunded</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in order.items %}
+                <tr class="{% if not item.is_bucket_item %}grey-text text-lighten-1{% endif %}">
+                  <td>
+                    <div class="order-item-product">
+                      {% if item.sale.variant.product.product_photo %}
+                        <img
+                          src="{{ item.sale.variant.product.product_photo.url }}"
+                          alt="{{ item.sale.variant.product.product_name }}"
+                        />
+                      {% else %}
+                        <div class="order-item-placeholder">No photo</div>
+                      {% endif %}
+                      <div>
+                        <div class="variant-code">
+                          {{ item.sale.variant.variant_code }}
+                          <a
+                            href="{% url 'admin:inventory_sale_change' item.sale.pk %}"
+                            class="variant-edit-link"
+                            target="_blank"
+                            rel="noopener"
+                            title="Edit sale in admin"
+                            aria-label="Edit sale {{ item.sale.sale_id }} in admin"
+                          >
+                            <i class="material-icons tiny">edit</i>
+                          </a>
                         </div>
-
                       </div>
-                    </td>
-                    <td>x{{ item.sold_quantity }}</td>
-                    <td>
-                      ¥{{ item.retail_price|floatformat:2 }}
-                    </td>
-                    <td>
-                      <div class="price-with-discount">
-                        <span class="actual-price">¥{{ item.actual_unit_price|floatformat:2 }}</span>
-                        {% if item.discount_percentage is not None %}
-                          <span class="discount-percentage grey-text text-darken-1">
-                            -{{ item.discount_percentage|floatformat:-1 }}%
-                          </span>
-                        {% endif %}
-                      </div>
-                    </td>
-                    <td>¥{{ item.actual_total|floatformat:2 }}</td>
+                    </div>
+                  </td>
+                  <td>x{{ item.sold_quantity }}</td>
+                  <td>¥{{ item.retail_price|floatformat:2 }}</td>
+                  <td>
+                    <div class="price-with-discount">
+                      <span class="actual-price">¥{{ item.actual_unit_price|floatformat:2 }}</span>
+                      {% if item.discount_percentage is not None %}
+                        <span class="discount-percentage grey-text text-darken-1">
+                          -{{ item.discount_percentage|floatformat:-1 }}%
+                        </span>
+                      {% endif %}
+                    </div>
+                  </td>
+                  <td>¥{{ item.actual_total|floatformat:2 }}</td>
                   <td>
                     {% if item.return_value %}
                       <span class="red-text text-darken-2">¥{{ item.return_value|floatformat:2 }} (x{{ item.return_quantity }})</span>
                     {% endif %}
-
                   </td>
                   <td>
                     {% if item.returned %}
@@ -141,242 +138,88 @@
                     {% endif %}
                   </td>
                 </tr>
-                {% endfor %}
-                <tr>
-                  <td></td>
-                  <td></td>
-                  <td></td>
-                  <td><strong>TOTAL</strong></td>
-                  <td>
-                    <div class="order-values">
-                      <span class="order-total">¥{{ order.total_value|floatformat:2 }}</span>
-                    </div>
-                  </td>
-                  <td>{% if order.returns_value %}
+              {% endfor %}
+              <tr>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td><strong>TOTAL</strong></td>
+                <td>
+                  <div class="order-values">
+                    <span class="order-total">¥{{ order.total_value|floatformat:2 }}</span>
+                  </div>
+                </td>
+                <td>
+                  {% if order.returns_value %}
                     <span class="order-returns red-text text-darken-1">-¥{{ order.returns_value|floatformat:2 }}</span>
-                  {% endif %}</td>
-                  <td></td>
-                </tr>
-              </tbody>
-            </table>
-            <div id="referrer-modal-{{ forloop.counter }}" class="modal">
-              <form method="post" action="{% url 'assign_order_referrer' bucket_key=bucket_key %}">
-                {% csrf_token %}
-                <input type="hidden" name="order_number" value="{{ order.order_number }}" />
-                {% if date_querystring %}
-                  <input type="hidden" name="date_querystring" value="{{ date_querystring }}" />
-                {% endif %}
-                <div class="modal-content">
-                  <h4>Assign referrer</h4>
-                  <input
-                    type="hidden"
-                    name="referrer_id"
-                    value="{% if order.referrer %}{{ order.referrer.id }}{% endif %}"
-                  />
-                  {% if referrers %}
-                    <p class="grey-text text-darken-1 modal-helper-text" style="margin-bottom: 0.75rem;">
-                      Select a referrer below.
-                    </p>
-                  {% else %}
-                    <p class="grey-text text-darken-1 modal-helper-text" style="margin-bottom: 0.75rem;">
-                      No referrers available yet. Add one from the admin to get started.
-                    </p>
                   {% endif %}
-                  <div class="referrer-chip-group">
+                </td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div id="referrer-modal-{{ forloop.counter }}" class="modal">
+            <form method="post" action="{% url 'assign_order_referrer' bucket_key=bucket_key %}">
+              {% csrf_token %}
+              <input type="hidden" name="order_number" value="{{ order.order_number }}" />
+              {% if date_querystring %}
+                <input type="hidden" name="date_querystring" value="{{ date_querystring }}" />
+              {% endif %}
+              <div class="modal-content">
+                <h4>Assign referrer</h4>
+                <input
+                  type="hidden"
+                  name="referrer_id"
+                  value="{% if order.referrer %}{{ order.referrer.id }}{% endif %}"
+                />
+                {% if referrers %}
+                  <p class="grey-text text-darken-1 modal-helper-text">
+                    Select a referrer below.
+                  </p>
+                {% else %}
+                  <p class="grey-text text-darken-1 modal-helper-text">
+                    No referrers available yet. Add one from the admin to get started.
+                  </p>
+                {% endif %}
+                <div class="referrer-chip-group">
+                  <div
+                    class="chip referrer-chip {% if not order.referrer %}selected{% endif %}"
+                    data-referrer-id=""
+                    tabindex="0"
+                  >
+                    No referrer
+                  </div>
+                  {% for referrer in referrers %}
                     <div
-                      class="chip referrer-chip {% if not order.referrer %}selected{% endif %}"
-                      data-referrer-id=""
+                      class="chip referrer-chip {% if order.referrer and order.referrer.id == referrer.id %}selected{% endif %}"
+                      data-referrer-id="{{ referrer.id }}"
                       tabindex="0"
                     >
-                      No referrer
+                      {{ referrer.name }}
                     </div>
-                    {% for referrer in referrers %}
-                      <div
-                        class="chip referrer-chip {% if order.referrer and order.referrer.id == referrer.id %}selected{% endif %}"
-                        data-referrer-id="{{ referrer.id }}"
-                        tabindex="0"
-                      >
-                        {{ referrer.name }}
-                      </div>
-                    {% endfor %}
-                  </div>
+                  {% endfor %}
                 </div>
-                <div class="modal-footer">
-                  <button
-                    type="submit"
-                    class="btn waves-effect waves-light"
-                  >
-                    Save
-                  </button>
-                  <a href="#!" class="modal-close btn-flat">Cancel</a>
-                </div>
-              </form>
-            </div>
+              </div>
+              <div class="modal-footer">
+                <button
+                  type="submit"
+                  class="btn waves-effect waves-light"
+                >
+                  Save
+                </button>
+                <a href="#!" class="modal-close btn-flat">Cancel</a>
+              </div>
+            </form>
           </div>
-        {% endfor %}
-      {% else %}
-        <p class="grey-text text-darken-1" style="margin-top: 2rem;">
-          No sales matched this pricing group for the selected date range.
-        </p>
-      {% endif %}
-    </div>
-
-
-<style>
-  .order-block {
-    background-color: #ffffff;
-    border-radius: 8px;
-    margin-bottom: 1.5rem;
-    padding: 1.25rem;
-    border: 1px solid #e1e1e1;
-  }
-
-  .order-header {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-  }
-
-  .order-number {
-    font-weight: 600;
-  }
-
-  .order-values {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    align-items: center;
-  }
-
-  .price-with-discount {
-    align-items: baseline;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-  }
-
-  .price-with-discount .actual-price {
-    font-weight: 600;
-  }
-
-  .discount-percentage {
-    font-size: 0.85rem;
-  }
-
-  .order-referrer {
-    align-items: center;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-  }
-
-  .assign-referrer-link {
-    color: #00897b;
-    font-weight: 600;
-    text-decoration: none;
-  }
-
-  .assign-referrer-link:hover {
-    text-decoration: underline;
-  }
-
-  .return-chip {
-    font-weight: 600;
-  }
-
-  .modal-helper-text {
-    font-size: 0.95rem;
-  }
-
-  .order-items-table th,
-  .order-items-table td {
-    vertical-align: middle;
-  }
-
-  .order-item-product {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .order-item-badge {
-    border-radius: 12px;
-    display: inline-block;
-    font-size: 0.8rem;
-    font-weight: 500;
-    margin-top: 0.3rem;
-    padding: 0.2rem 0.6rem;
-  }
-
-  .order-item-product img {
-    width: 32px;
-    height: 32px;
-    object-fit: cover;
-    border-radius: 6px;
-  }
-
-  .order-item-placeholder {
-    align-items: center;
-    background-color: #e0e0e0;
-    border-radius: 6px;
-    color: #616161;
-    display: flex;
-    font-size: 0.8rem;
-    height: 64px;
-    justify-content: center;
-    width: 64px;
-  }
-
-  .variant-code {
-    font-weight: 600;
-    margin-bottom: 0.25rem;
-  }
-
-  .variant-edit-link {
-    align-items: center;
-    color: #757575;
-    display: inline-flex;
-    margin-left: 0.35rem;
-    text-decoration: none;
-  }
-
-  .variant-edit-link .material-icons {
-    font-size: 1.05rem;
-  }
-
-  .variant-edit-link:hover,
-  .variant-edit-link:focus {
-    color: #424242;
-  }
-
-  .referrer-chip-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .referrer-chip {
-    cursor: pointer;
-    transition: background-color 0.2s ease, color 0.2s ease;
-  }
-
-  .referrer-chip.selected {
-    background-color: #00897b;
-    color: #ffffff;
-  }
-
-  .referrer-chip.selected:focus {
-    outline: none;
-  }
-
-  .referrer-chip:focus {
-    outline: 2px solid #00897b;
-    outline-offset: 2px;
-  }
-</style>
+        </div>
+      {% endfor %}
+    {% else %}
+      <p class="grey-text text-darken-1 no-data-message">
+        No sales matched this pricing group for the selected date range.
+      </p>
+    {% endif %}
+  </div>
 {% endblock %}
 
 {% block extrajs %}

--- a/inventory/templates/inventory/sales_referrers.html
+++ b/inventory/templates/inventory/sales_referrers.html
@@ -3,315 +3,214 @@
 {% block title %}Sales by Referrer{% endblock %}
 
 {% block content %}
-<div class="section">
+  <div class="section">
+    <h3>
+      Sales
+      <span class="grey-text small">
+        | Referrer sales from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}
+      </span>
+    </h3>
 
-  <h3>Sales <span class="grey-text small">| Referrer sales from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}</span></h3>
-
-  <div style="display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-start; margin-bottom: 1.5rem;">
-    <div class="grey lighten-4" style="padding: 0.75rem 1rem; border-radius: 6px;">
-      <a
-        href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
-        class=""
-      >
-        ← Back to sales overview
-      </a>
-      |
-      <strong>{{ orders_count }}</strong> order{{ orders_count|pluralize }} ·
-      <strong>{{ summary.items_count }}</strong> item{{ summary.items_count|pluralize }} ·
-      Retail: ¥{{ summary.retail_value|floatformat:2 }} ·
-      Actual: ¥{{ summary.actual_value|floatformat:2 }}
-      {% if summary.returns_value %}
-        · <span class="red-text text-darken-1">-¥{{ summary.returns_value|floatformat:2 }}</span>
-      {% endif %}
-      · Referrers: <strong>{{ summary.referrer_count }}</strong>
-      {% if selected_referrer %}
-        · Showing referrer:
-        <span class="chip teal lighten-5 teal-text text-darken-3">{{ selected_referrer.name }}</span>
-      {% endif %}
+    <div class="card-panel grey lighten-4 page-summary">
+      <div class="page-summary__primary">
+        <a
+          href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+          class="page-summary__back-link"
+        >
+          ← Back to sales overview
+        </a>
+      </div>
+      <div class="page-summary__stats">
+        <span class="page-summary__stat">
+          <strong>{{ orders_count }}</strong> order{{ orders_count|pluralize }}
+        </span>
+        <span class="page-summary__stat">
+          <strong>{{ summary.items_count }}</strong> item{{ summary.items_count|pluralize }}
+        </span>
+        <span class="page-summary__stat">Retail: ¥{{ summary.retail_value|floatformat:2 }}</span>
+        <span class="page-summary__stat">Actual: ¥{{ summary.actual_value|floatformat:2 }}</span>
+        {% if summary.returns_value %}
+          <span class="page-summary__stat red-text text-darken-1">
+            &minus;¥{{ summary.returns_value|floatformat:2 }}
+          </span>
+        {% endif %}
+        <span class="page-summary__stat">Referrers: <strong>{{ summary.referrer_count }}</strong></span>
+        {% if selected_referrer %}
+          <span class="page-summary__stat">
+            Showing referrer:
+            <span class="chip teal lighten-5 teal-text text-darken-3">{{ selected_referrer.name }}</span>
+          </span>
+        {% endif %}
+      </div>
     </div>
 
-    <div class="grey lighten-4" style="padding: 0.75rem 1rem; border-radius: 6px;">
-      <form method="get" novalidate>
-        <label for="start_date" class="active">Showing sales from</label>
-        <input
-          type="date"
-          id="start_date"
-          name="start_date"
-          value="{{ start_date|date:'Y-m-d' }}"
-          class="browser-default"
-        />
-
-        <label for="end_date" class="active">to</label>
-        <input
-          type="date"
-          id="end_date"
-          name="end_date"
-          value="{{ end_date|date:'Y-m-d' }}"
-          class="browser-default"
-        />
-
-        <label for="referrer" class="active">Referrer</label>
-        <select id="referrer" name="referrer" class="browser-default">
-          <option value="">All referrers</option>
-          {% for referrer in referrers %}
-            <option value="{{ referrer.id }}" {% if selected_referrer_id == referrer.id|stringformat:'s' %}selected{% endif %}>
-              {{ referrer.name }}
-            </option>
-          {% endfor %}
-        </select>
-
-        <button type="submit" class="btn-small waves-effect waves-light" style="margin-top: 0.75rem;">
-          Update
-        </button>
+    <div class="card-panel filter-toolbar">
+      <form method="get" novalidate class="filter-toolbar__form">
+        <div class="filter-toolbar__field">
+          <label for="start_date" class="active">From</label>
+          <input
+            type="date"
+            id="start_date"
+            name="start_date"
+            value="{{ start_date|date:'Y-m-d' }}"
+            class="browser-default"
+          />
+        </div>
+        <div class="filter-toolbar__field">
+          <label for="end_date" class="active">To</label>
+          <input
+            type="date"
+            id="end_date"
+            name="end_date"
+            value="{{ end_date|date:'Y-m-d' }}"
+            class="browser-default"
+          />
+        </div>
+        <div class="filter-toolbar__field">
+          <label for="referrer" class="active">Referrer</label>
+          <select id="referrer" name="referrer" class="browser-default">
+            <option value="">All referrers</option>
+            {% for referrer in referrers %}
+              <option value="{{ referrer.id }}" {% if selected_referrer_id == referrer.id|stringformat:'s' %}selected{% endif %}>
+                {{ referrer.name }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="filter-toolbar__actions">
+          <button type="submit" class="btn-small waves-effect waves-light">
+            Update
+          </button>
+        </div>
       </form>
     </div>
-  </div>
 
-  {% if has_sales_data %}
-    {% for order in orders %}
-      <div class="order-block">
-        <div class="order-header">
-          <div class="left">
-            <span class="order-number">#{{ order.order_number }}</span>
-            <span class="order-date">· {{ order.date|date:"F j, Y" }}</span>
-          </div>
+    {% if has_sales_data %}
+      {% for order in orders %}
+        <div class="order-block">
+          <div class="order-header">
+            <div class="left">
+              <span class="order-number">#{{ order.order_number }}</span>
+              <span class="order-date">· {{ order.date|date:"F j, Y" }}</span>
+            </div>
 
-          <div class="right">
-            <div class="order-referrer">
-              {% if order.referrers %}
-                <span class="grey-text text-darken-2">
-                  {% if order.has_multiple_referrers %}
-                    Referrers:
-                  {% else %}
-                    Referrer:
-                  {% endif %}
-                </span>
-                {% for referrer in order.referrers %}
-                  <span class="chip teal lighten-5 teal-text text-darken-3">{{ referrer.name }}</span>
-                {% endfor %}
-              {% else %}
-                <span class="chip white grey-text text-darken-1">No referrer</span>
-              {% endif %}
+            <div class="right">
+              <div class="order-referrer">
+                {% if order.referrers %}
+                  <span class="grey-text text-darken-2">
+                    {% if order.has_multiple_referrers %}
+                      Referrers:
+                    {% else %}
+                      Referrer:
+                    {% endif %}
+                  </span>
+                  {% for referrer in order.referrers %}
+                    <span class="chip teal lighten-5 teal-text text-darken-3">{{ referrer.name }}</span>
+                  {% endfor %}
+                {% else %}
+                  <span class="chip white grey-text text-darken-1">No referrer</span>
+                {% endif %}
+              </div>
             </div>
           </div>
-        </div>
 
-        <table class="highlight order-items-table">
-          <thead>
-            <tr>
-              <th>Item</th>
-              <th></th>
-              <th>Original price</th>
-              <th>Actual price</th>
-              <th>Total paid</th>
-              <th>Refunded</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for item in order.items %}
-              <tr class="{% if not item.is_referrer_item %}grey-text text-lighten-1{% endif %}">
-                <td>
-                  <div class="order-item-product">
-                    {% if item.sale.variant.product.product_photo %}
-                      <img
-                        src="{{ item.sale.variant.product.product_photo.url }}"
-                        alt="{{ item.sale.variant.product.product_name }}"
-                      />
-                    {% else %}
-                      <div class="order-item-placeholder">No photo</div>
-                    {% endif %}
-                    <div>
-                      <div class="variant-code">
-                        {{ item.sale.variant.variant_code }}
-                        <a
-                          href="{% url 'admin:inventory_sale_change' item.sale.pk %}"
-                          class="variant-edit-link"
-                          target="_blank"
-                          rel="noopener"
-                          title="Edit sale in admin"
-                          aria-label="Edit sale {{ item.sale.sale_id }} in admin"
-                        >
-                          <i class="material-icons tiny">edit</i>
-                        </a>
-                      </div>
-                      <div class="order-item-badge teal lighten-5 teal-text text-darken-3">
-                        {{ item.sale.referrer.name }}
+          <table class="highlight order-items-table">
+            <thead>
+              <tr>
+                <th>Item</th>
+                <th></th>
+                <th>Original price</th>
+                <th>Actual price</th>
+                <th>Total paid</th>
+                <th>Refunded</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in order.items %}
+                <tr class="{% if not item.is_referrer_item %}grey-text text-lighten-1{% endif %}">
+                  <td>
+                    <div class="order-item-product">
+                      {% if item.sale.variant.product.product_photo %}
+                        <img
+                          src="{{ item.sale.variant.product.product_photo.url }}"
+                          alt="{{ item.sale.variant.product.product_name }}"
+                        />
+                      {% else %}
+                        <div class="order-item-placeholder">No photo</div>
+                      {% endif %}
+                      <div>
+                        <div class="variant-code">
+                          {{ item.sale.variant.variant_code }}
+                          <a
+                            href="{% url 'admin:inventory_sale_change' item.sale.pk %}"
+                            class="variant-edit-link"
+                            target="_blank"
+                            rel="noopener"
+                            title="Edit sale in admin"
+                            aria-label="Edit sale {{ item.sale.sale_id }} in admin"
+                          >
+                            <i class="material-icons tiny">edit</i>
+                          </a>
+                        </div>
+                        <div class="order-item-badge teal lighten-5 teal-text text-darken-3">
+                          {{ item.sale.referrer.name }}
+                        </div>
                       </div>
                     </div>
-
-                  </div>
-                </td>
-                <td>x{{ item.sold_quantity }}</td>
-                <td>
-                  ¥{{ item.retail_price|floatformat:2 }}
-                </td>
-                <td>
-                  <div class="price-with-discount">
-                    <span class="actual-price">¥{{ item.actual_unit_price|floatformat:2 }}</span>
-                    {% if item.discount_percentage is not None %}
-                      <span class="discount-percentage grey-text text-darken-1">
-                        -{{ item.discount_percentage|floatformat:-1 }}%
-                      </span>
+                  </td>
+                  <td>x{{ item.sold_quantity }}</td>
+                  <td>¥{{ item.retail_price|floatformat:2 }}</td>
+                  <td>
+                    <div class="price-with-discount">
+                      <span class="actual-price">¥{{ item.actual_unit_price|floatformat:2 }}</span>
+                      {% if item.discount_percentage is not None %}
+                        <span class="discount-percentage grey-text text-darken-1">
+                          -{{ item.discount_percentage|floatformat:-1 }}%
+                        </span>
+                      {% endif %}
+                    </div>
+                  </td>
+                  <td>¥{{ item.actual_total|floatformat:2 }}</td>
+                  <td>
+                    {% if item.return_value %}
+                      <span class="red-text text-darken-2">¥{{ item.return_value|floatformat:2 }} (x{{ item.return_quantity }})</span>
                     {% endif %}
+                  </td>
+                  <td>
+                    {% if item.returned %}
+                      <span class="chip return-chip red lighten-5 red-text text-darken-2">Returned</span>
+                    {% else %}
+                      &mdash;
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+              <tr>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td><strong>TOTAL</strong></td>
+                <td>
+                  <div class="order-values">
+                    <span class="order-total">¥{{ order.total_value|floatformat:2 }}</span>
                   </div>
                 </td>
-                <td>¥{{ item.actual_total|floatformat:2 }}</td>
-              <td>
-                {% if item.return_value %}
-                  <span class="red-text text-darken-2">¥{{ item.return_value|floatformat:2 }} (x{{ item.return_quantity }})</span>
-                {% endif %}
-
-              </td>
-              <td>
-                {% if item.returned %}
-                  <span class="chip return-chip red lighten-5 red-text text-darken-2">Returned</span>
-                {% else %}
-                  &mdash;
-                {% endif %}
-              </td>
-            </tr>
-            {% endfor %}
-            <tr>
-              <td></td>
-              <td></td>
-              <td></td>
-              <td><strong>TOTAL</strong></td>
-              <td>
-                <div class="order-values">
-                  <span class="order-total">¥{{ order.total_value|floatformat:2 }}</span>
-                </div>
-              </td>
-              <td>{% if order.returns_value %}
-                <span class="order-returns red-text text-darken-1">-¥{{ order.returns_value|floatformat:2 }}</span>
-              {% endif %}</td>
-              <td></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    {% endfor %}
-  {% else %}
-    <p class="grey-text text-darken-1" style="margin-top: 2rem;">
-      No referrer sales found for this date range.
-    </p>
-  {% endif %}
-</div>
-
-<style>
-  .order-block {
-    background-color: #ffffff;
-    border-radius: 8px;
-    margin-bottom: 1.5rem;
-    padding: 1.25rem;
-    border: 1px solid #e1e1e1;
-  }
-
-  .order-header {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-  }
-
-  .order-number {
-    font-weight: 600;
-  }
-
-  .order-values {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    align-items: center;
-  }
-
-  .price-with-discount {
-    align-items: baseline;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-  }
-
-  .price-with-discount .actual-price {
-    font-weight: 600;
-  }
-
-  .discount-percentage {
-    font-size: 0.85rem;
-  }
-
-  .order-referrer {
-    align-items: center;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-  }
-
-  .return-chip {
-    font-weight: 600;
-  }
-
-  .order-items-table th,
-  .order-items-table td {
-    vertical-align: middle;
-  }
-
-  .order-item-product {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .order-item-badge {
-    border-radius: 12px;
-    display: inline-block;
-    font-size: 0.8rem;
-    font-weight: 500;
-    margin-top: 0.3rem;
-    padding: 0.2rem 0.6rem;
-  }
-
-  .order-item-product img {
-    width: 32px;
-    height: 32px;
-    object-fit: cover;
-    border-radius: 6px;
-  }
-
-  .order-item-placeholder {
-    align-items: center;
-    background-color: #e0e0e0;
-    border-radius: 6px;
-    color: #616161;
-    display: flex;
-    font-size: 0.8rem;
-    height: 64px;
-    justify-content: center;
-    width: 64px;
-  }
-
-  .variant-code {
-    font-weight: 600;
-    margin-bottom: 0.25rem;
-  }
-
-  .variant-edit-link {
-    align-items: center;
-    color: #757575;
-    display: inline-flex;
-    margin-left: 0.35rem;
-    text-decoration: none;
-  }
-
-  .variant-edit-link .material-icons {
-    font-size: 1.05rem;
-  }
-
-  .variant-edit-link:hover,
-  .variant-edit-link:focus {
-    color: #424242;
-  }
-</style>
+                <td>
+                  {% if order.returns_value %}
+                    <span class="order-returns red-text text-darken-1">-¥{{ order.returns_value|floatformat:2 }}</span>
+                  {% endif %}
+                </td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      {% endfor %}
+    {% else %}
+      <p class="grey-text text-darken-1 no-data-message">
+        No referrer sales found for this date range.
+      </p>
+    {% endif %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- reorganize the sales filters and tables to use a consistent toolbar and summary card layout
- clean up the sales bucket and referrer templates with shared summary styling and remove inline styles
- consolidate repeated CSS for sales pages into the shared stylesheet and keep existing scripts in the extrajs block

## Testing
- python manage.py test inventory *(fails: Django not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3a3461dc832c84b62004954c9854