### PR TITLE
Show only top 10 new products by default with expand/collapse toggle

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -598,6 +598,87 @@ vertical-align: middle;
   margin-top: 0.25rem;
 }
 
+.sales-insights-card {
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem;
+}
+
+.sales-insights__header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.sales-insights__title {
+  margin: 0;
+}
+
+.sales-insights__subtitle {
+  margin: 0.25rem 0 0;
+}
+
+.sales-insights__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+}
+
+.sales-insights__panel {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+}
+
+.sales-insights__stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sales-insights__panel--chart {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.sales-insights__panel-title {
+  margin: 0 0 0.75rem;
+}
+
+.sales-insights__chart-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.sales-insights-table {
+  margin: 0;
+}
+
+.sales-insights__chart {
+  min-height: 220px;
+  position: relative;
+}
+
+.sales-insights__actions {
+  margin-top: 0.75rem;
+  text-align: right;
+}
+
+.sales-insights__toggle {
+  font-weight: 600;
+  text-transform: none;
+}
+
+.sales-insights-table .is-hidden {
+  display: none;
+}
+
+.sales-insights__empty {
+  margin: 0;
+}
+
 .pricing-breakdown-card {
   border-radius: 8px;
   margin: 0 0 2rem;
@@ -815,6 +896,14 @@ vertical-align: middle;
 
   .filter-toolbar__aside {
     justify-content: flex-start;
+  }
+
+  .sales-insights__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sales-insights__chart {
+    min-height: 260px;
   }
 }
 

--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -82,6 +82,116 @@
         </div>
       </div>
 
+      <div class="card-panel sales-insights-card">
+        <div class="sales-insights__header">
+          <div>
+            <h6 class="sales-insights__title">Monthly sales snapshot</h6>
+            <p class="sales-insights__subtitle grey-text text-darken-1">
+              {{ insights_start|date:"M j" }}–{{ insights_end|date:"M j" }}
+              {% if insights_is_custom %}
+                · Custom range
+              {% elif insights_is_current %}
+                · Current month
+              {% else %}
+                · Previous month
+              {% endif %}
+            </p>
+          </div>
+        </div>
+
+        {% if insights_has_data %}
+          <div class="sales-insights__grid">
+            <div class="sales-insights__stack">
+              <div class="sales-insights__panel">
+                <h6 class="sales-insights__panel-title">Top selling products</h6>
+                <table class="striped sales-insights-table">
+                  <thead>
+                    <tr>
+                      <th>Product</th>
+                      <th class="right-align">Items</th>
+                      <th class="right-align">Value</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in top_products %}
+                      <tr>
+                        <td>{{ row.variant__product__product_name }}</td>
+                        <td class="right-align">{{ row.net_quantity }}</td>
+                        <td class="right-align">¥{{ row.net_value|floatformat:2 }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+              <div class="sales-insights__panel">
+                <h6 class="sales-insights__panel-title">New product performance</h6>
+                {% if new_products %}
+                  <table class="striped sales-insights-table">
+                    <thead>
+                      <tr>
+                        <th>Product</th>
+                        <th class="right-align">Sold</th>
+                        <th class="right-align">Stock</th>
+                        <th class="right-align">Sell-through (mo)</th>
+                      </tr>
+                    </thead>
+                    <tbody id="newProductsTable">
+                      {% for row in new_products %}
+                        <tr{% if forloop.counter > 10 %} class="is-hidden"{% endif %}>
+                          <td>{{ row.product_name }}</td>
+                          <td class="right-align">{{ row.sold_qty }}</td>
+                          <td class="right-align">{{ row.stock_qty }}</td>
+                          <td class="right-align">
+                            {% if row.sell_through_months %}
+                              {{ row.sell_through_months|floatformat:1 }}
+                            {% else %}
+                              &mdash;
+                            {% endif %}
+                          </td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                  {% if new_products|length > 10 %}
+                    <div class="sales-insights__actions">
+                      <button
+                        type="button"
+                        class="btn-flat sales-insights__toggle"
+                        data-target="newProductsTable"
+                      >
+                        Show more
+                      </button>
+                    </div>
+                  {% endif %}
+                {% else %}
+                  <p class="grey-text text-darken-1 sales-insights__empty">
+                    No new products in this timeframe.
+                  </p>
+                {% endif %}
+              </div>
+            </div>
+            <div class="sales-insights__panel sales-insights__panel--chart">
+              <div class="sales-insights__chart-block">
+                <h6 class="sales-insights__panel-title">Category mix</h6>
+                <div class="sales-insights__chart">
+                  <canvas id="salesCategoryChart" aria-label="Sales by category pie chart"></canvas>
+                </div>
+              </div>
+              <div class="sales-insights__chart-block">
+                <h6 class="sales-insights__panel-title">Group mix</h6>
+                <div class="sales-insights__chart">
+                  <canvas id="salesGroupChart" aria-label="Sales by group pie chart"></canvas>
+                </div>
+              </div>
+            </div>
+          </div>
+        {% else %}
+          <p class="grey-text text-darken-1 sales-insights__empty">
+            No sales recorded for this month.
+          </p>
+        {% endif %}
+      </div>
+
       <div class="card-panel blue lighten-5 pricing-breakdown-card">
         <h6 class="pricing-breakdown-card__title grey-text text-darken-2">Pricing breakdown</h6>
         <p class="pricing-breakdown-card__note grey-text text-darken-1">
@@ -146,6 +256,7 @@
 
 {% block extrajs %}
   {{ block.super }}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
     document.addEventListener("DOMContentLoaded", function () {
       document
@@ -189,6 +300,110 @@
           window.location.href = target;
         });
       }
+
+      const categoryChartEl = document.getElementById("salesCategoryChart");
+      if (categoryChartEl) {
+        const categoryChart = new Chart(categoryChartEl.getContext("2d"), {
+          type: "pie",
+          data: {
+            labels: JSON.parse('{{ category_chart_labels|escapejs }}'),
+            datasets: [
+              {
+                data: JSON.parse('{{ category_chart_values|escapejs }}'),
+                backgroundColor: JSON.parse('{{ category_chart_colors|escapejs }}'),
+                borderColor: "#ffffff",
+                borderWidth: 2,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: {
+                position: "bottom",
+                labels: {
+                  boxWidth: 12,
+                  padding: 16,
+                },
+              },
+              tooltip: {
+                callbacks: {
+                  label: function (context) {
+                    return context.label + ": " + context.parsed + " items";
+                  },
+                },
+              },
+            },
+          },
+        });
+      }
+
+      const groupChartEl = document.getElementById("salesGroupChart");
+      if (groupChartEl) {
+        const groupLabels = JSON.parse('{{ group_chart_labels|escapejs }}');
+        const groupValues = JSON.parse('{{ group_chart_values|escapejs }}');
+        const groupColors = JSON.parse('{{ group_chart_colors|escapejs }}');
+        const groupChart = new Chart(groupChartEl.getContext("2d"), {
+          type: "pie",
+          data: {
+            labels: groupLabels,
+            datasets: [
+              {
+                data: groupValues,
+                backgroundColor: groupValues.map(
+                  (_value, index) => groupColors[index % groupColors.length]
+                ),
+                borderColor: "#ffffff",
+                borderWidth: 2,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: {
+                position: "bottom",
+                labels: {
+                  boxWidth: 12,
+                  padding: 16,
+                },
+              },
+              tooltip: {
+                callbacks: {
+                  label: function (context) {
+                    return context.label + ": " + context.parsed + " items";
+                  },
+                },
+              },
+            },
+          },
+        });
+      }
+
+      document.querySelectorAll(".sales-insights__toggle").forEach((button) => {
+        const targetId = button.dataset.target;
+        const targetBody = document.getElementById(targetId);
+        if (!targetBody) {
+          return;
+        }
+        button.addEventListener("click", () => {
+          const hiddenRows = targetBody.querySelectorAll("tr.is-hidden");
+          const isExpanded = hiddenRows.length === 0;
+          if (isExpanded) {
+            Array.from(targetBody.rows).forEach((row, index) => {
+              if (index >= 10) {
+                row.classList.add("is-hidden");
+              }
+            });
+            button.textContent = "Show more";
+          } else {
+            hiddenRows.forEach((row) => row.classList.remove("is-hidden"));
+            button.textContent = "Show less";
+          }
+        });
+      });
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Improve readability of the "New product performance" panel by showing only the top 10 rows initially and allowing users to expand the list on demand.
- Keep the existing insights and charts unchanged while adding a lightweight client-side control to manage long lists.

### Description
- Hide rows after the first 10 in the new products table by adding `id="newProductsTable"` to the table body and rendering rows beyond 10 with the `is-hidden` class in `inventory/templates/inventory/sales.html`.
- Add a toggle button (rendered when there are more than 10 items) that targets the table via `data-target="newProductsTable"` and flips between "Show more" and "Show less` in `inventory/templates/inventory/sales.html`.
- Implement the expand/collapse behavior in the page JavaScript (registered in the `extrajs` block) to add/remove the `is-hidden` class on rows and update the button text.
- Add CSS rules for `.sales-insights__actions`, `.sales-insights__toggle`, and `.sales-insights-table .is-hidden` to `inventory/static/styles.css` to support layout and hide/show behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709e46881c832c9c9740e31fb103e5)