### PR TITLE
Refactor referrer templates: unify filter toolbar, surface summary metrics, and add referrer switch

### DIFF
--- a/inventory/templates/inventory/referrer_detail.html
+++ b/inventory/templates/inventory/referrer_detail.html
@@ -4,25 +4,29 @@
 
 {% block content %}
   <div class="section">
-    <h3 class="page-title">
-      Sales
-      <span class="grey-text small">
-        | {{ referrer.name }} from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}
-      </span>
-    </h3>
+    <h3 class="page-title">{{ referrer.name }} sales</h3>
 
-    <!-- FILTER ACTION BAR -->
-    <div class="card-panel grey lighten-4 page-summary">
-      <div class="page-summary__primary">
-        <a
-          href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
-          class="page-summary__back-link"
-        >
-          ← Back to sales overview
-        </a>
-      </div>
+    <div class="filter-divider"></div>
 
+    <div class="card-panel filter-toolbar">
       <form method="get" novalidate class="filter-toolbar__form">
+        <div class="filter-section-header">
+          <p class="filter-showing">
+            Showing: {{ start_date|date:"M j, Y" }} to {{ end_date|date:"M j, Y" }}
+            |
+            Total sales: ¥{{ financials.total_sales|floatformat:2 }}
+            |
+            Returns: -¥{{ financials.returns|floatformat:2 }}
+            |
+            COGS: -¥{{ financials.cost_of_goods_sold|floatformat:2 }}
+            |
+            Freebies: -¥{{ financials.freebies_cost|floatformat:2 }} ({{ stats.free_items }} items)
+            |
+            Net profit: ¥{{ financials.net_profit|floatformat:2 }}
+          </p>
+          <button type="submit" class="btn filter-apply-button">Apply</button>
+        </div>
+
         <div class="filter-bar">
           <div class="card-panel filter-card filter-card--compact filter-card--date-range">
             <p class="filter-card__title">Date Range</p>
@@ -47,70 +51,41 @@
               />
             </div>
           </div>
-          <div class="card-panel filter-card filter-card--compact filter-card--actions">
-            <div class="filter-toolbar__actions">
-              <button type="submit" class="btn-small waves-effect waves-light">
-                Update
-              </button>
+          {% if referrers %}
+            <div class="card-panel filter-card filter-card--compact">
+              <p class="filter-card__title">Referrer</p>
+              <div class="filter-toolbar__field">
+                <label for="referrerSwitch" class="active">Switch referrer</label>
+                <select id="referrerSwitch" class="browser-default">
+                  <option value="">Select referrer…</option>
+                  {% for referrer_option in referrers %}
+                    <option
+                      value="{% url 'referrer_detail' referrer_option.id %}"
+                      {% if selected_referrer_id == referrer_option.id|stringformat:'s' %}selected{% endif %}
+                    >
+                      {{ referrer_option.name }}
+                    </option>
+                  {% endfor %}
+                </select>
+              </div>
+            </div>
+          {% endif %}
+          <div class="card-panel filter-card filter-card--compact">
+            <p class="filter-card__title">Navigation</p>
+            <div class="filter-toolbar__aside">
+              <a
+                href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+                class="filter-toolbar__link"
+              >
+                Back to sales overview
+              </a>
             </div>
           </div>
         </div>
       </form>
-
-      <div class="filter-toolbar__aside">
-        {% if referrers %}
-          <label for="referrerSwitch" class="active">Switch referrer</label>
-          <select id="referrerSwitch" class="browser-default">
-            <option value="">Select referrer…</option>
-            {% for referrer_option in referrers %}
-              <option
-                value="{% url 'referrer_detail' referrer_option.id %}"
-                {% if selected_referrer_id == referrer_option.id|stringformat:'s' %}selected{% endif %}
-              >
-                {{ referrer_option.name }}
-              </option>
-            {% endfor %}
-          </select>
-        {% endif %}
-      </div>
     </div>
 
-
-
-
-
-    </div>
-
-
-    <!-- MAIN STATS SECTION -->
-    <div class="row referrer-summary-cards" id="mainStats">
-      <div class="col s12 m6">
-
-          <div class="row">
-            <div class="col s12 m12 blue lighten-4">
-              <h5 class="blue-text text-darken-2">¥{{ financials.total_sales|floatformat:2 }} total sales</h5>
-            </div>
-
-            <div class="col s12 m12 pink lighten-4">
-              <h5 class="pink-text">- ¥{{ financials.returns|floatformat:2 }} returns</h5>
-            </div>
-
-            <div class="col s12 m12 pink lighten-4">
-              <h5 class="pink-text">- ¥{{ financials.cost_of_goods_sold|floatformat:2 }} COGS</h5>
-            </div>
-
-            <div class="col s12 m12 pink lighten-4">
-              <h5 class="pink-text">- ¥{{ financials.freebies_cost|floatformat:2 }} freebies ({{ stats.free_items }} items)</h5>
-            </div>
-
-            <div class="col s12 m12 green lighten-4">
-              <h5 class="green-text text-darken-3">¥{{ financials.net_profit|floatformat:2 }} net profit</h5>
-            </div>
-          </div>
-      </div>
-
-    </div>
-
+    <div class="filter-divider"></div>
 
 
     {% if has_sales_data %}

--- a/inventory/templates/inventory/referrers_overview.html
+++ b/inventory/templates/inventory/referrers_overview.html
@@ -4,48 +4,31 @@
 
 {% block content %}
   <div class="section">
-    <h3 class="page-title">
-      Referrers overview
-      <span class="grey-text small">
-        | Data from {{ start_date|date:"F j, Y" }} to {{ end_date|date:"F j, Y" }}
-      </span>
-    </h3>
+    <h3 class="page-title">Referrers overview</h3>
 
-    <!-- STATISTICS SECTION -->
-    <div class="card-panel grey lighten-4 page-summary">
-      <div class="page-summary__primary">
-        <a
-          href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
-          class="page-summary__back-link"
-        >
-          ← Back to sales overview
-        </a>
-      </div>
-      <div class="page-summary__stats">
-        <span class="page-summary__stat">
-          Referrers: <strong>{{ referrers_count }}</strong>
-        </span>
-        <span class="page-summary__stat">
-          Active in range: <strong>{{ totals.with_sales }}</strong>
-        </span>
-        <span class="page-summary__stat">
-          Orders: <strong>{{ totals.orders }}</strong>
-        </span>
-        <span class="page-summary__stat">
-          Items: <strong>{{ totals.items }}</strong>
-        </span>
-        <span class="page-summary__stat">
-          Net sales: ¥{{ totals.sales|floatformat:2 }}
-        </span>
-        <span class="page-summary__stat">
-          Gifted items: <strong>{{ totals.gifted }}</strong>
-        </span>
-      </div>
-    </div>
-    <!-- END STATISTICS SECTION -->
+    <div class="filter-divider"></div>
 
     <div class="card-panel filter-toolbar">
       <form method="get" novalidate class="filter-toolbar__form">
+        <div class="filter-section-header">
+          <p class="filter-showing">
+            Showing: {{ start_date|date:"M j, Y" }} to {{ end_date|date:"M j, Y" }}
+            |
+            <strong>{{ referrers_count }}</strong> referrer{{ referrers_count|pluralize }}
+            |
+            Active: <strong>{{ totals.with_sales }}</strong>
+            |
+            Orders: <strong>{{ totals.orders }}</strong>
+            |
+            Items: <strong>{{ totals.items }}</strong>
+            |
+            Net sales: ¥{{ totals.sales|floatformat:2 }}
+            |
+            Gifted items: <strong>{{ totals.gifted }}</strong>
+          </p>
+          <button type="submit" class="btn filter-apply-button">Apply</button>
+        </div>
+
         <div class="filter-bar">
           <div class="card-panel filter-card filter-card--compact filter-card--date-range">
             <p class="filter-card__title">Date Range</p>
@@ -70,16 +53,22 @@
               />
             </div>
           </div>
-          <div class="card-panel filter-card filter-card--compact filter-card--actions">
-            <div class="filter-toolbar__actions">
-              <button type="submit" class="btn-small waves-effect waves-light">
-                Update
-              </button>
+          <div class="card-panel filter-card filter-card--compact">
+            <p class="filter-card__title">Navigation</p>
+            <div class="filter-toolbar__aside">
+              <a
+                href="{% url 'sales' %}{% if date_querystring %}?{{ date_querystring }}{% endif %}"
+                class="filter-toolbar__link"
+              >
+                Back to sales overview
+              </a>
             </div>
           </div>
         </div>
       </form>
     </div>
+
+    <div class="filter-divider"></div>
 
     {% if referrer_rows %}
       <div class="card">


### PR DESCRIPTION
### Motivation
- Improve the referrer overview and detail pages by consolidating filtering controls and summary information into a single, consistent toolbar for easier navigation and at-a-glance metrics.
- Provide a quick way to switch between referrers without leaving the filter form.
- Remove duplicated summary card layout and simplify the page structure while preserving existing conditional rendering and selection behavior.

### Description
- Reworked `inventory/templates/inventory/referrer_detail.html` to replace the old page-summary and separate summary cards with a unified `.filter-toolbar`, moved totals into a compact summary header, and added a `referrerSwitch` select inside the form to switch referrers.
- Updated `inventory/templates/inventory/referrers_overview.html` to use the same `.filter-toolbar` pattern, surface overall totals in the toolbar header, move the "Back to sales overview" link into the toolbar, and add `.filter-divider` and new `.filter-card` structure for consistency.
- Kept existing conditional logic for `has_sales_data`, `referrers`, `referrer_rows`, `orders`, and the selected-referrer highlighting intact; changes are structural/markup-only and do not alter backend business logic.

### Testing
- Ran the project's Django unit tests with `./manage.py test`, and the test suite completed with no failures.
- Performed automated template syntax checks and HTML linting against the modified templates with no errors reported.
- Executed static checks (linters) on the templates and CSS classes, and they passed with no new warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e138ce8ec8832ca4dcd6d73657a0d5)