### PR TITLE
Make referrer assignment modal a vertical, larger-font list

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -1118,12 +1118,16 @@ vertical-align: middle;
 
 .referrer-chip-group {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 0.5rem;
+  align-items: flex-start;
 }
 
 .referrer-chip {
   cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1.4;
+  padding: 0.45rem 0.8rem;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 


### PR DESCRIPTION
### Motivation
- Improve scanning and selection in the "Assign referrer" modal by switching the referrer options from a horizontal/wrapping chip layout to a vertical list and increasing the option text size and spacing for readability.

### Description
- Updated CSS in `inventory/static/styles.css` to change `.referrer-chip-group` from a wrapping row to a column (`flex-direction: column; align-items: flex-start;`) and to increase `.referrer-chip` `font-size`, `line-height`, and `padding` so items render as a larger vertical list.

### Testing
- Ran `python manage.py check` in the workspace and it failed because Django is not installed in this environment, so no Django checks could be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e096ec386c832c89aabb62b19f0327)