### PR TITLE
Clean up Sale fields and surface coupon/seller note in assign referrers

### DIFF
--- a/inventory/models.py
+++ b/inventory/models.py
@@ -324,29 +324,16 @@ class Sale(models.Model):
     discount_amount = models.DecimalField(
         max_digits=10, decimal_places=2, blank=True, null=True
     )
-    is_discounted = models.BooleanField(default=False, db_index=True)
+    is_discounted = models.BooleanField(default=False)
     discount_reasons = models.JSONField(default=list, blank=True)
-    coupon_name_raw = models.TextField(blank=True, null=True)
     seller_note = models.TextField(blank=True, null=True)
+    coupon_name_raw = models.CharField(max_length=255, blank=True, null=True)
     product_short_name = models.CharField(max_length=255, blank=True, null=True)
-    manual_discount_flag = models.BooleanField(default=False)
+    manual_discount_flag = models.BooleanField(blank=True, null=True)
     discount_notes = models.TextField(blank=True, null=True)
     return_value = models.DecimalField(
         max_digits=10, decimal_places=2, blank=True, null=True
     )
-    seller_note = models.TextField(blank=True, null=True)
-    coupon_name_raw = models.CharField(max_length=255, blank=True, null=True)
-    product_short_name = models.CharField(max_length=255, blank=True, null=True)
-    list_price = models.DecimalField(
-        max_digits=10, decimal_places=2, blank=True, null=True
-    )
-    discount_amount = models.DecimalField(
-        max_digits=10, decimal_places=2, blank=True, null=True
-    )
-    is_discounted = models.BooleanField(default=False)
-    discount_reasons = models.JSONField(default=list, blank=True)
-    manual_discount_flag = models.BooleanField(blank=True, null=True)
-    discount_notes = models.TextField(blank=True, null=True)
     referrer = models.ForeignKey(
         Referrer,
         on_delete=models.SET_NULL,

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -286,6 +286,16 @@
                             <i class="material-icons tiny">edit</i>
                           </a>
                         </div>
+                        {% if item.sale.coupon_name_raw %}
+                          <div class="grey-text text-darken-1">
+                            Coupon: {{ item.sale.coupon_name_raw }}
+                          </div>
+                        {% endif %}
+                        {% if item.sale.seller_note %}
+                          <div class="grey-text text-darken-1">
+                            Seller note: {{ item.sale.seller_note }}
+                          </div>
+                        {% endif %}
                       </div>
                     </div>
                   </td>


### PR DESCRIPTION
### Motivation
- Remove duplicated `Sale` model field declarations to avoid ambiguity and ensure each discount/notes-related attribute is defined once.
- Surface `coupon_name_raw` and `seller_note` on the assign-referrers sales list so reviewers can see coupon and seller notes while assigning referrers.

### Description
- Removed duplicate field declarations in `Sale` so `list_price`, `discount_amount`, `is_discounted`, `discount_reasons`, `seller_note`, `coupon_name_raw`, `product_short_name`, `manual_discount_flag`, `discount_notes`, and `return_value` are declared a single time in `inventory/models.py`.
- Normalized `is_discounted` to `models.BooleanField(default=False)` and adjusted `manual_discount_flag` to allow blank/null to match prior migrations.
- Changed `coupon_name_raw` to `models.CharField(max_length=255, blank=True, null=True)` and kept `seller_note` as `models.TextField(blank=True, null=True)` to match the migration history.
- Updated `inventory/templates/inventory/sales_assign_referrers.html` to display `Coupon: {{ item.sale.coupon_name_raw }}` and `Seller note: {{ item.sale.seller_note }}` for each sale item when present.

### Testing
- Attempted to run `python manage.py makemigrations --check --dry-run && python manage.py check` and it failed in this environment because Django is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e350eb44d0832ca7ccec0c35006003)