### PR TITLE
Move assign-referrers summary metrics into the Showing line

### DIFF
--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -144,7 +144,13 @@
             |
             {{ min_discount }}%–{{ max_discount }}%
             |
-            <!-- MOVE DETAILS STATS HERE -->
+            <strong>{{ orders_count }}</strong> order{{ orders_count|pluralize }}
+            |
+            <strong>{{ summary_totals.items_count }}</strong> item{{ summary_totals.items_count|pluralize }}
+            |
+            Retail: ¥{{ summary_totals.retail_value|floatformat:2 }}
+            |
+            Actual: ¥{{ summary_totals.actual_value|floatformat:2 }}
           </p>
           <button type="submit" class="btn filter-apply-button">Apply</button>
         </div>
@@ -186,22 +192,6 @@
         </div>
       </form>
     </div>
-
-    <!-- DETAILS SECTION -->
-    <div class="card-panel grey lighten-4 page-summary">
-      <div class="page-summary__primary">
-        <a href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}" class="page-summary__back-link">
-          ← Back to sales overview
-        </a>
-      </div>
-      <div class="page-summary__stats">
-        <span class="page-summary__stat"><strong>{{ orders_count }}</strong> order{{ orders_count|pluralize }}</span>
-        <span class="page-summary__stat"><strong>{{ summary_totals.items_count }}</strong> item{{ summary_totals.items_count|pluralize }}</span>
-        <span class="page-summary__stat">Retail: ¥{{ summary_totals.retail_value|floatformat:2 }}</span>
-        <span class="page-summary__stat">Actual: ¥{{ summary_totals.actual_value|floatformat:2 }}</span>
-      </div>
-    </div>
-    <!-- END DETAILS SECTION -->
 
     <div class="card-panel">
       <label for="orderNumbersText" class="active">Order numbers (copy list)</label>


### PR DESCRIPTION
### Motivation
- The Details summary card duplicated high-level sales metrics and created extra visual clutter under the filters.
- Surface the same order/item/value metrics more compactly in the filter toolbar to make the page cleaner and reduce duplication.

### Description
- Updated `inventory/templates/inventory/sales_assign_referrers.html` to add `{{ orders_count }}`, `{{ summary_totals.items_count }}`, `Retail: ¥{{ summary_totals.retail_value|floatformat:2 }}`, and `Actual: ¥{{ summary_totals.actual_value|floatformat:2 }}` into the existing `Showing:` line in the filter header.
- Removed the separate details summary card block (`page-summary` card) that previously displayed those same metrics below the filters.
- Kept the original variable names and formatting intact so displayed values remain unchanged.

### Testing
- Ran `python manage.py check`, which could not complete in this environment because Django is not installed (so runtime/template checks were not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12aa99dfc832c8d551adc823e7fbf)