### PR TITLE
Add product canvas view with Konva layout tooling

### DIFF
--- a/inventory/static/product-canvas.js
+++ b/inventory/static/product-canvas.js
@@ -1,0 +1,298 @@
+(function () {
+  function getContainer() {
+    return document.getElementById('product-canvas-container');
+  }
+
+  function parseProducts(container) {
+    if (!container) {
+      return [];
+    }
+    var payload = container.getAttribute('data-products');
+    if (!payload) {
+      return [];
+    }
+    try {
+      return JSON.parse(payload);
+    } catch (err) {
+      console.error('Unable to parse product canvas payload', err);
+      return [];
+    }
+  }
+
+  function stageSize(container) {
+    var width = container.offsetWidth || window.innerWidth * 0.9;
+    var height = Math.max(window.innerHeight * 0.6, 480);
+    return { width: width, height: height };
+  }
+
+  function createStage(container) {
+    var size = stageSize(container);
+    return new Konva.Stage({
+      container: 'konva-stage',
+      width: size.width,
+      height: size.height,
+    });
+  }
+
+  function createPlaceholder(group, text) {
+    var placeholder = new Konva.Text({
+      text: text,
+      fontSize: 14,
+      fill: '#757575',
+      width: 140,
+      height: 80,
+      align: 'center',
+      verticalAlign: 'middle',
+      x: 0,
+      y: 30,
+    });
+    group.add(placeholder);
+  }
+
+  function createProductNode(product, layer) {
+    var startX = 30 + (product.index % 5) * 160;
+    var startY = 30 + Math.floor(product.index / 5) * 160;
+
+    var group = new Konva.Group({
+      x: startX,
+      y: startY,
+      draggable: true,
+      id: 'product-' + product.id,
+    });
+
+    group.setAttrs({ startX: startX, startY: startY });
+
+    var frame = new Konva.Rect({
+      width: 150,
+      height: 150,
+      fill: '#ffffff',
+      stroke: '#26a69a',
+      strokeWidth: 2,
+      cornerRadius: 12,
+      shadowBlur: 6,
+      shadowOpacity: 0.1,
+    });
+    group.add(frame);
+
+    var title = product.name || 'Product';
+    var text = new Konva.Text({
+      text: title,
+      fontSize: 14,
+      fontStyle: 'bold',
+      fill: '#004d40',
+      width: 140,
+      x: 5,
+      y: 110,
+      align: 'center',
+      listening: false,
+    });
+
+    var meta = new Konva.Text({
+      text:
+        'SKU: ' + (product.productId || '—') +
+        '\nQty: ' + (product.totalInventory || 0),
+      fontSize: 12,
+      fill: '#546e7a',
+      width: 140,
+      x: 5,
+      y: 130,
+      align: 'center',
+      listening: false,
+    });
+
+    group.add(text);
+    group.add(meta);
+
+    if (product.photoUrl) {
+      var imageObj = new window.Image();
+      imageObj.onload = function () {
+        var ratio = Math.min(120 / imageObj.width, 80 / imageObj.height);
+        var imageWidth = imageObj.width * ratio;
+        var imageHeight = imageObj.height * ratio;
+        var image = new Konva.Image({
+          image: imageObj,
+          width: imageWidth,
+          height: imageHeight,
+          x: (150 - imageWidth) / 2,
+          y: 10 + (90 - imageHeight) / 2,
+        });
+        group.add(image);
+        layer.draw();
+      };
+      imageObj.crossOrigin = 'anonymous';
+      imageObj.src = product.photoUrl;
+    } else {
+      createPlaceholder(group, 'No photo');
+    }
+
+    layer.add(group);
+    return group;
+  }
+
+  function attachTransformer(stage, layer) {
+    var transformer = new Konva.Transformer({
+      rotateEnabled: false,
+      boundBoxFunc: function (oldBox, newBox) {
+        if (newBox.width < 80 || newBox.height < 80) {
+          return oldBox;
+        }
+        return newBox;
+      },
+    });
+    layer.add(transformer);
+
+    stage.on('click tap', function (e) {
+      if (e.target === stage) {
+        transformer.nodes([]);
+        layer.draw();
+        return;
+      }
+      var group = e.target.getParent();
+      if (group) {
+        transformer.nodes([group]);
+        layer.draw();
+      }
+    });
+
+    return transformer;
+  }
+
+  function serializeLayout(stage) {
+    return stage.find('Group').map(function (group) {
+      return {
+        id: group.id(),
+        x: group.x(),
+        y: group.y(),
+        scaleX: group.scaleX(),
+        scaleY: group.scaleY(),
+      };
+    });
+  }
+
+  function restoreLayout(stage, layout) {
+    var layoutMap = {};
+    layout.forEach(function (item) {
+      layoutMap[item.id] = item;
+    });
+    stage.find('Group').forEach(function (group) {
+      var config = layoutMap[group.id()];
+      if (!config) {
+        return;
+      }
+      group.position({ x: config.x, y: config.y });
+      if (config.scaleX && config.scaleY) {
+        group.scale({ x: config.scaleX, y: config.scaleY });
+      }
+    });
+    stage.batchDraw();
+  }
+
+  function exportAsImage(stage) {
+    var dataURL = stage.toDataURL({ pixelRatio: 2 });
+    var link = document.createElement('a');
+    link.download = 'product-canvas.png';
+    link.href = dataURL;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+
+  function toast(message, classes) {
+    if (window.M && M.toast) {
+      M.toast({ html: message, classes: classes });
+    } else {
+      console.log(message);
+    }
+  }
+
+  function ready(fn) {
+    if (document.readyState !== 'loading') {
+      fn();
+    } else {
+      document.addEventListener('DOMContentLoaded', fn);
+    }
+  }
+
+  ready(function () {
+    if (typeof Konva === 'undefined') {
+      console.warn('Konva.js is required for the product canvas');
+      return;
+    }
+
+    var container = getContainer();
+    var products = parseProducts(container);
+    if (!container || !products.length) {
+      return;
+    }
+
+    var stage = createStage(container);
+    var layer = new Konva.Layer();
+    stage.add(layer);
+    attachTransformer(stage, layer);
+
+    products.forEach(function (product) {
+      createProductNode(product, layer);
+    });
+
+    layer.draw();
+
+    window.addEventListener('resize', function () {
+      var size = stageSize(container);
+      stage.size(size);
+      stage.batchDraw();
+    });
+
+    var STORAGE_KEY = 'inventory-product-canvas';
+
+    var saveBtn = document.getElementById('save-layout');
+    var loadBtn = document.getElementById('load-layout');
+    var clearBtn = document.getElementById('clear-layout');
+    var exportBtn = document.getElementById('export-layout');
+
+    if (saveBtn) {
+      saveBtn.addEventListener('click', function () {
+        var layout = serializeLayout(stage);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+        toast('Layout saved locally', 'teal');
+      });
+    }
+
+    if (loadBtn) {
+      loadBtn.addEventListener('click', function () {
+        var payload = localStorage.getItem(STORAGE_KEY);
+        if (!payload) {
+          toast('No saved layout found', 'orange');
+          return;
+        }
+        try {
+          var layout = JSON.parse(payload);
+          restoreLayout(stage, layout);
+          toast('Layout restored', 'teal');
+        } catch (err) {
+          console.error('Unable to restore layout', err);
+          toast('Failed to load layout', 'red');
+        }
+      });
+    }
+
+    if (clearBtn) {
+      clearBtn.addEventListener('click', function () {
+        localStorage.removeItem(STORAGE_KEY);
+        stage.find('Group').forEach(function (group) {
+          var originalX = group.getAttr('startX') || 30;
+          var originalY = group.getAttr('startY') || 30;
+          group.position({ x: originalX, y: originalY });
+          group.scale({ x: 1, y: 1 });
+        });
+        stage.batchDraw();
+        toast('Layout cleared', 'grey darken-1');
+      });
+    }
+
+    if (exportBtn) {
+      exportBtn.addEventListener('click', function () {
+        exportAsImage(stage);
+      });
+    }
+  });
+})();

--- a/inventory/templates/inventory/base.html
+++ b/inventory/templates/inventory/base.html
@@ -34,6 +34,7 @@
         <li class="{% if request.resolver_match.url_name == 'home' %}active{% endif %}"><a href="{% url 'home' %}">Home</a></li>
         <li class="{% if request.resolver_match.url_name == 'dashboard' %}active{% endif %}"><a href="{% url 'dashboard' %}">Dashboard</a></li>
         <li class="{% if request.resolver_match.url_name == 'product_list' %}active{% endif %}"><a href="{% url 'product_list' %}">Products</a></li>
+        <li class="{% if request.resolver_match.url_name == 'product_canvas' %}active{% endif %}"><a href="{% url 'product_canvas' %}">Product Canvas</a></li>
         <li class="{% if request.resolver_match.url_name == 'inventory_snapshots' %}active{% endif %}"><a href="{% url 'inventory_snapshots' %}">Inventory</a></li>
         <li class="{% if request.resolver_match.url_name == 'order_list' %}active{% endif %}"><a href="{% url 'order_list' %}">Orders</a></li>
         <li class="{% if request.resolver_match.url_name == 'sales' %}active{% endif %}"><a href="{% url 'sales' %}">Sales</a></li>

--- a/inventory/templates/inventory/product_canvas.html
+++ b/inventory/templates/inventory/product_canvas.html
@@ -1,0 +1,35 @@
+{% extends "inventory/base.html" %}
+{% load static %}
+
+{% block title %}Product Canvas{% endblock %}
+
+{% block content %}
+<div class="section">
+  <div class="row">
+    <div class="col s12">
+      <h4 class="header">Product Canvas</h4>
+      <p class="grey-text text-darken-1">
+        Drag and resize products on the Konva.js canvas to plan merchandising layouts.
+        Use the buttons below to save a layout locally or export an image snapshot of the current arrangement.
+      </p>
+      <div class="card-panel teal lighten-5">
+        <div class="section">
+          <a class="btn teal" id="save-layout"><i class="material-icons left">save</i>Save Layout</a>
+          <a class="btn grey lighten-1 black-text" id="load-layout"><i class="material-icons left">refresh</i>Load Saved Layout</a>
+          <a class="btn amber darken-2" id="clear-layout"><i class="material-icons left">clear</i>Clear Layout</a>
+          <a class="btn cyan darken-2" id="export-layout"><i class="material-icons left">image</i>Export PNG</a>
+        </div>
+      </div>
+      <div id="product-canvas-container" class="white z-depth-1" data-products='{{ product_canvas_json|default:"[]"|safe }}'>
+        <div id="konva-stage" style="width: 100%; height: 70vh;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extrajs %}
+  {{ block.super }}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/konva/9.3.5/konva.min.js" integrity="sha512-jF+DGQmQWyZDWjxUV0NWB7p+1Jx8HgthXW3a4QJc1JOja2JmKHjLo1AHnpGpOa9DzGXCcJFOWeOFfppTlwkMxQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="{% static 'product-canvas.js' %}"></script>
+{% endblock %}

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path('', views.home, name='home'),
     path('dashboard/', views.dashboard, name='dashboard'),
     path('products/', views.product_list, name='product_list'),
+    path('products/canvas/', views.product_canvas, name='product_canvas'),
     path('inventory-snapshots/', views.inventory_snapshots, name='inventory_snapshots'),
     path('products/<int:product_id>/', views.product_detail, name='product_detail'),  # New route
     path('orders/', views.order_list, name='order_list'),  # Order List View

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -800,7 +800,9 @@ def dashboard(request):
     return render(request, "inventory/dashboard.html", context)
 
 
-def product_list(request):
+def _build_product_list_context(request):
+    """Return the computed context used by the product list style views."""
+
     # ─── Filter flags ───────────────────────────────────────────────────────────
     show_retired = request.GET.get("show_retired", "false").lower() == "true"
     type_filter = request.GET.get("type_filter", None)
@@ -1050,7 +1052,56 @@ def product_list(request):
         }
     )
 
+    return context
+
+
+def product_list(request):
+    context = _build_product_list_context(request)
     return render(request, "inventory/product_list.html", context)
+
+
+def product_canvas(request):
+    base_context = _build_product_list_context(request)
+    products = base_context.get("products", [])
+
+    canvas_items = []
+    for idx, product in enumerate(products):
+        photo_url = None
+        if getattr(product, "product_photo", None):
+            try:
+                if product.product_photo:
+                    photo_url = product.product_photo.url
+            except ValueError:
+                photo_url = None
+
+        canvas_items.append(
+            {
+                "id": product.pk,
+                "productId": product.product_id,
+                "name": product.product_name,
+                "photoUrl": photo_url,
+                "totalInventory": getattr(product, "total_inventory", 0),
+                "lastOrderLabel": getattr(product, "last_order_label", ""),
+                "lastOrderQty": getattr(product, "last_order_qty", 0),
+                "retailPrice": float(product.retail_price) if product.retail_price else None,
+                "index": idx,
+            }
+        )
+
+    if request.headers.get("x-requested-with") == "XMLHttpRequest" or request.GET.get(
+        "format"
+    ) == "json":
+        return JsonResponse({"products": canvas_items})
+
+    canvas_context = base_context.copy()
+    canvas_context.update(
+        {
+            "product_canvas_items": canvas_items,
+            "product_canvas_json": json.dumps(canvas_items),
+        }
+    )
+
+    return render(request, "inventory/product_canvas.html", canvas_context)
 
 
 def product_detail(request, product_id):


### PR DESCRIPTION
## Summary
- refactor product list logic into a reusable helper for shared queries
- add a product canvas view, route, and navigation entry rendering Konva.js nodes for each product
- introduce a Konva-powered front-end with local layout persistence and export actions

## Testing
- python manage.py check *(fails: missing Django dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e231783a2c832c8e2a320624d985de