### PR TITLE
Add new product performance panel to sales insights

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -598,6 +598,73 @@ vertical-align: middle;
   margin-top: 0.25rem;
 }
 
+.sales-insights-card {
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem;
+}
+
+.sales-insights__header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.sales-insights__title {
+  margin: 0;
+}
+
+.sales-insights__subtitle {
+  margin: 0.25rem 0 0;
+}
+
+.sales-insights__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+}
+
+.sales-insights__panel {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+}
+
+.sales-insights__stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sales-insights__panel--chart {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.sales-insights__panel-title {
+  margin: 0 0 0.75rem;
+}
+
+.sales-insights__chart-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.sales-insights-table {
+  margin: 0;
+}
+
+.sales-insights__chart {
+  min-height: 220px;
+  position: relative;
+}
+
+.sales-insights__empty {
+  margin: 0;
+}
+
 .pricing-breakdown-card {
   border-radius: 8px;
   margin: 0 0 2rem;
@@ -815,6 +882,14 @@ vertical-align: middle;
 
   .filter-toolbar__aside {
     justify-content: flex-start;
+  }
+
+  .sales-insights__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sales-insights__chart {
+    min-height: 260px;
   }
 }
 

--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -82,6 +82,105 @@
         </div>
       </div>
 
+      <div class="card-panel sales-insights-card">
+        <div class="sales-insights__header">
+          <div>
+            <h6 class="sales-insights__title">Monthly sales snapshot</h6>
+            <p class="sales-insights__subtitle grey-text text-darken-1">
+              {{ insights_start|date:"M j" }}–{{ insights_end|date:"M j" }}
+              {% if insights_is_custom %}
+                · Custom range
+              {% elif insights_is_current %}
+                · Current month
+              {% else %}
+                · Previous month
+              {% endif %}
+            </p>
+          </div>
+        </div>
+
+        {% if insights_has_data %}
+          <div class="sales-insights__grid">
+            <div class="sales-insights__stack">
+              <div class="sales-insights__panel">
+                <h6 class="sales-insights__panel-title">Top selling products</h6>
+                <table class="striped sales-insights-table">
+                  <thead>
+                    <tr>
+                      <th>Product</th>
+                      <th class="right-align">Items</th>
+                      <th class="right-align">Value</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in top_products %}
+                      <tr>
+                        <td>{{ row.variant__product__product_name }}</td>
+                        <td class="right-align">{{ row.net_quantity }}</td>
+                        <td class="right-align">¥{{ row.net_value|floatformat:2 }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+              <div class="sales-insights__panel">
+                <h6 class="sales-insights__panel-title">New product performance</h6>
+                {% if new_products %}
+                  <table class="striped sales-insights-table">
+                    <thead>
+                      <tr>
+                        <th>Product</th>
+                        <th class="right-align">Sold</th>
+                        <th class="right-align">Stock</th>
+                        <th class="right-align">Sell-through (mo)</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for row in new_products %}
+                        <tr>
+                          <td>{{ row.product_name }}</td>
+                          <td class="right-align">{{ row.sold_qty }}</td>
+                          <td class="right-align">{{ row.stock_qty }}</td>
+                          <td class="right-align">
+                            {% if row.sell_through_months %}
+                              {{ row.sell_through_months|floatformat:1 }}
+                            {% else %}
+                              &mdash;
+                            {% endif %}
+                          </td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                {% else %}
+                  <p class="grey-text text-darken-1 sales-insights__empty">
+                    No new products in this timeframe.
+                  </p>
+                {% endif %}
+              </div>
+            </div>
+            <div class="sales-insights__panel sales-insights__panel--chart">
+              <div class="sales-insights__chart-block">
+                <h6 class="sales-insights__panel-title">Category mix</h6>
+                <div class="sales-insights__chart">
+                  <canvas id="salesCategoryChart" aria-label="Sales by category pie chart"></canvas>
+                </div>
+              </div>
+              <div class="sales-insights__chart-block">
+                <h6 class="sales-insights__panel-title">Group mix</h6>
+                <div class="sales-insights__chart">
+                  <canvas id="salesGroupChart" aria-label="Sales by group pie chart"></canvas>
+                </div>
+              </div>
+            </div>
+          </div>
+        {% else %}
+          <p class="grey-text text-darken-1 sales-insights__empty">
+            No sales recorded for this month.
+          </p>
+        {% endif %}
+      </div>
+
       <div class="card-panel blue lighten-5 pricing-breakdown-card">
         <h6 class="pricing-breakdown-card__title grey-text text-darken-2">Pricing breakdown</h6>
         <p class="pricing-breakdown-card__note grey-text text-darken-1">
@@ -146,6 +245,7 @@
 
 {% block extrajs %}
   {{ block.super }}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
     document.addEventListener("DOMContentLoaded", function () {
       document
@@ -187,6 +287,87 @@
             target += dateQuerystring;
           }
           window.location.href = target;
+        });
+      }
+
+      const categoryChartEl = document.getElementById("salesCategoryChart");
+      if (categoryChartEl) {
+        const categoryChart = new Chart(categoryChartEl.getContext("2d"), {
+          type: "pie",
+          data: {
+            labels: JSON.parse('{{ category_chart_labels|escapejs }}'),
+            datasets: [
+              {
+                data: JSON.parse('{{ category_chart_values|escapejs }}'),
+                backgroundColor: JSON.parse('{{ category_chart_colors|escapejs }}'),
+                borderColor: "#ffffff",
+                borderWidth: 2,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: {
+                position: "bottom",
+                labels: {
+                  boxWidth: 12,
+                  padding: 16,
+                },
+              },
+              tooltip: {
+                callbacks: {
+                  label: function (context) {
+                    return context.label + ": " + context.parsed + " items";
+                  },
+                },
+              },
+            },
+          },
+        });
+      }
+
+      const groupChartEl = document.getElementById("salesGroupChart");
+      if (groupChartEl) {
+        const groupLabels = JSON.parse('{{ group_chart_labels|escapejs }}');
+        const groupValues = JSON.parse('{{ group_chart_values|escapejs }}');
+        const groupColors = JSON.parse('{{ group_chart_colors|escapejs }}');
+        const groupChart = new Chart(groupChartEl.getContext("2d"), {
+          type: "pie",
+          data: {
+            labels: groupLabels,
+            datasets: [
+              {
+                data: groupValues,
+                backgroundColor: groupValues.map(
+                  (_value, index) => groupColors[index % groupColors.length]
+                ),
+                borderColor: "#ffffff",
+                borderWidth: 2,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: {
+                position: "bottom",
+                labels: {
+                  boxWidth: 12,
+                  padding: 16,
+                },
+              },
+              tooltip: {
+                callbacks: {
+                  label: function (context) {
+                    return context.label + ": " + context.parsed + " items";
+                  },
+                },
+              },
+            },
+          },
         });
       }
     });


### PR DESCRIPTION
### Motivation
- Surface performance of recently-introduced products in the sales snapshot by identifying products whose first sale was within the last three months and showing their sell and stock metrics.
- Provide an estimated sell-through time to help inventory decisions for new SKUs.

### Description
- Compute `new_product_ids` by finding products with `Min(Sale.date)` within `insights_end - relativedelta(months=3)` and aggregate `sold_qty`, `return_qty`, and `net_quantity` from the `insights_sales` queryset in `inventory/views.py`.
- Look up latest snapshot stock per product using the most recent `InventorySnapshot` and build a `new_products` list containing `product_name`, `sold_qty`, `stock_qty`, and `sell_through_months` (calculated as `stock / (sold/months_in_range)`), and expose it in the template context as `new_products`.
- Render a new “New product performance” panel alongside the Top selling products table in `inventory/templates/inventory/sales.html`, including columns `Sold`, `Stock`, and `Sell-through (mo)`, and show a placeholder when none exist.
- Add CSS for stacked insights panels in `inventory/static/styles.css` and include the Chart.js script/initialization that the sales page already uses for the category/group pies.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709e46881c832c9c9740e31fb103e5)