### PR TITLE
Add discount/list-price fields to Sale; update admin, upload script, migration, and discount keyword settings

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -284,13 +284,17 @@ class SaleAdmin(admin.ModelAdmin):
         "date",
         "variant",
         "sold_quantity",
+        "list_price",
         "return_quantity",
         "sold_value",
+        "discount_amount",
+        "is_discounted",
+        "manual_discount_flag",
         "return_value",
         "referrer",
     )
-    list_filter = (SaleDateEqualsFilter, "referrer")
-    search_fields = ("order_number",)
+    list_filter = (SaleDateEqualsFilter, "referrer", "is_discounted", "manual_discount_flag")
+    search_fields = ("order_number", "coupon_name_raw", "seller_note", "product_short_name")
     actions = ["assign_referrer"]
 
     def get_search_results(self, request, queryset, search_term):

--- a/inventory/migrations/0022_sale_discount_fields.py
+++ b/inventory/migrations/0022_sale_discount_fields.py
@@ -1,0 +1,60 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0021_alter_orderitem_order"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="sale",
+            name="coupon_name_raw",
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="discount_amount",
+            field=models.DecimalField(
+                blank=True, decimal_places=2, max_digits=10, null=True
+            ),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="discount_notes",
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="discount_reasons",
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="is_discounted",
+            field=models.BooleanField(db_index=True, default=False),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="list_price",
+            field=models.DecimalField(
+                blank=True, decimal_places=2, max_digits=10, null=True
+            ),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="manual_discount_flag",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="product_short_name",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="seller_note",
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -320,6 +320,17 @@ class Sale(models.Model):
     sold_quantity = models.IntegerField()
     return_quantity = models.IntegerField(blank=True, null=True)
     sold_value = models.DecimalField(max_digits=10, decimal_places=2)
+    list_price = models.DecimalField(max_digits=10, decimal_places=2, blank=True, null=True)
+    discount_amount = models.DecimalField(
+        max_digits=10, decimal_places=2, blank=True, null=True
+    )
+    is_discounted = models.BooleanField(default=False, db_index=True)
+    discount_reasons = models.JSONField(default=list, blank=True)
+    coupon_name_raw = models.TextField(blank=True, null=True)
+    seller_note = models.TextField(blank=True, null=True)
+    product_short_name = models.CharField(max_length=255, blank=True, null=True)
+    manual_discount_flag = models.BooleanField(default=False)
+    discount_notes = models.TextField(blank=True, null=True)
     return_value = models.DecimalField(
         max_digits=10, decimal_places=2, blank=True, null=True
     )

--- a/progressplanner/settings.py
+++ b/progressplanner/settings.py
@@ -132,3 +132,28 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')  # Directory to store media files
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+
+SALES_DISCOUNT_REASON_KEYWORDS = {
+    "platform_coupon": [
+        "淘金币",
+        "taojinbi",
+        "天猫红包",
+        "红包优惠",
+    ],
+    "shop_coupon": [
+        "店铺优惠券",
+        "店铺券",
+        "关注店铺",
+        "粉丝券",
+        "优惠券",
+    ],
+    "bundle_deal": [
+        "套装",
+        "组合优惠",
+        "第二件",
+        "2件",
+        "满减",
+        "5%",
+    ],
+}

--- a/scripts/upload_sales.py
+++ b/scripts/upload_sales.py
@@ -13,7 +13,9 @@ django.setup()
 
 import pandas as pd
 from datetime import datetime, date
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from django.db import transaction
+from django.conf import settings
 from inventory.models import Sale, ProductVariant
 
 logger = logging.getLogger(__name__)
@@ -77,6 +79,81 @@ def _serialize_sale_fields(
     return payload
 
 
+def _get_row_value(row, key):
+    if key not in row:
+        return None
+    value = row[key]
+    if pd.isnull(value):
+        return None
+    return value
+
+
+def _to_decimal(value):
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+
+    if isinstance(value, str):
+        text = value.strip().replace(",", "")
+        if not text:
+            return None
+        try:
+            return Decimal(text)
+        except InvalidOperation:
+            return None
+
+    return None
+
+
+def _normalize_text(value):
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    return " ".join(text.split())
+
+
+def _classify_discount_reasons(coupon_name):
+    normalized_coupon = _normalize_text(coupon_name)
+    if not normalized_coupon:
+        return []
+
+    keyword_config = getattr(settings, "SALES_DISCOUNT_REASON_KEYWORDS", {})
+    matched_reasons = []
+    for reason, keywords in keyword_config.items():
+        for keyword in keywords:
+            normalized_keyword = _normalize_text(keyword)
+            if normalized_keyword and normalized_keyword in normalized_coupon:
+                matched_reasons.append(reason)
+                break
+
+    return sorted(set(matched_reasons))
+
+
+def _calculate_discount_fields(list_price, sold_value, coupon_name):
+    if list_price is None or sold_value is None:
+        return None, False, [], False, None
+
+    discount_amount = (list_price - sold_value).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+    is_discounted = discount_amount > Decimal("0.01")
+    reasons = []
+    manual_discount_flag = False
+    discount_notes = None
+
+    if is_discounted:
+        reasons = _classify_discount_reasons(coupon_name)
+        if not reasons:
+            manual_discount_flag = True
+            reasons = ["manual_price_adjustment"]
+            discount_notes = "Discount detected from list price vs sold value without matched coupon rule."
+
+    return discount_amount, is_discounted, reasons, manual_discount_flag, discount_notes
+
+
 
 def _parse_order_date(raw_value):
     if pd.isnull(raw_value):
@@ -128,6 +205,22 @@ def upload_sales(test=False, diff=False):
                 sold_value     = float(row['实发金额'])   if not pd.isnull(row['实发金额'])   else 0.00
                 return_quantity= int(row['实退数量'])   if not pd.isnull(row['实退数量']) else 0
                 return_value   = float(row['退货金额'])   if not pd.isnull(row['退货金额'])   else 0.00
+                list_price = _to_decimal(_get_row_value(row, "基本售价"))
+                sold_value_decimal = _to_decimal(sold_value)
+                coupon_name_raw = _get_row_value(row, "优惠券名称")
+                seller_note = _get_row_value(row, "卖家备注")
+                product_short_name = _get_row_value(row, "商品简称")
+                (
+                    discount_amount,
+                    is_discounted,
+                    discount_reasons,
+                    manual_discount_flag,
+                    discount_notes,
+                ) = _calculate_discount_fields(
+                    list_price=list_price,
+                    sold_value=sold_value_decimal,
+                    coupon_name=coupon_name_raw,
+                )
 
                 # ---- look up the variant ----
                 variant = ProductVariant.objects.filter(variant_code=variant_code).first()
@@ -146,6 +239,15 @@ def upload_sales(test=False, diff=False):
                         sold_quantity  = sold_quantity,
                         return_quantity= return_quantity,
                         sold_value     = sold_value,
+                        list_price     = list_price,
+                        discount_amount= discount_amount,
+                        is_discounted  = is_discounted,
+                        discount_reasons= discount_reasons,
+                        coupon_name_raw= str(coupon_name_raw) if coupon_name_raw is not None else None,
+                        seller_note    = str(seller_note) if seller_note is not None else None,
+                        product_short_name= str(product_short_name) if product_short_name is not None else None,
+                        manual_discount_flag=manual_discount_flag,
+                        discount_notes = discount_notes,
                         return_value   = return_value,
                     )
 


### PR DESCRIPTION
### Motivation
- Capture list price and discount metadata for sales to enable automated discount detection and reporting.
- Enrich the CSV/XLSX import pipeline to parse coupon and seller notes and classify discount reasons from configurable keywords.

### Description
- Added multiple fields to `Sale` including `list_price`, `discount_amount`, `is_discounted`, `discount_reasons`, `coupon_name_raw`, `seller_note`, `product_short_name`, `manual_discount_flag`, and `discount_notes`, and created migration `0022_sale_discount_fields.py` to persist them.
- Updated the admin (`inventory/admin.py`) to show and filter by `list_price`, `discount_amount`, `is_discounted`, and `manual_discount_flag`, and expanded `search_fields` to include `coupon_name_raw`, `seller_note`, and `product_short_name`.
- Extended the upload script (`scripts/upload_sales.py`) with robust decimal parsing, helpers `_to_decimal`, `_normalize_text`, `_classify_discount_reasons`, and `_calculate_discount_fields`, and populated the new `Sale` fields when creating records during import.
- Added `SALES_DISCOUNT_REASON_KEYWORDS` configuration to `progressplanner/settings.py` to drive coupon keyword-based reason classification.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e33d770e3c832c846223c8c218638e)