### PR TITLE
Simplify Time on Market statistics display

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -494,7 +494,6 @@
                     <span class="teal-text text-darken-2">{{ entry.percent }}%</span>
                   {% endif %}
                 </div>
-                <p class="grey-text text-darken-1" style="margin: 4px 0 0;">{{ entry.message }}</p>
               </li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
### Motivation
- The Time on market statistics should only show the category label and the percentage, not the descriptive message for individual items to reduce visual clutter.

### Description
- Removed the secondary descriptive line (`{{ entry.message }}`) from each row in the Time on market card in `inventory/templates/inventory/product_filtered_list.html` so only the label and percent remain.

### Testing
- Verified the change with `git diff -- inventory/templates/inventory/product_filtered_list.html` and inspected the updated lines with `nl -ba inventory/templates/inventory/product_filtered_list.html | sed -n '482,506p'`, both commands succeeded; no unit tests were required for this template-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff37e7a04832c92e2cc165e2c0814)