### PR TITLE
Align sales and assign-referrers filter bars with Products filter UI

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -681,64 +681,123 @@ div.metadata {
   padding: 0;
 }
 
+/* Shared filter bar styles (Products-style) */
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.filter-section-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin: 0 0 8px;
+}
+
+.filter-showing {
+  color: #546e7a;
+  font-weight: 600;
+  margin: 0;
+}
+
+.filter-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  box-shadow: none;
+  max-width: 100%;
+  min-width: 220px;
+  padding: 12px 16px 10px;
+}
+
+.filter-divider {
+  border-bottom: 1px solid #e0e0e0;
+  margin: 12px 0 20px;
+  padding-bottom: 8px;
+}
+
+.filter-apply-button {
+  background: #f5f5f5;
+  border: 1px solid #dcdcdc;
+  border-radius: 10px;
+  box-shadow: none;
+  color: #455a64;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 18px;
+  opacity: 1;
+  padding: 8px 8px;
+  text-transform: none;
+}
+
+.filter-card--compact {
+  flex: 1 1 220px;
+}
+
+.filter-card--actions {
+  align-items: flex-end;
+  display: flex;
+  justify-content: flex-end;
+}
+
 /* Sales pages */
 
 .filter-toolbar {
-  align-items: flex-end;
-  background-color: #f5f5f5;
-  border-radius: 0px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  justify-content: space-between;
-  margin-bottom: 1.5rem;
-  padding: 1rem 1.5rem;
+  background: transparent;
+  border: none;
+  border-radius: 0;
   box-shadow: none;
+  margin-bottom: 1.5rem;
+  padding: 0;
 }
 
 .filter-toolbar.card-panel {
   margin: 0 0 1.5rem;
-  padding: 1rem 1.5rem;
+  padding: 0;
 }
 
 .filter-toolbar__form {
-  align-items: flex-end;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
   margin: 0;
 }
 
 .filter-toolbar__field {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
-
+  gap: 0.35rem;
 }
 
-.filter-toolbar__field input {
-  font-size: 11px;
-  padding: 5px;
+.filter-toolbar__field input,
+.filter-toolbar__field select {
   border: 1px solid #e1e1e1;
+  font-size: 12px;
+  padding: 5px;
 }
 
 .filter-toolbar__field label {
   font-size: 0.85rem;
   font-weight: 600;
   margin: 0;
-  display:none;
+  display: block;
 }
 
 .filter-toolbar__actions {
-  align-items: center;
+  align-items: flex-end;
   display: flex;
-  gap: 0.75rem;
+  height: 100%;
+  justify-content: flex-end;
 }
 
-.filter-toolbar__actions  .btn-tiny {
-height: 25px;
-line-height: 20px;
-font-size: 11px;
+.filter-toolbar__actions .btn-tiny,
+.filter-toolbar__actions .btn-small {
+  border-radius: 10px;
+  box-shadow: none;
+  font-size: 12px;
+  height: auto;
+  line-height: 1.4;
+  text-transform: none;
 }
 
 .btn-tiny {
@@ -765,10 +824,10 @@ vertical-align: middle;
 }
 
 .filter-toolbar__aside {
-  align-self: flex-start;
   display: flex;
-  justify-content: flex-end;
-  min-width: 180px;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 260px;
 }
 
 .filter-toolbar__link {
@@ -777,7 +836,7 @@ vertical-align: middle;
   display: inline-flex;
   font-weight: 600;
   gap: 0.25rem;
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .filter-toolbar__link:hover,

--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -6,47 +6,61 @@
   <div class="section">
     <h3>Sales</h3>
 
+    <div class="filter-divider"></div>
     <div class="card-panel filter-toolbar">
       <form method="get" novalidate class="filter-toolbar__form">
-        <div class="filter-toolbar__field">
-          <label for="start_date" class="active">From</label>
-          <input
-            type="date"
-            id="start_date"
-            name="start_date"
-            value="{{ start_date|date:'Y-m-d' }}"
-            class="browser-default"
-          />
-        </div>
-        <div class="filter-toolbar__field">
-          <label for="end_date" class="active">To</label>
-          <input
-            type="date"
-            id="end_date"
-            name="end_date"
-            value="{{ end_date|date:'Y-m-d' }}"
-            class="browser-default"
-          />
-        </div>
-        <div class="filter-toolbar__actions">
-          <button type="submit" class="btn-tiny waves-effect waves-light">
+        <div class="filter-section-header">
+          <p class="filter-showing">
+            Showing: {{ start_date|date:"M j, Y" }} to {{ end_date|date:"M j, Y" }}
+          </p>
+          <button type="submit" class="btn filter-apply-button waves-effect waves-light">
             Update
           </button>
         </div>
+        <div class="filter-bar">
+          <div class="card-panel filter-card filter-card--compact">
+            <div class="filter-toolbar__field">
+              <label for="start_date" class="active">From</label>
+              <input
+                type="date"
+                id="start_date"
+                name="start_date"
+                value="{{ start_date|date:'Y-m-d' }}"
+                class="browser-default"
+              />
+            </div>
+          </div>
+          <div class="card-panel filter-card filter-card--compact">
+            <div class="filter-toolbar__field">
+              <label for="end_date" class="active">To</label>
+              <input
+                type="date"
+                id="end_date"
+                name="end_date"
+                value="{{ end_date|date:'Y-m-d' }}"
+                class="browser-default"
+              />
+            </div>
+          </div>
+        </div>
       </form>
-      <div class="filter-toolbar__aside">
-        <a
-          href="{% url 'sales_referrers' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
-          class="filter-toolbar__link"
-        >
-          View sales by referrer <span aria-hidden="true">→</span>
-        </a>
-        <a
-          href="{% url 'sales_assign_referrers' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
-          class="filter-toolbar__link"
-        >
-          Assign referrers <span aria-hidden="true">→</span>
-        </a>
+      <div class="filter-bar" style="margin-bottom: 0;">
+        <div class="card-panel filter-card filter-card--compact">
+          <div class="filter-toolbar__aside">
+            <a
+              href="{% url 'sales_referrers' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+              class="filter-toolbar__link"
+            >
+              View sales by referrer <span aria-hidden="true">→</span>
+            </a>
+            <a
+              href="{% url 'sales_assign_referrers' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+              class="filter-toolbar__link"
+            >
+              Assign referrers <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -130,37 +130,49 @@
       </span>
     </h3>
 
+    <div class="filter-divider"></div>
     <div class="card-panel filter-toolbar">
       <form method="get" novalidate class="filter-toolbar__form">
-        <div class="filter-toolbar__field">
-          <label for="start_date" class="active">From</label>
-          <input type="date" id="start_date" name="start_date" value="{{ start_date|date:'Y-m-d' }}" class="browser-default" />
+        <div class="filter-section-header">
+          <p class="filter-showing">
+            Showing: {{ start_date|date:"M j, Y" }} to {{ end_date|date:"M j, Y" }} · {{ min_discount }}%–{{ max_discount }}%
+          </p>
+          <button type="submit" class="btn filter-apply-button waves-effect waves-light">Update</button>
         </div>
-        <div class="filter-toolbar__field">
-          <label for="end_date" class="active">To</label>
-          <input type="date" id="end_date" name="end_date" value="{{ end_date|date:'Y-m-d' }}" class="browser-default" />
-        </div>
-        <div class="filter-toolbar__field" style="min-width: 280px;">
-          <label class="active">Discount range: <strong id="discountRangeLabel">{{ min_discount }}%–{{ max_discount }}%</strong></label>
-          <div class="discount-range-slider">
-            <span>0%</span>
-            <div>
-              <div class="discount-range-track-wrap">
-                <div class="discount-range-track-bg"></div>
-                <div class="discount-range-track-fill" id="discountRangeFill"></div>
-                <input type="range" id="min_discount" name="min_discount" min="0" max="100" value="{{ min_discount }}" />
-                <input type="range" id="max_discount" name="max_discount" min="0" max="100" value="{{ max_discount }}" />
-              </div>
-              <div class="discount-range-values">
-                <span id="discountMinValue">{{ min_discount }}%</span>
-                <span id="discountMaxValue">{{ max_discount }}%</span>
+        <div class="filter-bar">
+          <div class="card-panel filter-card filter-card--compact">
+            <div class="filter-toolbar__field">
+              <label for="start_date" class="active">From</label>
+              <input type="date" id="start_date" name="start_date" value="{{ start_date|date:'Y-m-d' }}" class="browser-default" />
+            </div>
+          </div>
+          <div class="card-panel filter-card filter-card--compact">
+            <div class="filter-toolbar__field">
+              <label for="end_date" class="active">To</label>
+              <input type="date" id="end_date" name="end_date" value="{{ end_date|date:'Y-m-d' }}" class="browser-default" />
+            </div>
+          </div>
+          <div class="card-panel filter-card filter-card--compact" style="min-width: 280px;">
+            <div class="filter-toolbar__field">
+              <label class="active">Discount range: <strong id="discountRangeLabel">{{ min_discount }}%–{{ max_discount }}%</strong></label>
+              <div class="discount-range-slider">
+                <span>0%</span>
+                <div>
+                  <div class="discount-range-track-wrap">
+                    <div class="discount-range-track-bg"></div>
+                    <div class="discount-range-track-fill" id="discountRangeFill"></div>
+                    <input type="range" id="min_discount" name="min_discount" min="0" max="100" value="{{ min_discount }}" />
+                    <input type="range" id="max_discount" name="max_discount" min="0" max="100" value="{{ max_discount }}" />
+                  </div>
+                  <div class="discount-range-values">
+                    <span id="discountMinValue">{{ min_discount }}%</span>
+                    <span id="discountMaxValue">{{ max_discount }}%</span>
+                  </div>
+                </div>
+                <span>100%</span>
               </div>
             </div>
-            <span>100%</span>
           </div>
-        </div>
-        <div class="filter-toolbar__actions">
-          <button type="submit" class="btn-tiny waves-effect waves-light">Update</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
### Motivation
- Unify the visual language of filter controls so the Sales pages match the Products page filter/category bar for consistent UI across the app.
- Reuse existing Products-style classes where possible to avoid duplicate styling and simplify future maintenance.

### Description
- Added shared filter styles to `inventory/static/styles.css` (introduced `.filter-bar`, `.filter-card`, `.filter-section-header`, `.filter-showing`, `.filter-divider`, `.filter-apply-button`, `.filter-card--compact`, and related adjustments) so Products-style filters can be reused by other pages.
- Updated the Sales page template `inventory/templates/inventory/sales.html` to adopt the Products-style filter structure and classes, including a `Showing` header, card-wrapped date inputs, and the update action styled with the new shared classes.
- Updated the Assign Referrers template `inventory/templates/inventory/sales_assign_referrers.html` to the same Products-style structure, placing the discount-range control inside a matching filter card and reusing the same shared classes.
- No backend logic changes; this PR only modifies templates and CSS to make filter UIs consistent.

### Testing
- Ran `python manage.py check` to validate the project, which failed in this environment because `django` is not installed, so runtime checks could not be completed here.
- Verified the templates and stylesheet diffs locally in the repository to ensure the new classes are referenced and CSS rules are present without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10ef7dcb0832ca29d909a9d870f28)