### PR TITLE
Unify H3 page titles and implement compact Date Range filter cards

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -704,6 +704,15 @@ div.metadata {
   margin: 0;
 }
 
+.page-title {
+  color: inherit;
+  font-size: 2.92rem;
+  font-weight: 400;
+  line-height: 110%;
+  margin: 1.46rem 0 1.168rem;
+  padding: 0;
+}
+
 .filter-card {
   border: 1px solid #e0e0e0;
   border-radius: 10px;
@@ -735,6 +744,21 @@ div.metadata {
 
 .filter-card--compact {
   flex: 1 1 220px;
+}
+
+.filter-card__title {
+  color: #546e7a;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.filter-card--date-range {
+  flex: 1 1 220px;
+}
+
+.filter-card--date-range .filter-toolbar__field + .filter-toolbar__field {
+  margin-top: 8px;
 }
 
 .filter-card--actions {

--- a/inventory/templates/inventory/inventory_snapshots.html
+++ b/inventory/templates/inventory/inventory_snapshots.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="section">
-  <h3>Inventory</h3>
+  <h3 class="page-title">Inventory</h3>
 
   <div class="row">
     <div class="col s12">

--- a/inventory/templates/inventory/order_list.html
+++ b/inventory/templates/inventory/order_list.html
@@ -6,7 +6,7 @@
 
 
 <div class="section">
-  <h3>Order Planner</h3>
+  <h3 class="page-title">Order Planner</h3>
 
   <style>
     .filter-bar {

--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -179,7 +179,7 @@
   </style>
   {% if filter_controls %}
 
-  <h3 class="filter-title">Products</h3>
+  <h3 class="page-title">Products</h3>
 
   <div class="filter-divider"></div>
 

--- a/inventory/templates/inventory/product_list.html
+++ b/inventory/templates/inventory/product_list.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="section">
 
-  <h3>Products</h3>
+  <h3 class="page-title">Products</h3>
 
   <div id="controls" class="row grey lighten-3">
     <form id="productFilterForm" method="get">

--- a/inventory/templates/inventory/referrer_detail.html
+++ b/inventory/templates/inventory/referrer_detail.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   <div class="section">
-    <h3>
+    <h3 class="page-title">
       Sales
       <span class="grey-text small">
         | {{ referrer.name }} from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}
@@ -23,30 +23,37 @@
       </div>
 
       <form method="get" novalidate class="filter-toolbar__form">
-        <div class="filter-toolbar__field">
-          <label for="start_date" class="active">From</label>
-          <input
-            type="date"
-            id="start_date"
-            name="start_date"
-            value="{{ start_date|date:'Y-m-d' }}"
-            class="browser-default"
-          />
-        </div>
-        <div class="filter-toolbar__field">
-          <label for="end_date" class="active">To</label>
-          <input
-            type="date"
-            id="end_date"
-            name="end_date"
-            value="{{ end_date|date:'Y-m-d' }}"
-            class="browser-default"
-          />
-        </div>
-        <div class="filter-toolbar__actions">
-          <button type="submit" class="btn-small waves-effect waves-light">
-            Update
-          </button>
+        <div class="filter-bar">
+          <div class="card-panel filter-card filter-card--compact filter-card--date-range">
+            <p class="filter-card__title">Date Range</p>
+            <div class="filter-toolbar__field">
+              <label for="start_date" class="active">From</label>
+              <input
+                type="date"
+                id="start_date"
+                name="start_date"
+                value="{{ start_date|date:'Y-m-d' }}"
+                class="browser-default"
+              />
+            </div>
+            <div class="filter-toolbar__field">
+              <label for="end_date" class="active">To</label>
+              <input
+                type="date"
+                id="end_date"
+                name="end_date"
+                value="{{ end_date|date:'Y-m-d' }}"
+                class="browser-default"
+              />
+            </div>
+          </div>
+          <div class="card-panel filter-card filter-card--compact filter-card--actions">
+            <div class="filter-toolbar__actions">
+              <button type="submit" class="btn-small waves-effect waves-light">
+                Update
+              </button>
+            </div>
+          </div>
         </div>
       </form>
 

--- a/inventory/templates/inventory/referrers_overview.html
+++ b/inventory/templates/inventory/referrers_overview.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   <div class="section">
-    <h3>
+    <h3 class="page-title">
       Referrers overview
       <span class="grey-text small">
         | Data from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}
@@ -44,30 +44,37 @@
 
     <div class="card-panel filter-toolbar">
       <form method="get" novalidate class="filter-toolbar__form">
-        <div class="filter-toolbar__field">
-          <label for="start_date" class="active">From</label>
-          <input
-            type="date"
-            id="start_date"
-            name="start_date"
-            value="{{ start_date|date:'Y-m-d' }}"
-            class="browser-default"
-          />
-        </div>
-        <div class="filter-toolbar__field">
-          <label for="end_date" class="active">To</label>
-          <input
-            type="date"
-            id="end_date"
-            name="end_date"
-            value="{{ end_date|date:'Y-m-d' }}"
-            class="browser-default"
-          />
-        </div>
-        <div class="filter-toolbar__actions">
-          <button type="submit" class="btn-small waves-effect waves-light">
-            Update
-          </button>
+        <div class="filter-bar">
+          <div class="card-panel filter-card filter-card--compact filter-card--date-range">
+            <p class="filter-card__title">Date Range</p>
+            <div class="filter-toolbar__field">
+              <label for="start_date" class="active">From</label>
+              <input
+                type="date"
+                id="start_date"
+                name="start_date"
+                value="{{ start_date|date:'Y-m-d' }}"
+                class="browser-default"
+              />
+            </div>
+            <div class="filter-toolbar__field">
+              <label for="end_date" class="active">To</label>
+              <input
+                type="date"
+                id="end_date"
+                name="end_date"
+                value="{{ end_date|date:'Y-m-d' }}"
+                class="browser-default"
+              />
+            </div>
+          </div>
+          <div class="card-panel filter-card filter-card--compact filter-card--actions">
+            <div class="filter-toolbar__actions">
+              <button type="submit" class="btn-small waves-effect waves-light">
+                Update
+              </button>
+            </div>
+          </div>
         </div>
       </form>
     </div>

--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   <div class="section">
-    <h3>Sales</h3>
+    <h3 class="page-title">Sales</h3>
 
     <div class="filter-divider"></div>
     <div class="card-panel filter-toolbar">
@@ -18,7 +18,8 @@
           </button>
         </div>
         <div class="filter-bar">
-          <div class="card-panel filter-card filter-card--compact">
+          <div class="card-panel filter-card filter-card--compact filter-card--date-range">
+            <p class="filter-card__title">Date Range</p>
             <div class="filter-toolbar__field">
               <label for="start_date" class="active">From</label>
               <input
@@ -29,8 +30,6 @@
                 class="browser-default"
               />
             </div>
-          </div>
-          <div class="card-panel filter-card filter-card--compact">
             <div class="filter-toolbar__field">
               <label for="end_date" class="active">To</label>
               <input
@@ -42,13 +41,11 @@
               />
             </div>
           </div>
-        </div>
-      </form>
-      <div class="filter-bar" style="margin-bottom: 0;">
-        <div class="card-panel filter-card filter-card--compact">
-          <div class="filter-toolbar__aside">
-            <a
-              href="{% url 'sales_referrers' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+          <div class="card-panel filter-card filter-card--compact">
+            <p class="filter-card__title">Referrer Tools</p>
+            <div class="filter-toolbar__aside">
+              <a
+                href="{% url 'sales_referrers' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
               class="filter-toolbar__link"
             >
               View sales by referrer <span aria-hidden="true">→</span>
@@ -59,9 +56,10 @@
             >
               Assign referrers <span aria-hidden="true">→</span>
             </a>
+            </div>
           </div>
         </div>
-      </div>
+      </form>
     </div>
 
     <div class="row">

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -123,7 +123,7 @@
     }
   </style>
   <div class="section">
-    <h3>
+    <h3 class="page-title">
       Assign referrers
       <span class="grey-text small">
         | Discounted {{ min_discount }}%–{{ max_discount }}% from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}
@@ -140,13 +140,12 @@
           <button type="submit" class="btn filter-apply-button waves-effect waves-light">Update</button>
         </div>
         <div class="filter-bar">
-          <div class="card-panel filter-card filter-card--compact">
+          <div class="card-panel filter-card filter-card--compact filter-card--date-range">
+            <p class="filter-card__title">Date Range</p>
             <div class="filter-toolbar__field">
               <label for="start_date" class="active">From</label>
               <input type="date" id="start_date" name="start_date" value="{{ start_date|date:'Y-m-d' }}" class="browser-default" />
             </div>
-          </div>
-          <div class="card-panel filter-card filter-card--compact">
             <div class="filter-toolbar__field">
               <label for="end_date" class="active">To</label>
               <input type="date" id="end_date" name="end_date" value="{{ end_date|date:'Y-m-d' }}" class="browser-default" />

--- a/inventory/templates/inventory/sales_referrers.html
+++ b/inventory/templates/inventory/sales_referrers.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   <div class="section">
-    <h3>
+    <h3 class="page-title">
       Sales
       <span class="grey-text small">
         | Referrer sales from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}
@@ -46,41 +46,51 @@
 
     <div class="card-panel filter-toolbar">
       <form method="get" novalidate class="filter-toolbar__form">
-        <div class="filter-toolbar__field">
-          <label for="start_date" class="active">From</label>
-          <input
-            type="date"
-            id="start_date"
-            name="start_date"
-            value="{{ start_date|date:'Y-m-d' }}"
-            class="browser-default"
-          />
-        </div>
-        <div class="filter-toolbar__field">
-          <label for="end_date" class="active">To</label>
-          <input
-            type="date"
-            id="end_date"
-            name="end_date"
-            value="{{ end_date|date:'Y-m-d' }}"
-            class="browser-default"
-          />
-        </div>
-        <div class="filter-toolbar__field">
-          <label for="referrer" class="active">Referrer</label>
-          <select id="referrer" name="referrer" class="browser-default">
-            <option value="">All referrers</option>
-            {% for referrer in referrers %}
-              <option value="{{ referrer.id }}" {% if selected_referrer_id == referrer.id|stringformat:'s' %}selected{% endif %}>
-                {{ referrer.name }}
-              </option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="filter-toolbar__actions">
-          <button type="submit" class="btn-small waves-effect waves-light">
-            Update
-          </button>
+        <div class="filter-bar">
+          <div class="card-panel filter-card filter-card--compact filter-card--date-range">
+            <p class="filter-card__title">Date Range</p>
+            <div class="filter-toolbar__field">
+              <label for="start_date" class="active">From</label>
+              <input
+                type="date"
+                id="start_date"
+                name="start_date"
+                value="{{ start_date|date:'Y-m-d' }}"
+                class="browser-default"
+              />
+            </div>
+            <div class="filter-toolbar__field">
+              <label for="end_date" class="active">To</label>
+              <input
+                type="date"
+                id="end_date"
+                name="end_date"
+                value="{{ end_date|date:'Y-m-d' }}"
+                class="browser-default"
+              />
+            </div>
+          </div>
+          <div class="card-panel filter-card filter-card--compact">
+            <p class="filter-card__title">Referrer</p>
+            <div class="filter-toolbar__field">
+              <label for="referrer" class="active">Referrer</label>
+              <select id="referrer" name="referrer" class="browser-default">
+                <option value="">All referrers</option>
+                {% for referrer in referrers %}
+                  <option value="{{ referrer.id }}" {% if selected_referrer_id == referrer.id|stringformat:'s' %}selected{% endif %}>
+                    {{ referrer.name }}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="card-panel filter-card filter-card--compact filter-card--actions">
+            <div class="filter-toolbar__actions">
+              <button type="submit" class="btn-small waves-effect waves-light">
+                Update
+              </button>
+            </div>
+          </div>
         </div>
       </form>
     </div>


### PR DESCRIPTION
### Motivation
- Make top-level H3 headings consistent across product, sales, inventory and order pages so page titles share the same size, margins and weight as the Product page.
- Group date pickers into a single compact filter card (matching Product-style filter boxes) and surface referrer actions in a neighboring compact card on sales pages for a cleaner, consistent toolbar.

### Description
- Added a reusable `.page-title` CSS rule and small filter helpers (`.filter-card__title`, `.filter-card--date-range`) in `inventory/static/styles.css` to match Product page heading/box styles and spacing.
- Updated multiple templates to use the shared heading and compact date-range card: `inventory/templates/inventory/product_list.html`, `product_filtered_list.html`, `sales.html`, `inventory_snapshots.html`, and `order_list.html` now use `h3 class="page-title"` for uniform H3 styling.
- Grouped `From` and `To` date inputs inside a single `Date Range` filter card and stacked `From` above `To` on `sales.html`, and applied the same pattern to `sales_referrers.html`, `referrer_detail.html`, `referrers_overview.html`, and `sales_assign_referrers.html`.
- Added a neighboring compact filter card on the Sales page titled `Referrer Tools` containing the links `View sales by referrer` and `Assign referrers`.

### Testing
- Ran `python manage.py check`; it could not complete in this environment because Django is not installed and the command failed with `ModuleNotFoundError: No module named 'django'`.
- Verified templates and CSS changes by inspecting the updated files in the repo (no UI/browser test available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11f3a502c832c894e288d4485f96a)