### PR TITLE
Update Products list scorecard for review workflow

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -129,6 +129,67 @@ main {
   font-size: 0.95rem;
 }
 
+.scorecard-box--review .metric {
+  margin-bottom: 10px;
+}
+
+.variant-summary-trigger {
+  text-transform: none;
+  padding: 0;
+  color: #0277bd;
+  text-decoration: underline;
+}
+
+.variant-summary-trigger:hover {
+  background: transparent;
+}
+
+.variant-panel {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 1200;
+}
+
+.variant-panel.is-open {
+  display: block;
+}
+
+.variant-panel__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.variant-panel__content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(760px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.24);
+}
+
+.variant-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #eceff1;
+}
+
+.variant-panel__header h6 {
+  margin: 0;
+}
+
+.variant-panel__body {
+  padding: 12px 16px 16px;
+}
+
 :where(.card, .card-panel).amber.lighten-5 { --card-border-color: #ffecb3; }
 :where(.card, .card-panel).amber.lighten-4 { --card-border-color: #ffe082; }
 :where(.card, .card-panel).amber.lighten-3 { --card-border-color: #ffd54f; }

--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -1644,6 +1644,27 @@
       renderVerticalBarChart('ageBreakdownChart', ageLabels, ageValues, 'Age');
       renderVerticalBarChart('genderBreakdownChart', genderLabels, genderValues, 'Gender');
 
+      const toggleVariantPanel = (panel, open) => {
+        if (!panel) return;
+        panel.classList.toggle('is-open', open);
+        panel.setAttribute('aria-hidden', open ? 'false' : 'true');
+      };
+
+      document.querySelectorAll('[data-variant-panel-trigger]').forEach((trigger) => {
+        trigger.addEventListener('click', () => {
+          const productId = trigger.getAttribute('data-product-id');
+          const panel = document.querySelector(`[data-variant-panel="${productId}"]`);
+          toggleVariantPanel(panel, true);
+        });
+      });
+
+      document.querySelectorAll('[data-variant-panel-close]').forEach((closeButton) => {
+        closeButton.addEventListener('click', () => {
+          const panel = closeButton.closest('.variant-panel');
+          toggleVariantPanel(panel, false);
+        });
+      });
+
       if (!dataPoints || !dataPoints.length || !document.getElementById('quarterlySalesChart')) {
         return;
       }

--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -34,48 +34,27 @@
 
 
             <div class="col s12 m6 l3">
-              <div class="card-panel scorecard-box">
-                <div class="confidence-highlight">
-                  {% if product.confidence_level == "High" %}
-                    <span class="confidence-icon green lighten-1">
-                      <i class="material-icons white-text">check_circle</i>
-                    </span>
-                  {% elif product.confidence_level == "Medium" %}
-                    <span class="confidence-icon amber lighten-1">
-                      <i class="material-icons white-text">priority_high</i>
-                    </span>
-                  {% elif product.confidence_level == "Low" %}
-                    <span class="confidence-icon red lighten-1">
-                      <i class="material-icons white-text">warning</i>
-                    </span>
-                  {% else %}
-                    <span class="confidence-icon grey lighten-2">
-                      <i class="material-icons white-text">help_outline</i>
-                    </span>
-                  {% endif %}
-                  <div>
-                    <small class="grey-text text-darken-1">Confidence</small>
-                    <p class="confidence-value">
-                      {% if product.confidence_level %}
-                        {{ product.confidence_level }}
-                        {% if product.confidence_score %}
-                          ({{ product.confidence_score|floatformat:0 }}%)
-                        {% endif %}
-                      {% else %}
-                        -
-                      {% endif %}
-                    </p>
-                  </div>
+              <div class="card-panel scorecard-box scorecard-box--review">
+                <div class="metric">
+                  <small class="grey-text">Current Stock</small>
+                  <p class="metric-value">{{ product.total_inventory|default:0 }}</p>
                 </div>
-                {% if product.confidence_advisories %}
-                  <ul class="advisories">
-                    {% for note in product.confidence_advisories %}
-                      <li>{{ note }}</li>
-                    {% endfor %}
-                  </ul>
-                {% else %}
-                  <small class="grey-text">No advisories</small>
-                {% endif %}
+                <div class="metric">
+                  <small class="grey-text">Total Sold</small>
+                  <p class="metric-value">{{ product.total_sales|default:0 }}</p>
+                </div>
+                <div class="metric">
+                  <small class="grey-text">Total Ordered</small>
+                  <p class="metric-value">{{ product.total_ordered|default:0 }}</p>
+                </div>
+                <button
+                  type="button"
+                  class="btn-flat variant-summary-trigger"
+                  data-variant-panel-trigger
+                  data-product-id="{{ product.id }}"
+                >
+                  This product has {{ product.variant_count|default:0 }} variants
+                </button>
               </div>
             </div>
 
@@ -189,6 +168,51 @@
 
 
 
+          </div>
+
+          <div
+            class="variant-panel"
+            data-variant-panel="{{ product.id }}"
+            aria-hidden="true"
+          >
+            <div class="variant-panel__backdrop" data-variant-panel-close></div>
+            <div class="variant-panel__content">
+              <div class="variant-panel__header">
+                <h6>
+                  {{ product.product_name }} variants
+                </h6>
+                <button type="button" class="btn-flat" data-variant-panel-close>&times;</button>
+              </div>
+              <div class="variant-panel__body">
+                <table class="striped responsive-table">
+                  <thead>
+                    <tr>
+                      <th>Variant</th>
+                      <th>Stock</th>
+                      <th>Sold</th>
+                      <th>Previous Order</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for variant in product.variants_with_inventory %}
+                      <tr>
+                        <td>
+                          {{ variant.size|default:"—" }}
+                          <span class="grey-text">({{ variant.variant_code }})</span>
+                        </td>
+                        <td>{{ variant.latest_inventory|default:0 }}</td>
+                        <td>{{ variant.total_sold|default:0 }}</td>
+                        <td>{{ variant.previous_order_qty|default:0 }}</td>
+                      </tr>
+                    {% empty %}
+                      <tr>
+                        <td colspan="4" class="grey-text">No variants available.</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -957,9 +957,21 @@ def _build_product_list_context(request, preset_filters=None):
         .order_by("-date")
         .values("inventory_count")[:1]
     )
+    latest_variant_order_qty = (
+        OrderItem.objects.filter(product_variant=OuterRef("pk"))
+        .order_by("-date_expected", "-id")
+        .values("quantity")[:1]
+    )
 
     variants_qs = ProductVariant.objects.annotate(
-        latest_inventory=Coalesce(Subquery(latest_snapshot), 0)
+        latest_inventory=Coalesce(Subquery(latest_snapshot), 0),
+        total_sold=Coalesce(
+            Sum(F("sales__sold_quantity") - Coalesce(F("sales__return_quantity"), 0)),
+            0,
+            output_field=IntegerField(),
+        ),
+        total_ordered=Coalesce(Sum("order_items__quantity"), 0, output_field=IntegerField()),
+        previous_order_qty=Coalesce(Subquery(latest_variant_order_qty), 0),
     )
 
     # ─── Build product queryset ─────────────────────────────────────────────────
@@ -1111,6 +1123,10 @@ def _build_product_list_context(request, preset_filters=None):
                     SIZE_ORDER.get(variant.size, 9999),
                 )
             )
+        product.total_ordered = sum(
+            getattr(variant, "total_ordered", 0) or 0
+            for variant in product.variants_with_inventory
+        )
         product.low_stock_skus = [
             variant.size
             for variant in product.variants_with_inventory


### PR DESCRIPTION
### Motivation
- Make the Products list easier to review by replacing the confidence box with a compact review box showing stock/sales/order totals and an easy way to inspect variants. 
- Keep the existing filter bar and top-level statistics unchanged while changing only the product list presentation. 

### Description
- Removed the confidence/advisories block from the product scorecard and added a new review box that displays `Current Stock`, `Total Sold`, and `Total Ordered`, plus a clickable line `This product has X variants`. 
- Added a floating variant panel (HTML + CSS + JS) that opens when the variants line is clicked and lists each variant's size/code, `Stock`, `Sold`, and `Previous Order` quantities. 
- Annotated variant queryset in `_build_product_list_context` with `total_sold`, `total_ordered`, and `previous_order_qty` and computed `product.total_ordered` by summing variant `total_ordered` to back the UI values. 
- Added styling for the review box, variant trigger, and floating panel and wired small client-side toggles in the product list script to open/close panels. 

### Testing
- Ran `python manage.py check` in this environment and it failed because Django is not installed here (environment limitation). 
- No other automated tests were executed in the container; template/JS changes were added but not execution-tested due to the missing runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df43cadb10832c8530f5e39943d6c5)