### PR TITLE
Add compact top-line category stats summary on Products page

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -345,6 +345,22 @@
 
   <!-- CATEGORY STATISTICS SECTION -->
   <div class="row">
+    <div class="col s12">
+      <div class="card-panel" style="padding: 16px 20px;">
+        <p style="margin: 0 0 8px; font-size: 1.1rem;">
+          <strong>{{ filtered_inventory_total }}</strong> items of stock in this category
+          |
+          Cost <strong>¥{{ inventory_value_total|floatformat:"0g" }}</strong>
+          |
+          Retail Value <strong>¥{{ inventory_value_total|floatformat:"0g" }}</strong>
+        </p>
+        <p style="margin: 0; font-size: 1.1rem;">
+          <strong>{{ sales_last_year_total }}</strong> items sold in the last 12 months from this category
+          |
+          Sales value <strong>¥{{ sales_last_year_value_total|floatformat:"0g" }}</strong>
+        </p>
+      </div>
+    </div>
 
     <!-- SALES SECTION -->
     <div class="col s12 m4">


### PR DESCRIPTION
### Motivation
- Present a compact, easy-to-scan summary of category-level Past Sales and Current Stock at the top of the existing CATEGORY STATISTICS SECTION using already-computed view values.

### Description
- Inserted a two-line summary card into `inventory/templates/inventory/product_filtered_list.html` that displays `filtered_inventory_total`, `inventory_value_total` (used for both Cost and Retail Value currently), `sales_last_year_total`, and `sales_last_year_value_total` without altering other page areas.

### Testing
- Ran `python manage.py check` in this environment and it failed because Django is not installed, so no Django checks could complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfed6e7cbc832cb0fdf2d187a7ebed)