### PR TITLE
Add assign-referrers UI, views, URL routes, and tests for discount-range assignment

### DIFF
--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -47,6 +47,12 @@
         >
           View sales by referrer <span aria-hidden="true">→</span>
         </a>
+        <a
+          href="{% url 'sales_assign_referrers' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+          class="filter-toolbar__link"
+        >
+          Assign referrers <span aria-hidden="true">→</span>
+        </a>
         {% if referrers %}
           <div class="filter-toolbar__field referrer-detail-selector">
             <label for="referrerDetailSelect" class="active">Referrer detail</label>

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -1,0 +1,315 @@
+{% extends 'inventory/base.html' %}
+
+{% block title %}Assign Referrers{% endblock %}
+
+{% block content %}
+  <div class="section">
+    <h3>
+      Assign referrers
+      <span class="grey-text small">
+        | Discounted {{ min_discount }}%–{{ max_discount }}% from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}
+      </span>
+    </h3>
+
+    <div class="card-panel filter-toolbar">
+      <form method="get" novalidate class="filter-toolbar__form">
+        <div class="filter-toolbar__field">
+          <label for="start_date" class="active">From</label>
+          <input type="date" id="start_date" name="start_date" value="{{ start_date|date:'Y-m-d' }}" class="browser-default" />
+        </div>
+        <div class="filter-toolbar__field">
+          <label for="end_date" class="active">To</label>
+          <input type="date" id="end_date" name="end_date" value="{{ end_date|date:'Y-m-d' }}" class="browser-default" />
+        </div>
+        <div class="filter-toolbar__field" style="min-width: 280px;">
+          <label class="active">Discount range: <strong id="discountRangeLabel">{{ min_discount }}%–{{ max_discount }}%</strong></label>
+          <input type="range" id="min_discount" name="min_discount" min="0" max="100" value="{{ min_discount }}" />
+          <input type="range" id="max_discount" name="max_discount" min="0" max="100" value="{{ max_discount }}" />
+        </div>
+        <div class="filter-toolbar__actions">
+          <button type="submit" class="btn-tiny waves-effect waves-light">Update</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="card-panel grey lighten-4 page-summary">
+      <div class="page-summary__primary">
+        <a href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}" class="page-summary__back-link">
+          ← Back to sales overview
+        </a>
+      </div>
+      <div class="page-summary__stats">
+        <span class="page-summary__stat"><strong>{{ orders_count }}</strong> order{{ orders_count|pluralize }}</span>
+        <span class="page-summary__stat"><strong>{{ summary_totals.items_count }}</strong> item{{ summary_totals.items_count|pluralize }}</span>
+        <span class="page-summary__stat">Retail: ¥{{ summary_totals.retail_value|floatformat:2 }}</span>
+        <span class="page-summary__stat">Actual: ¥{{ summary_totals.actual_value|floatformat:2 }}</span>
+      </div>
+    </div>
+
+    {% if orders %}
+      {% for order in orders %}
+        <div class="order-block" data-order-number="{{ order.order_number }}">
+          <div class="order-header">
+            <div class="left">
+              <span class="order-number">#{{ order.order_number }}</span>
+              <span class="order-date">· {{ order.date|date:"F j, Y" }}</span>
+            </div>
+
+            <div class="right">
+              <div class="order-referrer">
+                {% if order.referrer %}
+                  <span class="chip teal lighten-5 teal-text text-darken-3">
+                    Referrer: {{ order.referrer.name }}
+                    <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger assign-referrer-link">
+                      <i class="material-icons tiny">edit</i>
+                    </a>
+                  </span>
+                {% else %}
+                  <a href="#referrer-modal-{{ forloop.counter }}" class="chip white modal-trigger assign-referrer-link">
+                    Assign referrer +
+                  </a>
+                {% endif %}
+                <button
+                  type="button"
+                  class="btn-flat red-text text-darken-2 ignore-order-button"
+                  data-order-number="{{ order.order_number }}"
+                >
+                  Ignore
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <table class="highlight order-items-table">
+            <thead>
+              <tr>
+                <th>Item</th>
+                <th></th>
+                <th>Original price</th>
+                <th>Actual price</th>
+                <th>Total paid</th>
+                <th>Refunded</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in order.items %}
+                <tr class="{% if not item.is_filtered_item %}grey-text text-lighten-1{% endif %}">
+                  <td>
+                    <div class="order-item-product">
+                      {% if item.sale.variant.product.product_photo %}
+                        <img src="{{ item.sale.variant.product.product_photo.url }}" alt="{{ item.sale.variant.product.product_name }}" />
+                      {% else %}
+                        <div class="order-item-placeholder">No photo</div>
+                      {% endif %}
+                      <div>
+                        <div class="variant-code">
+                          {{ item.sale.variant.variant_code }}
+                          <a
+                            href="{% url 'admin:inventory_sale_change' item.sale.pk %}"
+                            class="variant-edit-link"
+                            target="_blank"
+                            rel="noopener"
+                            title="Edit sale in admin"
+                            aria-label="Edit sale {{ item.sale.sale_id }} in admin"
+                          >
+                            <i class="material-icons tiny">edit</i>
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>x{{ item.sold_quantity }}</td>
+                  <td>¥{{ item.retail_price|floatformat:2 }}</td>
+                  <td>
+                    <div class="price-with-discount">
+                      <span class="actual-price">¥{{ item.actual_unit_price|floatformat:2 }}</span>
+                      {% if item.discount_percentage is not None %}
+                        <span class="discount-percentage grey-text text-darken-1">
+                          -{{ item.discount_percentage|floatformat:-1 }}%
+                        </span>
+                      {% endif %}
+                    </div>
+                  </td>
+                  <td>¥{{ item.actual_total|floatformat:2 }}</td>
+                  <td>
+                    {% if item.return_value %}
+                      <span class="red-text text-darken-2">¥{{ item.return_value|floatformat:2 }} (x{{ item.return_quantity }})</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if item.returned %}
+                      <span class="chip return-chip red lighten-5 red-text text-darken-2">Returned</span>
+                    {% else %}
+                      &mdash;
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+              <tr>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td><strong>TOTAL</strong></td>
+                <td><span class="order-total">¥{{ order.total_value|floatformat:2 }}</span></td>
+                <td>
+                  {% if order.returns_value %}
+                    <span class="order-returns red-text text-darken-1">-¥{{ order.returns_value|floatformat:2 }}</span>
+                  {% endif %}
+                </td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div id="referrer-modal-{{ forloop.counter }}" class="modal">
+            <form method="post" action="{% url 'assign_order_referrer_discount_range' %}">
+              {% csrf_token %}
+              <input type="hidden" name="order_number" value="{{ order.order_number }}" />
+              {% if date_querystring %}
+                <input type="hidden" name="date_querystring" value="{{ date_querystring }}" />
+              {% endif %}
+              <div class="modal-content">
+                <h4>Assign referrer</h4>
+                <input type="hidden" name="referrer_id" value="{% if order.referrer %}{{ order.referrer.id }}{% endif %}" />
+                <div class="referrer-chip-group">
+                  <div class="chip referrer-chip {% if not order.referrer %}selected{% endif %}" data-referrer-id="" tabindex="0">
+                    No referrer
+                  </div>
+                  {% for referrer in referrers %}
+                    <div class="chip referrer-chip {% if order.referrer and order.referrer.id == referrer.id %}selected{% endif %}" data-referrer-id="{{ referrer.id }}" tabindex="0">
+                      {{ referrer.name }}
+                    </div>
+                  {% endfor %}
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button type="submit" class="btn waves-effect waves-light">Save</button>
+                <a href="#!" class="modal-close btn-flat">Cancel</a>
+              </div>
+            </form>
+          </div>
+        </div>
+      {% endfor %}
+    {% else %}
+      <p class="grey-text text-darken-1 no-data-message">
+        No orders matched this discount range for the selected date range.
+      </p>
+    {% endif %}
+  </div>
+{% endblock %}
+
+{% block extrajs %}
+  {{ block.super }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var getCookie = function(name) {
+        var value = '; ' + document.cookie;
+        var parts = value.split('; ' + name + '=');
+        if (parts.length === 2) {
+          return parts.pop().split(';').shift();
+        }
+        return '';
+      };
+
+      var modalElems = document.querySelectorAll('.modal');
+      M.Modal.init(modalElems);
+
+      var chipGroups = document.querySelectorAll('.referrer-chip-group');
+      chipGroups.forEach(function(group) {
+        var chips = group.querySelectorAll('.referrer-chip');
+        var form = group.closest('form');
+        if (!chips.length || !form) {
+          return;
+        }
+
+        var hiddenInput = form.querySelector('input[name="referrer_id"]');
+        var setActiveChip = function(targetChip) {
+          chips.forEach(function(chip) {
+            chip.classList.remove('selected');
+          });
+          targetChip.classList.add('selected');
+          if (hiddenInput) {
+            hiddenInput.value = targetChip.dataset.referrerId || '';
+          }
+        };
+
+        chips.forEach(function(chip) {
+          chip.addEventListener('click', function() {
+            setActiveChip(chip);
+          });
+          chip.addEventListener('keydown', function(event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              setActiveChip(chip);
+            }
+          });
+        });
+      });
+
+      var minInput = document.getElementById('min_discount');
+      var maxInput = document.getElementById('max_discount');
+      var label = document.getElementById('discountRangeLabel');
+
+      var updateLabel = function() {
+        if (!minInput || !maxInput || !label) {
+          return;
+        }
+
+        var minVal = parseInt(minInput.value || '0', 10);
+        var maxVal = parseInt(maxInput.value || '0', 10);
+        if (minVal > maxVal) {
+          var temp = minVal;
+          minVal = maxVal;
+          maxVal = temp;
+        }
+        label.textContent = minVal + '%–' + maxVal + '%';
+      };
+
+      if (minInput && maxInput) {
+        minInput.addEventListener('input', updateLabel);
+        maxInput.addEventListener('input', updateLabel);
+      }
+      updateLabel();
+
+      var ignoreButtons = document.querySelectorAll('.ignore-order-button');
+      ignoreButtons.forEach(function(button) {
+        button.addEventListener('click', function() {
+          var orderNumber = button.dataset.orderNumber || '';
+          if (!orderNumber || button.disabled) {
+            return;
+          }
+
+          button.disabled = true;
+          fetch("{% url 'ignore_order_referrer_discount_range' %}", {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+              'X-CSRFToken': getCookie('csrftoken'),
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: new URLSearchParams({ order_number: orderNumber }).toString(),
+          })
+            .then(function(response) {
+              if (!response.ok) {
+                throw new Error('Request failed');
+              }
+              return response.json();
+            })
+            .then(function(data) {
+              if (!data.ok) {
+                throw new Error(data.error || 'Unable to ignore order');
+              }
+              var orderBlock = button.closest('.order-block');
+              if (orderBlock) {
+                orderBlock.remove();
+              }
+            })
+            .catch(function() {
+              button.disabled = false;
+            });
+        });
+      });
+    });
+  </script>
+{% endblock %}

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -978,6 +978,141 @@ class SalesViewTests(TestCase):
         self.assertIsNone(sale_one.referrer)
         self.assertIsNone(sale_two.referrer)
 
+    def test_assign_referrers_view_defaults_to_ten_to_fifty_discount(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+
+        Sale.objects.create(
+            order_number="IN-RANGE",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),  # 20%
+        )
+        Sale.objects.create(
+            order_number="OUT-LOW",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("95.00"),  # 5%
+        )
+        Sale.objects.create(
+            order_number="OUT-HIGH",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("40.00"),  # 60%
+        )
+
+        response = self.client.get(
+            reverse("sales_assign_referrers"),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["min_discount"], 10)
+        self.assertEqual(response.context["max_discount"], 50)
+        self.assertEqual(response.context["orders_count"], 1)
+        self.assertEqual(response.context["orders"][0]["order_number"], "IN-RANGE")
+
+    def test_assign_referrer_discount_range_updates_all_sales(self):
+        referrer = Referrer.objects.create(name="Referrer A")
+        first_sale = Sale.objects.create(
+            order_number="ASSIGN-RANGE",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("90.00"),
+        )
+        second_sale = Sale.objects.create(
+            order_number="ASSIGN-RANGE",
+            date=date(2024, 4, 6),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+        )
+
+        response = self.client.post(
+            reverse("assign_order_referrer_discount_range"),
+            {
+                "order_number": "ASSIGN-RANGE",
+                "referrer_id": str(referrer.id),
+                "date_querystring": "start_date=2024-04-01&end_date=2024-04-30&min_discount=10&max_discount=50",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            f"{reverse('sales_assign_referrers')}?start_date=2024-04-01&end_date=2024-04-30&min_discount=10&max_discount=50",
+        )
+
+        first_sale.refresh_from_db()
+        second_sale.refresh_from_db()
+        self.assertEqual(first_sale.referrer, referrer)
+        self.assertEqual(second_sale.referrer, referrer)
+
+    def test_assign_referrers_view_excludes_orders_marked_no_referrer(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        no_referrer = Referrer.objects.create(name="no_referrer")
+
+        Sale.objects.create(
+            order_number="VISIBLE",
+            date=date(2024, 4, 7),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+        )
+        Sale.objects.create(
+            order_number="IGNORED",
+            date=date(2024, 4, 7),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+            referrer=no_referrer,
+        )
+
+        response = self.client.get(
+            reverse("sales_assign_referrers"),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        order_numbers = [order["order_number"] for order in response.context["orders"]]
+        self.assertEqual(order_numbers, ["VISIBLE"])
+        self.assertEqual(list(response.context["referrers"]), [])
+
+    def test_ignore_order_endpoint_sets_no_referrer(self):
+        no_referrer = Referrer.objects.create(name="no_referrer")
+        sale_one = Sale.objects.create(
+            order_number="IGNORE-1",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("90.00"),
+        )
+        sale_two = Sale.objects.create(
+            order_number="IGNORE-1",
+            date=date(2024, 4, 11),
+            variant=self.variant,
+            sold_quantity=2,
+            sold_value=Decimal("150.00"),
+        )
+
+        response = self.client.post(
+            reverse("ignore_order_referrer_discount_range"),
+            {"order_number": "IGNORE-1"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["ok"], True)
+
+        sale_one.refresh_from_db()
+        sale_two.refresh_from_db()
+        self.assertEqual(sale_one.referrer, no_referrer)
+        self.assertEqual(sale_two.referrer, no_referrer)
+
 
 class SalesBucketDetailViewTests(TestCase):
     def setUp(self):

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -23,6 +23,17 @@ urlpatterns = [
     path('sales/referrers/', views.sales_referrers, name='sales_referrers'),
     path('sales/referrers/overview/', views.referrers_overview, name='referrers_overview'),
     path('sales/referrers/<int:referrer_id>/', views.referrer_detail, name='referrer_detail'),
+    path('sales/assign-referrers/', views.sales_assign_referrers, name='sales_assign_referrers'),
+    path(
+        'sales/assign-referrers/assign/',
+        views.assign_order_referrer_discount_range,
+        name='assign_order_referrer_discount_range',
+    ),
+    path(
+        'sales/assign-referrers/ignore/',
+        views.ignore_order_referrer_discount_range,
+        name='ignore_order_referrer_discount_range',
+    ),
     path('sales/price-group/<str:bucket_key>/', views.sales_bucket_detail, name='sales_bucket_detail'),
     path(
         'sales/price-group/<str:bucket_key>/assign-referrer/',

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -284,6 +284,36 @@ def _determine_price_bucket(sale) -> Optional[str]:
     return "wholesale"
 
 
+def _calculate_sale_discount_percentage(sale) -> Optional[Decimal]:
+    sold_quantity = sale.sold_quantity or 0
+    if sold_quantity <= 0:
+        return None
+
+    retail_price = sale.variant.product.retail_price or Decimal("0")
+    if retail_price <= 0:
+        return None
+
+    actual_total = sale.sold_value or Decimal("0")
+    if not actual_total:
+        refund_value = sale.return_value or Decimal("0")
+        if refund_value:
+            actual_total = abs(refund_value)
+
+    actual_unit_price = actual_total / sold_quantity
+    discount_percentage = ((retail_price - actual_unit_price) / retail_price) * Decimal(
+        "100"
+    )
+    return discount_percentage.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _parse_discount_percent(param: Optional[str], default: int) -> int:
+    try:
+        value = int(param) if param is not None else default
+    except (TypeError, ValueError):
+        value = default
+    return min(100, max(0, value))
+
+
 # — Helper to bucket types into our four categories —
 def _simplify_type(type_code):
     tc = (type_code or "").lower()
@@ -4977,14 +5007,7 @@ def referrer_detail(request, referrer_id: int):
                     actual_total / sold_quantity if sold_quantity else Decimal("0")
                 )
 
-                discount_percentage = None
-                if retail_price > 0 and sold_quantity > 0:
-                    discount_percentage = (
-                        (retail_price - actual_unit_price) / retail_price
-                    ) * Decimal("100")
-                    discount_percentage = discount_percentage.quantize(
-                        Decimal("0.01"), rounding=ROUND_HALF_UP
-                    )
+                discount_percentage = _calculate_sale_discount_percentage(sale)
 
                 order_total += actual_total
                 returns_total += return_value
@@ -5325,6 +5348,249 @@ def assign_order_referrer(request, bucket_key: str):
         redirect_url = f"{redirect_url}?{date_querystring}"
 
     return redirect(redirect_url)
+
+
+def sales_assign_referrers(request):
+    start_date, end_date = _get_sales_date_range(request)
+    min_discount = _parse_discount_percent(request.GET.get("min_discount"), default=10)
+    max_discount = _parse_discount_percent(request.GET.get("max_discount"), default=50)
+    if min_discount > max_discount:
+        min_discount, max_discount = max_discount, min_discount
+
+    sales_qs = Sale.objects.filter(date__range=(start_date, end_date))
+
+    ignored_order_numbers = set(
+        sales_qs.filter(referrer__name__iexact="no_referrer").values_list(
+            "order_number", flat=True
+        )
+    )
+
+    eligible_sales = (
+        sales_qs.filter(Q(return_quantity__isnull=True) | Q(return_quantity=0))
+        .filter(sold_quantity__gt=0)
+        .select_related("variant__product", "referrer")
+    )
+
+    filtered_sales = []
+    filtered_sale_ids = set()
+    orders_meta = {}
+    total_items = 0
+    total_retail_value = Decimal("0")
+    total_actual_value = Decimal("0")
+
+    min_discount_decimal = Decimal(str(min_discount))
+    max_discount_decimal = Decimal(str(max_discount))
+
+    for sale in eligible_sales:
+        if sale.order_number in ignored_order_numbers:
+            continue
+
+        discount_percentage = _calculate_sale_discount_percentage(sale)
+        if discount_percentage is None:
+            continue
+        if discount_percentage < min_discount_decimal or discount_percentage > max_discount_decimal:
+            continue
+
+        filtered_sales.append(sale)
+        filtered_sale_ids.add(sale.pk)
+
+        order_info = orders_meta.get(sale.order_number)
+        if not order_info:
+            order_info = {
+                "order_number": sale.order_number,
+                "date": sale.date,
+                "referrer": sale.referrer,
+            }
+            orders_meta[sale.order_number] = order_info
+        else:
+            if sale.date and (not order_info["date"] or sale.date > order_info["date"]):
+                order_info["date"] = sale.date
+            if not order_info.get("referrer") and sale.referrer:
+                order_info["referrer"] = sale.referrer
+
+        retail_price = sale.variant.product.retail_price or Decimal("0")
+        sold_quantity = sale.sold_quantity or 0
+        actual_total = sale.sold_value or Decimal("0")
+
+        total_items += sold_quantity
+        total_retail_value += retail_price * sold_quantity
+        total_actual_value += actual_total
+
+    orders = []
+
+    if orders_meta:
+        order_numbers = [number for number in orders_meta.keys() if number is not None]
+        include_null_orders = any(number is None for number in orders_meta.keys())
+
+        filters = []
+        if order_numbers:
+            filters.append(Q(order_number__in=order_numbers))
+        if include_null_orders:
+            filters.append(Q(order_number__isnull=True))
+
+        all_order_sales = []
+        if filters:
+            order_filter = filters[0]
+            for clause in filters[1:]:
+                order_filter |= clause
+            all_order_sales = list(sales_qs.filter(order_filter).select_related("variant__product", "referrer"))
+
+        sales_by_order = defaultdict(list)
+        for sale in all_order_sales:
+            sales_by_order[sale.order_number].append(sale)
+
+        filtered_sales_by_order = defaultdict(list)
+        for sale in filtered_sales:
+            filtered_sales_by_order[sale.order_number].append(sale)
+
+        def sale_sort_key(sale_obj):
+            return (sale_obj.date or date.min, sale_obj.sale_id or "", sale_obj.pk or 0)
+
+        for order_number, meta in orders_meta.items():
+            order_sales = list(sales_by_order.get(order_number, []))
+            if not order_sales:
+                order_sales = list(filtered_sales_by_order.get(order_number, []))
+            if not order_sales:
+                continue
+
+            order_sales.sort(key=sale_sort_key, reverse=True)
+
+            order_total = Decimal("0")
+            returns_total = Decimal("0")
+            retail_total = Decimal("0")
+            latest_date = meta["date"]
+            referrer = meta.get("referrer")
+            items = []
+
+            for sale in order_sales:
+                if sale.date and latest_date:
+                    if sale.date > latest_date:
+                        latest_date = sale.date
+                elif sale.date and not latest_date:
+                    latest_date = sale.date
+
+                if not referrer and sale.referrer:
+                    referrer = sale.referrer
+
+                retail_price = sale.variant.product.retail_price or Decimal("0")
+                sold_quantity = sale.sold_quantity or 0
+                actual_total = sale.sold_value or Decimal("0")
+                return_value = sale.return_value or Decimal("0")
+                return_quantity = sale.return_quantity or 0
+
+                actual_unit_price = (
+                    actual_total / sold_quantity if sold_quantity else Decimal("0")
+                )
+
+                order_total += actual_total
+                returns_total += return_value
+                retail_total += retail_price * sold_quantity
+
+                items.append(
+                    {
+                        "sale": sale,
+                        "retail_price": retail_price,
+                        "actual_unit_price": actual_unit_price,
+                        "actual_total": actual_total,
+                        "sold_quantity": sold_quantity,
+                        "returned": bool(return_quantity) or bool(return_value),
+                        "return_quantity": return_quantity,
+                        "return_value": return_value,
+                        "is_filtered_item": sale.pk in filtered_sale_ids,
+                        "discount_percentage": _calculate_sale_discount_percentage(sale),
+                    }
+                )
+
+            orders.append(
+                {
+                    "order_number": order_number,
+                    "date": latest_date,
+                    "total_value": order_total,
+                    "returns_value": returns_total,
+                    "retail_total": retail_total,
+                    "referrer": referrer,
+                    "items": items,
+                }
+            )
+
+    orders.sort(key=lambda order: (order["date"] or date.min, order["order_number"] or ""), reverse=True)
+
+    date_querystring = urlencode(
+        {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "min_discount": min_discount,
+            "max_discount": max_discount,
+        }
+    )
+
+    return render(
+        request,
+        "inventory/sales_assign_referrers.html",
+        {
+            "start_date": start_date,
+            "end_date": end_date,
+            "orders": orders,
+            "orders_count": len(orders),
+            "summary_totals": {
+                "items_count": total_items,
+                "retail_value": total_retail_value,
+                "actual_value": total_actual_value,
+            },
+            "date_querystring": date_querystring,
+            "referrers": Referrer.objects.exclude(name__iexact="no_referrer").order_by(
+                "name"
+            ),
+            "min_discount": min_discount,
+            "max_discount": max_discount,
+        },
+    )
+
+
+@require_POST
+def assign_order_referrer_discount_range(request):
+    order_number = (request.POST.get("order_number") or "").strip()
+    if not order_number:
+        raise Http404("Missing order number")
+
+    sales_qs = Sale.objects.filter(order_number=order_number)
+    if not sales_qs.exists():
+        raise Http404("Order not found")
+
+    referrer_id = request.POST.get("referrer_id")
+    referrer = None
+    if referrer_id:
+        referrer = get_object_or_404(Referrer, pk=referrer_id)
+
+    sales_qs.update(referrer=referrer)
+
+    redirect_url = reverse("sales_assign_referrers")
+    date_querystring = request.POST.get("date_querystring")
+    if date_querystring:
+        redirect_url = f"{redirect_url}?{date_querystring}"
+
+    return redirect(redirect_url)
+
+
+@require_POST
+def ignore_order_referrer_discount_range(request):
+    order_number = (request.POST.get("order_number") or "").strip()
+    if not order_number:
+        return JsonResponse({"ok": False, "error": "Missing order number"}, status=400)
+
+    sales_qs = Sale.objects.filter(order_number=order_number)
+    if not sales_qs.exists():
+        return JsonResponse({"ok": False, "error": "Order not found"}, status=404)
+
+    no_referrer = Referrer.objects.filter(name__iexact="no_referrer").first()
+    if not no_referrer:
+        return JsonResponse(
+            {"ok": False, "error": "Referrer 'no_referrer' not found"},
+            status=400,
+        )
+
+    sales_qs.update(referrer=no_referrer)
+    return JsonResponse({"ok": True, "order_number": order_number})
 
 
 # a small helper to keep (date, change) pairs


### PR DESCRIPTION
### Motivation
- Provide a workflow for scanning sales within a discount range and assigning a referrer to all line items of an order in that range. 
- Allow marking orders as explicitly ignored (set to a special `no_referrer`) so they are excluded from future scans. 

### Description
- Added a new view `sales_assign_referrers` to filter sales by date and discount percentage, collect order-level metadata, and render a new template. 
- Implemented helper functions `_calculate_sale_discount_percentage` and `_parse_discount_percent` and reused the discount calculation in `referrer_detail`. 
- Added POST endpoints `assign_order_referrer_discount_range` and `ignore_order_referrer_discount_range` and corresponding URL routes in `urls.py`. 
- Introduced `inventory/templates/inventory/sales_assign_referrers.html` with client-side JS to select referrers (chip UI), adjust discount range sliders, open/save modals, and perform AJAX ignore requests. 
- Tied the new page into the existing sales toolbar by adding an "Assign referrers" link in `sales.html`. 
- Added tests in `inventory/tests.py` covering default discount range behavior, assigning a referrer across an order's sales, excluding orders marked `no_referrer`, and the ignore endpoint. 

### Testing
- Ran the inventory test suite with `./manage.py test inventory` which executed the updated `SalesViewTests` and the new tests `test_assign_referrers_view_defaults_to_ten_to_fifty_discount`, `test_assign_referrer_discount_range_updates_all_sales`, `test_assign_referrers_view_excludes_orders_marked_no_referrer`, and `test_ignore_order_endpoint_sets_no_referrer`, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09b7f6178832c92a8805b4237ce1d)