### PR TITLE
Stop auto-assigning manual discount reasons in sales upload

### DIFF
--- a/scripts/upload_sales.py
+++ b/scripts/upload_sales.py
@@ -146,10 +146,6 @@ def _calculate_discount_fields(list_price, sold_value, coupon_name):
 
     if is_discounted:
         reasons = _classify_discount_reasons(coupon_name)
-        if not reasons:
-            manual_discount_flag = True
-            reasons = ["manual_price_adjustment"]
-            discount_notes = "Discount detected from list price vs sold value without matched coupon rule."
 
     return discount_amount, is_discounted, reasons, manual_discount_flag, discount_notes
 


### PR DESCRIPTION
### Motivation
- Ensure `discount_reasons` are only assigned when there is an explicit coupon-name match in the input (the `优惠券名称` column) instead of inferring a reason from list-price vs sold-value differences.

### Description
- Remove the fallback that set `manual_discount_flag = True`, added `["manual_price_adjustment"]` to `discount_reasons`, and populated `discount_notes` when a discount was detected but no coupon keyword matched inside `_calculate_discount_fields`.
- `_calculate_discount_fields` now only returns reasons populated via `_classify_discount_reasons(coupon_name)` and leaves `manual_discount_flag` and `discount_notes` unset when there is no explicit coupon match.

### Testing
- Ran `python -m py_compile scripts/upload_sales.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3481c0df4832c8a7b70c9c903774b)