### PR TITLE
Add "Exclude no referrer" toggle to Assign Referrers page

### DIFF
--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -195,7 +195,20 @@
 
           <!-- CHECKBOXES -->
           <div class="card-panel filter-card filter-card--compact" >
-
+            <p class="filter-card__title">Checkboxes</p>
+            <p>
+              <input type="hidden" name="exclude_no_referrer" value="0" />
+              <label>
+                <input
+                  type="checkbox"
+                  class="filled-in"
+                  name="exclude_no_referrer"
+                  value="1"
+                  {% if exclude_no_referrer %}checked{% endif %}
+                />
+                <span>Exclude no referrer</span>
+              </label>
+            </p>
           </div>
           <!-- END CHECKBOXES-->
 

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -5382,16 +5382,19 @@ def sales_assign_referrers(request):
     start_date, end_date = _get_sales_date_range(request)
     min_discount = _parse_discount_percent(request.GET.get("min_discount"), default=10)
     max_discount = _parse_discount_percent(request.GET.get("max_discount"), default=50)
+    exclude_no_referrer = request.GET.get("exclude_no_referrer", "1") != "0"
     if min_discount > max_discount:
         min_discount, max_discount = max_discount, min_discount
 
     sales_qs = Sale.objects.filter(date__range=(start_date, end_date))
 
-    ignored_order_numbers = set(
-        sales_qs.filter(referrer__name__iexact="no_referrer").values_list(
-            "order_number", flat=True
+    ignored_order_numbers = set()
+    if exclude_no_referrer:
+        ignored_order_numbers = set(
+            sales_qs.filter(referrer__name__iexact="no_referrer").values_list(
+                "order_number", flat=True
+            )
         )
-    )
 
     eligible_sales = (
         sales_qs.filter(Q(return_quantity__isnull=True) | Q(return_quantity=0))
@@ -5554,6 +5557,7 @@ def sales_assign_referrers(request):
             "end_date": end_date.isoformat(),
             "min_discount": min_discount,
             "max_discount": max_discount,
+            "exclude_no_referrer": "1" if exclude_no_referrer else "0",
         }
     )
 
@@ -5577,6 +5581,7 @@ def sales_assign_referrers(request):
             "min_discount": min_discount,
             "max_discount": max_discount,
             "order_numbers_text": order_numbers_text,
+            "exclude_no_referrer": exclude_no_referrer,
         },
     )
 


### PR DESCRIPTION
### Motivation

- Allow users to choose whether orders marked with the special `no_referrer` referrer are hidden from the Assign Referrers view instead of always excluding them. 
- Preserve existing behavior by default (exclude `no_referrer`) while making it possible to opt in to seeing those orders.

### Description

- Added a checkbox to the filter bar in `inventory/templates/inventory/sales_assign_referrers.html` labeled `Exclude no referrer`, with a hidden fallback input so unchecked state submits correctly, and the checkbox is checked by default when `exclude_no_referrer` is truthy in the template context. 
- Introduced `exclude_no_referrer = request.GET.get("exclude_no_referrer", "1") != "0"` in `sales_assign_referrers` to read the toggle from query params and default to enabled. 
- Only collect `ignored_order_numbers` from `Sale` rows with `referrer__name__iexact="no_referrer"` when `exclude_no_referrer` is enabled, otherwise include those orders in results. 
- Preserve the toggle state across interactions by adding `exclude_no_referrer` to the generated `date_querystring` and returning it in the template context.

### Testing

- Ran `python manage.py check` but it failed in this environment with `ModuleNotFoundError: No module named 'django'`, so no Django checks could be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1eb997380832ca016ce3d25865144)