### PR TITLE
Align product scorecard markup with Orders card framework

### DIFF
--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -1,148 +1,145 @@
 {% load inventory_extras %}
 
+{% for product in products %}
 
-  {% for product in products %}
-
-  <ul class="collection">
-    <li class="collection-item avatar lighten-4 {% if product.total_sales|default:0 == 0 and product.total_inventory|default:0 == 0 %}new{% endif %}">
-
-        <div class="row item">
-
-          <div class="col s12 content">
-            <div class="row title">
-              <div class="col s12">
-                <span class="title">
-                  <a href="{% url 'product_detail' product.id %}">
-                    <strong>{{ product.product_name }}</strong>
-                  </a>
-                </span>
-                ({{ product.product_id }})
-              </div>
-            </div>
-
-            <div class="row scorecard-boxes">
-
-              <div class="col s12 m6 l2 photo">
-                {% if product.product_photo %}
-                  <img src="{{ product.product_photo.url }}" alt="{{ product.product_name }}" class="circle product-photo-large">
-                {% else %}
-                  <img src="{{ MEDIA_URL }}product_photos/product-placeholder.jpg" alt="{{ product.product_name }}" class="circle product-photo-large">
-                {% endif %}
-              </div>
-
-      <!-- STATISTICS NEW SECTION -->
-      <div class="signal-grid">
-
-        <article class="signal-card">
-
-          <div class="signal-card__status-row">
-            <span class="signal-badge signal-badge--{{ product.status_signal|default:'monitor'|slugify }}">
-              {{ product.status_signal|default:"Monitor" }}
+<ul class="collection">
+  <li class="collection-item avatar lighten-4 {% if product.total_sales|default:0 == 0 and product.total_inventory|default:0 == 0 %}new{% endif %}">
+    <div class="row item">
+      <div class="col s12 content">
+        <div class="row title">
+          <div class="col s12">
+            <span class="title">
+              <a href="{% url 'product_detail' product.id %}">
+                <strong>{{ product.product_name }}</strong>
+              </a>
             </span>
+            ({{ product.product_id }})
           </div>
-
-          <div class="signal-card__metrics">
-          <p class="signal-line signal-line--stock">
-            <span class="signal-label">Stock</span>
-            <strong>{{ product.total_inventory|default:0 }} / {{ product.last_order_qty|default:0 }}</strong>
-            <span class="signal-muted">{{ product.total_sales|default:0 }} sold</span>
-          </p>
-
-          <div class="signal-progress-wrap">
-            <div class="signal-progress">
-              <span
-                class="signal-progress__fill"
-                style="width: {% if product.stock_remaining_pct is not None %}{{ product.stock_remaining_pct|floatformat:0 }}{% else %}0{% endif %}%; --stock-pct: {% if product.stock_remaining_pct is not None %}{{ product.stock_remaining_pct|floatformat:0 }}{% else %}0{% endif %};"
-              ></span>
-            </div>
-            <span class="signal-muted">
-              {% if product.stock_remaining_pct is not None %}
-                {{ product.stock_remaining_pct|floatformat:0 }}%
-              {% else %}
-                -
-              {% endif %}
-            </span>
-          </div>
-
-          <p class="signal-line">
-            <strong>
-              {% if product.time_on_market_months is not None %}
-                {{ product.time_on_market_months|floatformat:0 }}m
-              {% else %}
-                -
-              {% endif %}
-            </strong>
-            <span class="signal-muted">on market</span>
-          </p>
-
-          <p class="signal-line">
-            <span class="signal-label">Core Sizes</span>
-            {% for core in product.core_size_signals %}
-              <span class="signal-core {% if core.in_stock %}signal-core--ok{% else %}signal-core--miss{% endif %}">
-                {% if core.in_stock %}✔{% else %}✖{% endif %} {{ core.size }}
-              </span>
-            {% endfor %}
-          </p>
-
-          <button
-            type="button"
-            class="btn-flat signal-line signal-line--variants variant-summary-trigger"
-            data-variant-panel-trigger
-            data-product-id="{{ product.id }}"
-          >
-            Variants: {{ product.out_of_stock_variant_count|default:0 }} OOS · {{ product.low_stock_variant_count|default:0 }} Low
-          </button>
-
-          <div class="signal-splits">
-            <p class="signal-line"><span class="signal-label">Speed</span> <strong>{{ product.speed_signal|default:"Unknown" }}</strong></p>
-            <p class="signal-line"><span class="signal-label">Quality</span> <strong>{{ product.stock_quality_signal|default:"Mixed" }}</strong></p>
-          </div>
-
-          <p class="signal-line signal-line--secondary">
-            GM {{ product.profit_percentage|floatformat:0|default_if_none:"-" }}% ·
-            Disc {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
-          </p>
-          </div>
-        </article>
-      </div>
-    </section>
-
-    <!-- STATISTICS NEW SECTION -->
-
-    <div class="variant-panel" data-variant-panel="{{ product.id }}" aria-hidden="true">
-      <div class="variant-panel__backdrop" data-variant-panel-close></div>
-      <div class="variant-panel__content">
-        <div class="variant-panel__header">
-          <h6>{{ product.product_name }} variants</h6>
-          <button type="button" class="btn-flat" data-variant-panel-close>&times;</button>
         </div>
-        <div class="variant-panel__body">
-          <table class="striped responsive-table">
-            <thead>
-              <tr>
-                <th>Variant</th>
-                <th>Stock</th>
-                <th>Sold</th>
-                <th>Previous Order</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for variant in product.variants_with_inventory %}
-                <tr>
-                  <td>{{ variant.size|default:"—" }} <span class="grey-text">({{ variant.variant_code }})</span></td>
-                  <td>{{ variant.latest_inventory|default:0 }}</td>
-                  <td>{{ variant.total_sold|default:0 }}</td>
-                  <td>{{ variant.previous_order_qty|default:0 }}</td>
-                </tr>
-              {% empty %}
-                <tr>
-                  <td colspan="4" class="grey-text">No variants available.</td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
+
+        <div class="row scorecard-boxes">
+          <div class="col s12 m6 l2 photo">
+            {% if product.product_photo %}
+              <img src="{{ product.product_photo.url }}" alt="{{ product.product_name }}" class="circle product-photo-large">
+            {% else %}
+              <img src="{{ MEDIA_URL }}product_photos/product-placeholder.jpg" alt="{{ product.product_name }}" class="circle product-photo-large">
+            {% endif %}
+          </div>
+
+          <!-- STATISTICS NEW SECTION -->
+          <div class="col s12 m6 l10">
+            <div class="card-panel scorecard-box signal-card">
+              <div class="signal-card__status-row">
+                <span class="signal-badge signal-badge--{{ product.status_signal|default:'monitor'|slugify }}">
+                  {{ product.status_signal|default:"Monitor" }}
+                </span>
+              </div>
+
+              <div class="signal-card__metrics">
+                <p class="signal-line signal-line--stock">
+                  <span class="signal-label">Stock</span>
+                  <strong>{{ product.total_inventory|default:0 }} / {{ product.last_order_qty|default:0 }}</strong>
+                  <span class="signal-muted">{{ product.total_sales|default:0 }} sold</span>
+                </p>
+
+                <div class="signal-progress-wrap">
+                  <div class="signal-progress">
+                    <span
+                      class="signal-progress__fill"
+                      style="width: {% if product.stock_remaining_pct is not None %}{{ product.stock_remaining_pct|floatformat:0 }}{% else %}0{% endif %}%; --stock-pct: {% if product.stock_remaining_pct is not None %}{{ product.stock_remaining_pct|floatformat:0 }}{% else %}0{% endif %};"
+                    ></span>
+                  </div>
+                  <span class="signal-muted">
+                    {% if product.stock_remaining_pct is not None %}
+                      {{ product.stock_remaining_pct|floatformat:0 }}%
+                    {% else %}
+                      -
+                    {% endif %}
+                  </span>
+                </div>
+
+                <p class="signal-line">
+                  <strong>
+                    {% if product.time_on_market_months is not None %}
+                      {{ product.time_on_market_months|floatformat:0 }}m
+                    {% else %}
+                      -
+                    {% endif %}
+                  </strong>
+                  <span class="signal-muted">on market</span>
+                </p>
+
+                <p class="signal-line">
+                  <span class="signal-label">Core Sizes</span>
+                  {% for core in product.core_size_signals %}
+                    <span class="signal-core {% if core.in_stock %}signal-core--ok{% else %}signal-core--miss{% endif %}">
+                      {% if core.in_stock %}✔{% else %}✖{% endif %} {{ core.size }}
+                    </span>
+                  {% endfor %}
+                </p>
+
+                <button
+                  type="button"
+                  class="btn-flat signal-line signal-line--variants variant-summary-trigger"
+                  data-variant-panel-trigger
+                  data-product-id="{{ product.id }}"
+                >
+                  Variants: {{ product.out_of_stock_variant_count|default:0 }} OOS · {{ product.low_stock_variant_count|default:0 }} Low
+                </button>
+
+                <div class="signal-splits">
+                  <p class="signal-line"><span class="signal-label">Speed</span> <strong>{{ product.speed_signal|default:"Unknown" }}</strong></p>
+                  <p class="signal-line"><span class="signal-label">Quality</span> <strong>{{ product.stock_quality_signal|default:"Mixed" }}</strong></p>
+                </div>
+
+                <p class="signal-line signal-line--secondary">
+                  GM {{ product.profit_percentage|floatformat:0|default_if_none:"-" }}% ·
+                  Disc {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
+                </p>
+              </div>
+            </div>
+          </div>
+          <!-- STATISTICS NEW SECTION -->
         </div>
       </div>
     </div>
-  {% endfor %}
+  </li>
+</ul>
+
+<div class="variant-panel" data-variant-panel="{{ product.id }}" aria-hidden="true">
+  <div class="variant-panel__backdrop" data-variant-panel-close></div>
+  <div class="variant-panel__content">
+    <div class="variant-panel__header">
+      <h6>{{ product.product_name }} variants</h6>
+      <button type="button" class="btn-flat" data-variant-panel-close>&times;</button>
+    </div>
+    <div class="variant-panel__body">
+      <table class="striped responsive-table">
+        <thead>
+          <tr>
+            <th>Variant</th>
+            <th>Stock</th>
+            <th>Sold</th>
+            <th>Previous Order</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for variant in product.variants_with_inventory %}
+            <tr>
+              <td>{{ variant.size|default:"—" }} <span class="grey-text">({{ variant.variant_code }})</span></td>
+              <td>{{ variant.latest_inventory|default:0 }}</td>
+              <td>{{ variant.total_sold|default:0 }}</td>
+              <td>{{ variant.previous_order_qty|default:0 }}</td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td colspan="4" class="grey-text">No variants available.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
 </div>
+
+{% endfor %}


### PR DESCRIPTION
### Motivation
- Ensure the Products filtered list uses the same HTML framework and Materialize styling as the Orders product cards for consistent visuals.
- Keep the existing white-box statistics content (stock bar, badge, core sizes, variants summary, speed/quality, GM/discount) while restoring the established layout and classes.
- Fix HTML nesting and stray/mismatched tags that were introduced during prior edits so the template renders cleanly and the variant panel remains functional.

### Description
- Refactored `inventory/templates/inventory/snippets/product_scorecard.html` to mirror the `row`/`col` grid and `card-panel scorecard-box` pattern used by `product_card.html`. 
- Replaced the ad-hoc `signal-grid`/`article` wrapper with a `col s12 m6 l10` container and a `card-panel scorecard-box signal-card` to restore shared styling. 
- Preserved all statistic elements (status badge, stock metrics and progress bar, time on market, core sizes, variant summary trigger, speed/quality, GM/discount) without altering their templating logic. 
- Cleaned up HTML structure and balanced closing tags around the scorecard and the `variant-panel` to avoid broken markup.

### Testing
- Ran `python manage.py check` in this environment and it failed to run because Django is not installed (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9ee6b374832cb65e4f536bb86b14)