### PR TITLE
Add Sale discount-triage fields and admin exposure

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -97,6 +97,44 @@ class SaleDateEqualsFilter(admin.SimpleListFilter):
         }
 
 
+class SaleHasDiscountReasonsFilter(admin.SimpleListFilter):
+    title = _("discount reasons")
+    parameter_name = "discount_reasons_state"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("has_values", _("Has discount reasons")),
+            ("empty", _("No discount reasons")),
+        )
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == "has_values":
+            return queryset.exclude(discount_reasons=[])
+        if value == "empty":
+            return queryset.filter(discount_reasons=[])
+        return queryset
+
+
+class SaleHasSellerNoteFilter(admin.SimpleListFilter):
+    title = _("seller note")
+    parameter_name = "seller_note_state"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("has_value", _("Has seller note")),
+            ("empty", _("No seller note")),
+        )
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == "has_value":
+            return queryset.exclude(seller_note__isnull=True).exclude(seller_note="")
+        if value == "empty":
+            return queryset.filter(Q(seller_note__isnull=True) | Q(seller_note=""))
+        return queryset
+
+
 
 def get_size_order_case(field_name="size"):
     """Return a Case expression ordering by size based on SIZE_CHOICES."""
@@ -281,15 +319,34 @@ class ProductVariantAdmin(admin.ModelAdmin):
 class SaleAdmin(admin.ModelAdmin):
     list_display = (
         "sale_id",
+        "order_number",
         "date",
         "variant",
         "sold_quantity",
         "return_quantity",
         "sold_value",
+        "list_price",
+        "discount_amount",
+        "is_discounted",
+        "discount_reasons",
+        "coupon_name_raw",
+        "product_short_name",
+        "seller_note",
+        "manual_discount_flag",
+        "discount_notes",
         "return_value",
         "referrer",
     )
-    list_filter = (SaleDateEqualsFilter, "referrer")
+    list_filter = (
+        SaleDateEqualsFilter,
+        "is_discounted",
+        SaleHasDiscountReasonsFilter,
+        "coupon_name_raw",
+        "product_short_name",
+        SaleHasSellerNoteFilter,
+        "manual_discount_flag",
+        "referrer",
+    )
     search_fields = ("order_number",)
     actions = ["assign_referrer"]
 

--- a/inventory/migrations/0022_sale_discount_fields.py
+++ b/inventory/migrations/0022_sale_discount_fields.py
@@ -1,0 +1,66 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0021_alter_orderitem_order"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="sale",
+            name="coupon_name_raw",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="discount_amount",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=2,
+                max_digits=10,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="discount_notes",
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="discount_reasons",
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="is_discounted",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="list_price",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=2,
+                max_digits=10,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="manual_discount_flag",
+            field=models.BooleanField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="product_short_name",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="seller_note",
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -323,6 +323,19 @@ class Sale(models.Model):
     return_value = models.DecimalField(
         max_digits=10, decimal_places=2, blank=True, null=True
     )
+    seller_note = models.TextField(blank=True, null=True)
+    coupon_name_raw = models.CharField(max_length=255, blank=True, null=True)
+    product_short_name = models.CharField(max_length=255, blank=True, null=True)
+    list_price = models.DecimalField(
+        max_digits=10, decimal_places=2, blank=True, null=True
+    )
+    discount_amount = models.DecimalField(
+        max_digits=10, decimal_places=2, blank=True, null=True
+    )
+    is_discounted = models.BooleanField(default=False)
+    discount_reasons = models.JSONField(default=list, blank=True)
+    manual_discount_flag = models.BooleanField(blank=True, null=True)
+    discount_notes = models.TextField(blank=True, null=True)
     referrer = models.ForeignKey(
         Referrer,
         on_delete=models.SET_NULL,


### PR DESCRIPTION
### Motivation
- Capture raw intake and computed discount metadata on `Sale` to support triage, analytics, and operational review without breaking existing data.
- Surface discount-related signals in the admin so operations can quickly find and review discounted sales and raw source data.

### Description
- Added nullable/raw intake fields on `Sale` in `inventory/models.py`: `seller_note`, `coupon_name_raw`, `product_short_name`, and `list_price` with safe `blank=True`/`null=True` settings.
- Added computed-storage and ops-review fields on `Sale`: `discount_amount` (`DecimalField`), `is_discounted` (`BooleanField`), `discount_reasons` (`JSONField` defaulting to an empty list), `manual_discount_flag` (`BooleanField`), and `discount_notes` (`TextField`).
- Created migration `inventory/migrations/0022_sale_discount_fields.py` which adds all new fields with nullable/default-safe definitions for backwards compatibility.
- Updated admin in `inventory/admin.py` to expose the new columns in `SaleAdmin.list_display` (including `is_discounted`, `discount_reasons`, `coupon_name_raw`, `product_short_name`, `seller_note`, `list_price`, `discount_amount`, `manual_discount_flag`, and `discount_notes`) and added filters including `is_discounted`, custom `SaleHasDiscountReasonsFilter`, and custom `SaleHasSellerNoteFilter` for triage.

### Testing
- Compiled Python files with `python -m py_compile inventory/models.py inventory/admin.py inventory/migrations/0022_sale_discount_fields.py`, which succeeded.
- Attempted `python manage.py makemigrations inventory` but it failed due to the environment missing Django (`ModuleNotFoundError: No module named 'django'`).
- The migration file `inventory/migrations/0022_sale_discount_fields.py` was created in-place to ensure the database changes are represented and are safe to apply in a real Django environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e342495ea8832c85f1f32c4725f549)