### PR TITLE
Add order number search and simplify sale admin filters

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -150,16 +150,8 @@ class SaleAdmin(admin.ModelAdmin):
         "return_value",
         "referrer",
     )
-    list_filter = (
-        "sale_id",
-        "date",
-        "variant",
-        "sold_quantity",
-        "return_quantity",
-        "sold_value",
-        "return_value",
-        "referrer",
-    )  # Add filters for easy management
+    list_filter = ("variant", "referrer")
+    search_fields = ("order_number",)
 
 
 @admin.register(InventorySnapshot)


### PR DESCRIPTION
## Summary
- enable searching Sales by order number in the admin
- reduce Sale admin sidebar filters to variant and referrer for a simpler experience

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d2d59b7ba8832cb30cdb603d8905c8