### PR TITLE
Show top referrers on Sales page and exclude placeholder referrer

### DIFF
--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -88,6 +88,30 @@
         </div>
       </div>
 
+      <div class="card-panel">
+        <h6 class="grey-text text-darken-2" style="margin-top: 0;">Top referrers</h6>
+        {% if top_referrers %}
+          <ul class="collection" style="margin-bottom: 12px;">
+            {% for row in top_referrers %}
+              <li class="collection-item">
+                <span>{{ row.referrer__name }}</span>
+                <span class="secondary-content">¥{{ row.total_sales|floatformat:2 }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="grey-text text-darken-1" style="margin-bottom: 12px;">
+            No referrer sales found for this date range.
+          </p>
+        {% endif %}
+        <a
+          href="{% url 'referrers_overview' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+          class="filter-toolbar__link"
+        >
+          See all <span aria-hidden="true">→</span>
+        </a>
+      </div>
+
       <div class="card-panel sales-insights-card">
         <div class="sales-insights__header">
           <div>

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -767,6 +767,60 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.context["net_sales_value"], Decimal("75"))
         self.assertTrue(response.context["has_sales_data"])
 
+    def test_sales_includes_top_five_referrers_by_value(self):
+        no_referrer = Referrer.objects.create(name="no_referrer")
+        referrers = [
+            Referrer.objects.create(name="Alpha"),
+            Referrer.objects.create(name="Beta"),
+            Referrer.objects.create(name="Gamma"),
+            Referrer.objects.create(name="Delta"),
+            Referrer.objects.create(name="Epsilon"),
+            Referrer.objects.create(name="Zeta"),
+        ]
+
+        Sale.objects.create(
+            order_number="NO-REF",
+            date=date(2024, 4, 9),
+            variant=self.variant,
+            referrer=no_referrer,
+            sold_quantity=1,
+            sold_value=Decimal("999"),
+        )
+
+        totals = [
+            Decimal("500"),
+            Decimal("420"),
+            Decimal("300"),
+            Decimal("200"),
+            Decimal("100"),
+            Decimal("50"),
+        ]
+        for index, referrer in enumerate(referrers):
+            Sale.objects.create(
+                order_number=f"R{index}",
+                date=date(2024, 4, 10),
+                variant=self.variant,
+                referrer=referrer,
+                sold_quantity=1,
+                sold_value=totals[index],
+            )
+
+        with patch("inventory.views.now") as mock_now:
+            mock_now.return_value = timezone.make_aware(datetime(2024, 5, 15))
+            response = self.client.get(reverse("sales"))
+
+        self.assertEqual(response.status_code, 200)
+        top_referrers = response.context["top_referrers"]
+        self.assertEqual(len(top_referrers), 5)
+        self.assertEqual(
+            [row["referrer__name"] for row in top_referrers],
+            ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+        )
+        self.assertEqual(
+            [row["total_sales"] for row in top_referrers],
+            [Decimal("500"), Decimal("420"), Decimal("300"), Decimal("200"), Decimal("100")],
+        )
+
     def test_price_breakdown_categorises_sales(self):
         self.product.retail_price = Decimal("100")
         self.product.save(update_fields=["retail_price"])
@@ -1623,6 +1677,37 @@ class ReferrersOverviewViewTests(TestCase):
         rows = response.context["referrer_rows"]
         self.assertEqual(rows[0]["total_items"], 2)
         self.assertEqual(rows[0]["total_sales"], Decimal("160.00"))
+
+    def test_overview_excludes_no_referrer_row(self):
+        no_referrer = Referrer.objects.create(name="no_referrer")
+        Sale.objects.create(
+            order_number="NO-REF-100",
+            date=date(2024, 4, 3),
+            variant=self.variant,
+            sold_quantity=4,
+            sold_value=Decimal("400.00"),
+            referrer=no_referrer,
+        )
+        Sale.objects.create(
+            order_number="ALPHA-100",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            sold_quantity=2,
+            sold_value=Decimal("180.00"),
+            referrer=self.alpha,
+        )
+
+        response = self.client.get(
+            reverse("referrers_overview"),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        rows = response.context["referrer_rows"]
+        self.assertEqual([row["referrer"] for row in rows], [self.alpha, self.beta])
+        self.assertEqual(response.context["totals"]["sales"], Decimal("180.00"))
+
+
 class ReferrerDetailViewTests(TestCase):
     def setUp(self):
         self.product = Product.objects.create(

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -4314,6 +4314,31 @@ def sales(request):
     returns_total_value = value_aggregates["returns_total"] or Decimal("0")
     net_sales_value = gross_sales_value - returns_total_value
 
+    top_referrers = list(
+        sales_qs.filter(referrer__isnull=False)
+        .exclude(referrer__name__iexact="no_referrer")
+        .values("referrer_id", "referrer__name")
+        .annotate(
+            total_sales=Coalesce(
+                Sum(
+                    ExpressionWrapper(
+                        Coalesce(
+                            F("sold_value"),
+                            Value(Decimal("0.00"), output_field=DecimalField()),
+                        )
+                        - Coalesce(
+                            F("return_value"),
+                            Value(Decimal("0.00"), output_field=DecimalField()),
+                        ),
+                        output_field=DecimalField(max_digits=12, decimal_places=2),
+                    )
+                ),
+                Value(Decimal("0.00"), output_field=DecimalField()),
+            )
+        )
+        .order_by("-total_sales", "referrer__name")[:5]
+    )
+
     if pricing_total_actual_value:
         for bucket in price_breakdown:
             percentage = (
@@ -4527,6 +4552,7 @@ def sales(request):
         "gross_sales_value": gross_sales_value,
         "net_sales_value": net_sales_value,
         "returns_total_value": returns_total_value,
+        "top_referrers": top_referrers,
         "date_querystring": date_querystring,
         "referrers": Referrer.objects.order_by("name"),
         "insights_start": insights_start,
@@ -4710,7 +4736,9 @@ def referrers_overview(request):
 
     start_date, end_date = _get_sales_date_range(request)
 
-    referrers = list(Referrer.objects.order_by("name"))
+    referrers = list(
+        Referrer.objects.exclude(name__iexact="no_referrer").order_by("name")
+    )
 
     net_sales_expression = ExpressionWrapper(
         Coalesce("sold_value", Value(Decimal("0")))


### PR DESCRIPTION
### Motivation
- Surface the top-performing referrers on the Sales page to help quickly identify where revenue is coming from and omit a placeholder/referrer bucket named "no_referrer" from reports.

### Description
- Added computation of `top_referrers` in `sales` view by aggregating net sales per referrer (sold_value - return_value), excluding null referrers and case-insensitive `no_referrer`, and returning the top five ordered by value.
- Rendered a new "Top referrers" card in `inventory/templates/inventory/sales.html` that lists the top five referrers with their sales and links to the referrers overview with the current date range querystring.
- Updated `referrers_overview` to exclude referrers with name equal to `no_referrer` (case-insensitive) when building the referrer list.
- Added unit tests: `test_sales_includes_top_five_referrers_by_value` in `SalesViewTests` and `test_overview_excludes_no_referrer_row` in `ReferrersOverviewViewTests` to validate the new behavior.

### Testing
- Ran the inventory test suite with `./manage.py test inventory`; the test run completed and all tests (including the two new tests) passed.
- Confirmed the sales view returns `top_referrers` in the response context and the referrers overview excludes the placeholder referrer via the added unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d2c165d0832c8aa22d2052936b5b)