### PR TITLE
Add server-side resizing for product canvas images

### DIFF
--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1,15 +1,21 @@
 from datetime import date, timedelta, datetime
 from decimal import Decimal
+import os
+import tempfile
+from io import BytesIO
 
 from unittest.mock import patch
 from dateutil.relativedelta import relativedelta
 from django.contrib.admin.sites import AdminSite
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, override_settings
 from django.utils import timezone
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.contrib.auth import get_user_model
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from PIL import Image
 
 from .models import (
     Product,
@@ -30,6 +36,7 @@ from .utils import (
     calculate_variant_sales_speed,
     get_category_speed_stats,
 )
+from .views import PRODUCT_CANVAS_MAX_DIMENSION, DEFAULT_PRODUCT_IMAGE
 
 
 class LowStockProductsTests(TestCase):
@@ -1537,3 +1544,52 @@ class SaleAdminAssignReferrerActionTests(TestCase):
         self.sale_two.refresh_from_db()
         self.assertEqual(self.sale_one.referrer, self.referrer)
         self.assertEqual(self.sale_two.referrer, self.referrer)
+
+
+class ProductCanvasImageTests(TestCase):
+    def setUp(self):
+        self.media_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.media_dir.cleanup)
+
+    def _image_bytes(self, size=(640, 480), color=(200, 50, 50)):
+        image = Image.new("RGB", size, color)
+        buffer = BytesIO()
+        image.save(buffer, format="JPEG")
+        return buffer.getvalue()
+
+    def _upload(self, name="photo.jpg", size=(640, 480)):
+        return SimpleUploadedFile(name, self._image_bytes(size=size), content_type="image/jpeg")
+
+    def test_product_canvas_image_resizes_large_photos(self):
+        with override_settings(MEDIA_ROOT=self.media_dir.name):
+            product = Product.objects.create(
+                product_id="PX1",
+                product_name="Canvas Product",
+                product_photo=self._upload(size=(1200, 900)),
+            )
+
+            response = self.client.get(reverse("product_canvas_image", args=[product.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "image/jpeg")
+
+        with Image.open(BytesIO(response.content)) as img:
+            self.assertLessEqual(max(img.size), PRODUCT_CANVAS_MAX_DIMENSION)
+
+    def test_product_canvas_image_uses_default_when_missing_photo(self):
+        with override_settings(MEDIA_ROOT=self.media_dir.name):
+            default_path = os.path.join(self.media_dir.name, DEFAULT_PRODUCT_IMAGE)
+            os.makedirs(os.path.dirname(default_path), exist_ok=True)
+            with open(default_path, "wb") as handle:
+                handle.write(self._image_bytes(size=(300, 300), color=(20, 20, 20)))
+
+            product = Product.objects.create(
+                product_id="PX2",
+                product_name="No Photo Product",
+            )
+
+            response = self.client.get(reverse("product_canvas_image", args=[product.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        with Image.open(BytesIO(response.content)) as img:
+            self.assertLessEqual(max(img.size), PRODUCT_CANVAS_MAX_DIMENSION)

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('dashboard/', views.dashboard, name='dashboard'),
     path('products/', views.product_list, name='product_list'),
     path('products/canvas/', views.product_canvas, name='product_canvas'),
+    path('products/canvas/image/<int:product_id>/', views.product_canvas_image, name='product_canvas_image'),
     path('inventory-snapshots/', views.inventory_snapshots, name='inventory_snapshots'),
     path('products/<int:product_id>/', views.product_detail, name='product_detail'),  # New route
     path('orders/', views.order_list, name='order_list'),  # Order List View

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -7,8 +7,10 @@ from collections import defaultdict, namedtuple, OrderedDict
 import calendar
 import statistics
 import math
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode
 import logging
+from io import BytesIO
+import os
 
 from django.core.cache import cache
 
@@ -39,10 +41,13 @@ from django.db.models import (
     DateField,
 )
 from django.db.models.functions import Coalesce
-from django.http import HttpResponse, JsonResponse, Http404
+from django.http import Http404, HttpResponse, JsonResponse
 from django.db.models.functions import TruncMonth
 from django.urls import reverse
-from django.views.decorators.http import require_POST
+from django.utils.http import http_date
+from django.views.decorators.cache import cache_control
+from django.views.decorators.http import require_GET, require_POST
+from PIL import Image, ImageOps
 
 from .models import (
     Product,
@@ -82,6 +87,8 @@ from .utils import (
 
 # e.g. MEDIA_ROOT/product_photos/default.jpg  (put the file there)
 DEFAULT_PRODUCT_IMAGE = getattr(settings, "DEFAULT_PRODUCT_IMAGE", "product_photos/default.jpg")
+PRODUCT_CANVAS_MAX_DIMENSION = getattr(settings, "PRODUCT_CANVAS_MAX_DIMENSION", 320)
+PRODUCT_CANVAS_IMAGE_QUALITY = getattr(settings, "PRODUCT_CANVAS_IMAGE_QUALITY", 85)
 
 
 # used in 'home' view
@@ -1073,27 +1080,12 @@ def product_canvas(request):
 
     canvas_items = []
     for idx, product in enumerate(products):
-        # Try to get the product's own photo URL
-        photo_url = None
-        try:
-            if getattr(product, "product_photo", None) and getattr(product.product_photo, "url", None):
-                photo_url = product.product_photo.url
-        except ValueError:
-            # e.g. missing underlying file
-            photo_url = None
-
-        # Fallback to a default media image if missing/invalid
-        if not photo_url:
-            # Make a relative media URL (e.g. "/media/product_photos/default.jpg")
-            photo_url = urljoin(settings.MEDIA_URL, DEFAULT_PRODUCT_IMAGE)
-
-        # (Optional) If you want absolute URLs, uncomment the next line:
-        # photo_url = request.build_absolute_uri(photo_url)
-
         canvas_items.append(
             {
                 "id": product.pk,
-                "photoUrl": photo_url,
+                "photoUrl": request.build_absolute_uri(
+                    reverse("product_canvas_image", args=[product.pk])
+                ),
                 "index": idx,
             }
         )
@@ -1112,6 +1104,81 @@ def product_canvas(request):
     )
 
     return render(request, "inventory/product_canvas.html", canvas_context)
+
+
+def _resolve_product_canvas_image_path(product: Optional[Product]) -> Optional[str]:
+    """Return a filesystem path for the product canvas image."""
+
+    if product and getattr(product, "product_photo", None):
+        try:
+            if product.product_photo and product.product_photo.path:
+                return product.product_photo.path
+        except (ValueError, FileNotFoundError):
+            pass
+
+    fallback_path = os.path.join(settings.MEDIA_ROOT, DEFAULT_PRODUCT_IMAGE)
+    if os.path.isfile(fallback_path):
+        return fallback_path
+
+    return None
+
+
+def _prepare_canvas_image_bytes(image_path: str) -> tuple[bytes, str]:
+    """Resize the image located at ``image_path`` for canvas usage."""
+
+    try:
+        with Image.open(image_path) as source:
+            image = ImageOps.exif_transpose(source)
+            image.thumbnail(
+                (PRODUCT_CANVAS_MAX_DIMENSION, PRODUCT_CANVAS_MAX_DIMENSION),
+                Image.LANCZOS,
+            )
+
+            if image.mode in ("RGBA", "LA"):
+                background = Image.new("RGB", image.size, (255, 255, 255))
+                background.paste(image, mask=image.split()[-1])
+                image = background
+            elif image.mode != "RGB":
+                image = image.convert("RGB")
+
+            output = BytesIO()
+            image.save(
+                output,
+                format="JPEG",
+                quality=PRODUCT_CANVAS_IMAGE_QUALITY,
+                optimize=True,
+            )
+            return output.getvalue(), "image/jpeg"
+    except OSError as exc:
+        raise Http404("Unable to process product image") from exc
+
+    raise Http404("Unable to process product image")
+
+
+@require_GET
+@cache_control(max_age=86400)
+def product_canvas_image(request, product_id: int):
+    """Serve a resized product image tailored for the product canvas."""
+
+    product = get_object_or_404(Product, pk=product_id)
+    image_path = _resolve_product_canvas_image_path(product)
+    if not image_path:
+        raise Http404("Product image not found")
+
+    image_bytes, content_type = _prepare_canvas_image_bytes(image_path)
+
+    response = HttpResponse(image_bytes, content_type=content_type)
+    response["Content-Length"] = str(len(image_bytes))
+
+    try:
+        modified_time = os.path.getmtime(image_path)
+    except OSError:
+        modified_time = None
+
+    if modified_time:
+        response["Last-Modified"] = http_date(modified_time)
+
+    return response
 
 
 def product_detail(request, product_id):


### PR DESCRIPTION
## Summary
- serve product canvas imagery through a dedicated endpoint that resizes uploads to a capped dimension and compresses them as JPEGs
- update the product canvas data to point at the optimized endpoint and expose configuration constants for size and quality
- add tests covering resized product photos and the default image fallback

## Testing
- python manage.py test inventory.tests.ProductCanvasImageTests

------
https://chatgpt.com/codex/tasks/task_e_68e3a7c61fdc832c9054f0d11b6414ae