### PR TITLE
Add top referrers summary card on Sales page

### DIFF
--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -88,6 +88,30 @@
         </div>
       </div>
 
+      <div class="card-panel">
+        <h6 class="grey-text text-darken-2" style="margin-top: 0;">Top referrers</h6>
+        {% if top_referrers %}
+          <ul class="collection" style="margin-bottom: 12px;">
+            {% for row in top_referrers %}
+              <li class="collection-item">
+                <span>{{ row.referrer__name }}</span>
+                <span class="secondary-content">¥{{ row.total_sales|floatformat:2 }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="grey-text text-darken-1" style="margin-bottom: 12px;">
+            No referrer sales found for this date range.
+          </p>
+        {% endif %}
+        <a
+          href="{% url 'referrers_overview' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+          class="filter-toolbar__link"
+        >
+          See all <span aria-hidden="true">→</span>
+        </a>
+      </div>
+
       <div class="card-panel sales-insights-card">
         <div class="sales-insights__header">
           <div>

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -767,6 +767,40 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.context["net_sales_value"], Decimal("75"))
         self.assertTrue(response.context["has_sales_data"])
 
+    def test_sales_includes_top_five_referrers_by_value(self):
+        referrers = [
+            Referrer.objects.create(name="Alpha"),
+            Referrer.objects.create(name="Beta"),
+            Referrer.objects.create(name="Gamma"),
+            Referrer.objects.create(name="Delta"),
+            Referrer.objects.create(name="Epsilon"),
+            Referrer.objects.create(name="Zeta"),
+        ]
+
+        totals = [Decimal("500"), Decimal("420"), Decimal("300"), Decimal("200"), Decimal("100"), Decimal("50")]
+        for index, referrer in enumerate(referrers):
+            Sale.objects.create(
+                order_number=f"R{index}",
+                date=date(2024, 4, 10),
+                variant=self.variant,
+                referrer=referrer,
+                sold_quantity=1,
+                sold_value=totals[index],
+            )
+
+        with patch("inventory.views.now") as mock_now:
+            mock_now.return_value = timezone.make_aware(datetime(2024, 5, 15))
+            response = self.client.get(reverse("sales"))
+
+        self.assertEqual(response.status_code, 200)
+        top_referrers = response.context["top_referrers"]
+        self.assertEqual(len(top_referrers), 5)
+        self.assertEqual([row["referrer__name"] for row in top_referrers], ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"])
+        self.assertEqual(
+            [row["total_sales"] for row in top_referrers],
+            [Decimal("500"), Decimal("420"), Decimal("300"), Decimal("200"), Decimal("100")],
+        )
+
     def test_price_breakdown_categorises_sales(self):
         self.product.retail_price = Decimal("100")
         self.product.save(update_fields=["retail_price"])

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -4314,6 +4314,30 @@ def sales(request):
     returns_total_value = value_aggregates["returns_total"] or Decimal("0")
     net_sales_value = gross_sales_value - returns_total_value
 
+    top_referrers = list(
+        sales_qs.filter(referrer__isnull=False)
+        .values("referrer_id", "referrer__name")
+        .annotate(
+            total_sales=Coalesce(
+                Sum(
+                    ExpressionWrapper(
+                        Coalesce(
+                            F("sold_value"),
+                            Value(Decimal("0.00"), output_field=DecimalField()),
+                        )
+                        - Coalesce(
+                            F("return_value"),
+                            Value(Decimal("0.00"), output_field=DecimalField()),
+                        ),
+                        output_field=DecimalField(max_digits=12, decimal_places=2),
+                    )
+                ),
+                Value(Decimal("0.00"), output_field=DecimalField()),
+            )
+        )
+        .order_by("-total_sales", "referrer__name")[:5]
+    )
+
     if pricing_total_actual_value:
         for bucket in price_breakdown:
             percentage = (
@@ -4527,6 +4551,7 @@ def sales(request):
         "gross_sales_value": gross_sales_value,
         "net_sales_value": net_sales_value,
         "returns_total_value": returns_total_value,
+        "top_referrers": top_referrers,
         "date_querystring": date_querystring,
         "referrers": Referrer.objects.order_by("name"),
         "insights_start": insights_start,


### PR DESCRIPTION
### Motivation
- Surface the highest-value referrers on the Sales overview for the selected date range so users can quickly see who drives the most revenue and navigate to the full Referrer Overview.

### Description
- Add a `top_referrers` aggregation to the `sales` view that computes net sales per referrer (`sold_value - return_value`) using `ExpressionWrapper`/`Coalesce`, orders by `-total_sales`, and limits the result to 5 entries for the active date range.
- Inject `top_referrers` into the view `context` so templates can render the data.
- Render a new “Top referrers” card in `inventory/templates/inventory/sales.html` that lists the top 5 referrers with formatted totals and includes a `See all` link to the Referrer Overview while preserving `start_date`/`end_date` via the existing `date_querystring`.
- Add a unit test `test_sales_includes_top_five_referrers_by_value` to `SalesViewTests` that creates multiple `Referrer` and `Sale` records and asserts the `top_referrers` context contains exactly 5 entries ordered by value.

### Testing
- Ran `python -m compileall inventory/views.py inventory/templates/inventory/sales.html inventory/tests.py` which completed successfully.
- Attempted to run the focused test with `python -m pytest inventory/tests.py -k "SalesViewTests and top_five_referrers_by_value"`, but test collection failed in this environment due to a missing dependency (`python-dateutil`), so the new test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d2c165d0832c8aa22d2052936b5b)