### PR TITLE
Rework homepage sales stats into combined quadrant card and adjust chart row layout

### DIFF
--- a/inventory/templates/inventory/home.html
+++ b/inventory/templates/inventory/home.html
@@ -23,7 +23,26 @@
 
 
     <!-- SALES INFORMATION SECTION -->
-    <div class="col s12">
+    <div class="col s12 m4">
+      <div class="card-panel" style="padding: 0; overflow: hidden;">
+        <div style="display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: auto auto;">
+          <div class="green lighten-2 white-text center-align" style="padding: 16px;">
+            <span class="green-text text-darken-4" style="font-size: 1rem; font-weight: 600;">Gross Sales</span>
+            <h5 id="totalSales" style="margin: 8px 0 0; font-weight: 500;">¥{{ total_sales|floatformat:0 }}</h5>
+          </div>
+          <div class="red lighten-2 white-text center-align" style="padding: 16px;">
+            <span class="red-text text-darken-4" style="font-size: 1rem; font-weight: 600;">Returns</span>
+            <h5 id="totalReturns" style="margin: 8px 0 0; font-weight: 500;">¥{{ total_returns|floatformat:0 }}</h5>
+          </div>
+          <div class="blue lighten-2 white-text center-align" style="padding: 18px 16px; grid-column: 1 / span 2;">
+            <span class="blue-text text-darken-4" style="font-size: 1rem; font-weight: 600;">Net Sales</span>
+            <h5 id="netSales" style="margin: 8px 0 0; font-weight: 500;">¥{{ net_sales|floatformat:0 }}</h5>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col s12 m8">
       <div id="sales-info-card" class="card z-depth-2" style="overflow: hidden; position: relative;">
         <a href="#" id="prevMonth" class="month-arrow" style="position:absolute; left:0; top:50%; transform:translate(-50%,-50%);">
           <i class="material-icons">chevron_left</i>
@@ -32,82 +51,30 @@
           <i class="material-icons">chevron_right</i>
         </a>
 
-          <!-- Bottom: White section with donut chart + legend -->
-          <div class="card-content white">
-            <h6 id="salesMonthLabel" class="center-align">{{ current_month_name }}</h6>
-            <div class="row" style="margin: 0;">
-
-              <!-- Left: Donut Chart (1/3) -->
-              <div class="col s12 m2">
-                <div style="position: relative; width: 150px; height: 150px;">
-                  <canvas id="categoryDonutChart" width="150" height="150"></canvas>
-                  <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">
-                    <span id="totalItemsSold" style="font-size: 1.4rem; font-weight: bold;">{{ total_items_sold }}</span><br>
-                    <span style="font-size: 0.9rem;">Items Sold</span>
-                  </div>
+        <div class="card-content white">
+          <h6 id="salesMonthLabel" class="center-align">{{ current_month_name }}</h6>
+          <div class="row" style="margin: 0;">
+            <div class="col s12 m6">
+              <div style="position: relative; width: 150px; height: 150px; margin: 0 auto;">
+                <canvas id="categoryDonutChart" width="150" height="150"></canvas>
+                <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">
+                  <span id="totalItemsSold" style="font-size: 1.4rem; font-weight: bold;">{{ total_items_sold }}</span><br>
+                  <span style="font-size: 0.9rem;">Items Sold</span>
                 </div>
               </div>
-
-            <!-- Custom Legend -->
-            <div class="col s12 m2" style="position: relative; height: 150px;">
-
-                <ul class="" style="list-style: none; padding-left: 0; margin-top:30px;">
-                  <li><span style="background:#43a047; display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:8px;"></span>Gi</li>
-                  <li><span style="background:#1e88e5; display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:8px;"></span>Rashguard</li>
-                  <li><span style="background:#fb8c00; display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:8px;"></span>Shorts</li>
-                  <li><span style="background:#9e9e9e; display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:8px;"></span>Other</li>
-                </ul>
             </div>
-
-              <!-- Right: Summary Cards (2/3) -->
-              <div class="col s12 m8">
-                <div class="row" style="margin: 0;">
-                  <!-- Sales -->
-                  <div class="col s4 m4 l4">
-                    <div class="card green lighten-2 z-depth-1" style="margin-bottom: 10px;">
-                      <div class="card-content white-text center-align">
-                        <span class="green-text text-darken-4"  style="font-size: 1.1rem; font-weight: 600;">Gross Sales</span>
-                        <h5 id="totalSales" style="margin: 0px; font-weight: 500;">¥{{ total_sales|floatformat:0 }}</h5>
-                      </div>
-                      <div class="green lighten-1 center-align" style="padding: 8px; ">
-                        <a href="#" class="white-text" style="font-weight: 500;">View Details</a>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- Returns -->
-                  <div class="col s4 m4 l4">
-                    <div class="card red lighten-2 z-depth-1" style="margin-bottom: 10px;">
-                      <div class="card-content white-text center-align">
-                        <span class="red-text text-darken-4" style="font-size: 1.1rem; font-weight: 600;">Returns</span>
-                        <h5 id="totalReturns" style="margin: 0px; font-weight: 500;">¥{{ total_returns|floatformat:0 }}</h5>
-                      </div>
-                      <div class="red lighten-1 center-align" style="padding: 8px; ">
-                        <a href="{% url 'returns' %}" class="white-text" style="font-weight: 500;">View Details</a>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- Net Sales -->
-                  <div class="col s4 m4 l4">
-                    <div class="card blue lighten-2 z-depth-1">
-                      <div class="card-content white-text center-align">
-                        <span class="blue-text text-darken-4" style="font-size: 1.1rem; font-weight: 600;">Net Sales</span>
-                        <h5 id="netSales" style="margin: 0px; font-weight: 500;">¥{{ net_sales|floatformat:0 }}</h5>
-                      </div>
-                      <div class="blue lighten-1 center-align" style="padding: 8px; ">
-                        <a href="#" class="white-text" style="font-weight: 500;">View Details</a>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
+            <div class="col s12 m6" style="position: relative; min-height: 150px;">
+              <ul style="list-style: none; padding-left: 0; margin-top: 24px;">
+                <li><span style="background:#43a047; display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:8px;"></span>Gi</li>
+                <li><span style="background:#1e88e5; display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:8px;"></span>Rashguard</li>
+                <li><span style="background:#fb8c00; display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:8px;"></span>Shorts</li>
+                <li><span style="background:#9e9e9e; display:inline-block; width:12px; height:12px; border-radius:50%; margin-right:8px;"></span>Other</li>
+              </ul>
             </div>
-          </div> <!-- end of card content -->
-
+          </div>
+        </div>
       </div>
-    </div> <!-- end of col s12 -->
+    </div>
 
 
     <!-- INVENTORY SECTION -->


### PR DESCRIPTION
### Motivation
- Simplify the sales summary area under the monthly sales line chart into a single compact card that matches the requested quadrant layout. 
- Place the sales stats in a `col s12 m4` `card-panel` on the left and keep the category donut chart + legend on the right so the row matches the desired visual balance. 
- Preserve existing JS targets and behaviour so month-switching and data updates continue to work without JS changes.

### Description
- Updated `inventory/templates/inventory/home.html` to replace the three separate sales cards with a single combined sales stats box inside a `div` with `class="col s12 m4"` and a `card-panel` container. 
- Implemented the quadrant layout using a simple CSS grid: top-left is **Gross Sales** (green), top-right is **Returns** (red), and the bottom row spans both columns showing **Net Sales** (blue). 
- Moved the category donut and legend into the adjacent `col s12 m8` so the donut + legend occupy the right side of the same row under the line chart. 
- Kept all existing DOM IDs and elements used by client code (`totalSales`, `totalReturns`, `netSales`, `totalItemsSold`, `salesMonthLabel`, `prevMonth`, `nextMonth`) to avoid breaking the month navigation/data refresh logic.

### Testing
- Ran a quick environment validation by invoking `python manage.py check`, which could not complete because Django is not installed in this environment (`ModuleNotFoundError: No module named 'django'`).
- No other automated test runner was executed in this environment due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e110a5aa00832caca6b4eac47f0efe)