### PR TITLE
Assign-referrers: show referrer name/edit icon and add order/item discount-reason chips

### DIFF
--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -91,8 +91,43 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+      gap: 16px;
       font-weight: 600;
       margin-bottom: 16px;
+    }
+
+    .order-topline__meta {
+      flex: 0 0 auto;
+    }
+
+    .order-topline__discount-reasons {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-left: auto;
+      margin-right: 12px;
+      font-weight: 500;
+    }
+
+    .order-topline__discount-link {
+      font-size: 0.95rem;
+      color: #00897b;
+      text-decoration: underline;
+      cursor: pointer;
+    }
+
+    .discount-reason-chip {
+      border: 1px solid #b2dfdb;
+      background: #ffffff;
+      color: #00695c;
+      cursor: pointer;
+      user-select: none;
+      margin: 0;
+    }
+
+    .discount-reason-chip.selected {
+      background: #e0f2f1;
     }
 
     .order-topline__actions {
@@ -114,12 +149,43 @@
       line-height: 1.2;
     }
 
-    .order-topline__action--no-referrer {
-      color: #e53935;
+    .order-topline__referrer-muted {
+      color: #616161;
+      font-weight: 500;
     }
 
-    .order-topline__separator {
-      color: #9e9e9e;
+    .order-topline__referrer-name {
+      color: #00695c;
+      font-weight: 600;
+    }
+
+    .order-item-reasons {
+      margin-top: 8px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .order-item-reason-title {
+      width: 100%;
+      font-size: 0.8rem;
+      color: #616161;
+      font-weight: 500;
+    }
+
+    .order-item-reason-chip {
+      border: 1px solid #d0d0d0;
+      background: #fff;
+      color: #616161;
+      cursor: pointer;
+      margin: 0;
+      user-select: none;
+    }
+
+    .order-item-reason-chip.selected {
+      border-color: #80cbc4;
+      background: #f1fffd;
+      color: #00695c;
     }
   </style>
   <div class="section">
@@ -228,24 +294,24 @@
       {% for order in orders %}
         <div class="order-block" data-order-number="{{ order.order_number }}">
           <div class="order-topline">
-            <span>#{{ order.order_number }} · {{ order.date|date:"F j, Y" }}</span>
+            <span class="order-topline__meta">#{{ order.order_number }} · {{ order.date|date:"F j, Y" }}</span>
+            <span class="order-topline__discount-reasons" data-order-discount-reasons>
+              <a href="#!" class="order-topline__discount-link" data-add-discount-reason>Add reason for discount</a>
+              <button type="button" class="chip discount-reason-chip" data-discount-reason="淘金币">淘金币</button>
+              <button type="button" class="chip discount-reason-chip" data-discount-reason="Gift">Gift</button>
+              <button type="button" class="chip discount-reason-chip" data-discount-reason="Coupon">Coupon</button>
+            </span>
             <span class="order-topline__actions">
               {% if order.referrer %}
-                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action">
-                  Referrer: {{ order.referrer.name }}
+                <span class="order-topline__referrer-name">{{ order.referrer.name }}</span>
+                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action" title="Edit referrer">
+                  <i class="material-icons tiny">edit</i>
                 </a>
               {% else %}
-                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action">
-                  Add Referrer
+                <span class="order-topline__referrer-muted">No referrer</span>
+                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action" title="Add referrer">
+                  <i class="material-icons tiny">add</i>
                 </a>
-                <span class="order-topline__separator">|</span>
-                <button
-                  type="button"
-                  class="order-topline__action order-topline__action--no-referrer ignore-order-button"
-                  data-order-number="{{ order.order_number }}"
-                >
-                  No Referrer
-                </button>
               {% endif %}
             </span>
           </div>
@@ -296,6 +362,12 @@
                             Seller note: {{ item.sale.seller_note }}
                           </div>
                         {% endif %}
+                        <div class="order-item-reasons" data-item-reasons>
+                          <span class="order-item-reason-title">Discount reason</span>
+                          <button type="button" class="chip order-item-reason-chip" data-item-reason="淘金币">淘金币</button>
+                          <button type="button" class="chip order-item-reason-chip" data-item-reason="Gift">Gift</button>
+                          <button type="button" class="chip order-item-reason-chip" data-item-reason="Coupon">Coupon</button>
+                        </div>
                       </div>
                     </div>
                   </td>
@@ -395,48 +467,6 @@
       var modalElems = document.querySelectorAll('.modal');
       M.Modal.init(modalElems);
 
-      var bindIgnoreButton = function(button) {
-        if (!button || button.dataset.ignoreBound === '1') {
-          return;
-        }
-        button.dataset.ignoreBound = '1';
-        button.addEventListener('click', function() {
-          var orderNumber = button.dataset.orderNumber || '';
-          if (!orderNumber || button.disabled) {
-            return;
-          }
-
-          button.disabled = true;
-          fetch("{% url 'ignore_order_referrer_discount_range' %}", {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-              'X-CSRFToken': getCookie('csrftoken'),
-              'X-Requested-With': 'XMLHttpRequest',
-            },
-            body: new URLSearchParams({ order_number: orderNumber }).toString(),
-          })
-            .then(function(response) {
-              if (!response.ok) {
-                throw new Error('Request failed');
-              }
-              return response.json();
-            })
-            .then(function(data) {
-              if (!data.ok) {
-                throw new Error(data.error || 'Unable to ignore order');
-              }
-              var orderBlock = button.closest('.order-block');
-              if (orderBlock) {
-                orderBlock.remove();
-              }
-            })
-            .catch(function() {
-              button.disabled = false;
-            });
-        });
-      };
-
       var chipGroups = document.querySelectorAll('.referrer-chip-group');
       chipGroups.forEach(function(group) {
         var chips = group.querySelectorAll('.referrer-chip');
@@ -512,16 +542,14 @@
                 if (actionsContainer) {
                   if (data.referrer_name) {
                     actionsContainer.innerHTML =
-                      '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action">Referrer: '
-                      + escapeHtml(data.referrer_name) + '</a>';
+                      '<span class="order-topline__referrer-name">' + escapeHtml(data.referrer_name) + '</span>'
+                      + '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action" title="Edit referrer">'
+                      + '<i class="material-icons tiny">edit</i></a>';
                   } else {
-                    var orderNumber = orderBlock.dataset.orderNumber || '';
                     actionsContainer.innerHTML =
-                      '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action">Add Referrer</a>'
-                      + '<span class="order-topline__separator">|</span>'
-                      + '<button type="button" class="order-topline__action order-topline__action--no-referrer ignore-order-button" data-order-number="'
-                      + escapeHtml(orderNumber) + '">No Referrer</button>';
-                    bindIgnoreButton(actionsContainer.querySelector('.ignore-order-button'));
+                      '<span class="order-topline__referrer-muted">No referrer</span>'
+                      + '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action" title="Add referrer">'
+                      + '<i class="material-icons tiny">add</i></a>';
                   }
                 }
               }
@@ -590,9 +618,94 @@
       }
       updateLabel();
 
-      var ignoreButtons = document.querySelectorAll('.ignore-order-button');
-      ignoreButtons.forEach(function(button) {
-        bindIgnoreButton(button);
+      var bindOrderReasonGroup = function(orderBlock) {
+        if (!orderBlock) {
+          return;
+        }
+
+        var orderReasonChips = orderBlock.querySelectorAll('.discount-reason-chip');
+        var addReasonLink = orderBlock.querySelector('[data-add-discount-reason]');
+        var itemReasonGroups = orderBlock.querySelectorAll('[data-item-reasons]');
+
+        var toggleItemReason = function(itemGroup, reason, selected) {
+          var itemChip = itemGroup.querySelector('[data-item-reason="' + reason + '"]');
+          if (!itemChip) {
+            return;
+          }
+          itemChip.classList.toggle('selected', selected);
+        };
+
+        orderReasonChips.forEach(function(chip) {
+          chip.addEventListener('click', function() {
+            var reason = chip.dataset.discountReason || '';
+            if (!reason) {
+              return;
+            }
+
+            var isSelected = !chip.classList.contains('selected');
+            chip.classList.toggle('selected', isSelected);
+            itemReasonGroups.forEach(function(itemGroup) {
+              toggleItemReason(itemGroup, reason, isSelected);
+            });
+          });
+        });
+
+        if (addReasonLink) {
+          addReasonLink.addEventListener('click', function(event) {
+            event.preventDefault();
+            var reason = window.prompt('Add a discount reason chip (e.g. 淘金币):');
+            if (!reason) {
+              return;
+            }
+            var trimmedReason = reason.trim();
+            if (!trimmedReason) {
+              return;
+            }
+
+            var existingOrderChip = orderBlock.querySelector('[data-discount-reason="' + trimmedReason + '"]');
+            if (existingOrderChip) {
+              return;
+            }
+
+            var orderChip = document.createElement('button');
+            orderChip.type = 'button';
+            orderChip.className = 'chip discount-reason-chip';
+            orderChip.dataset.discountReason = trimmedReason;
+            orderChip.textContent = trimmedReason;
+            addReasonLink.insertAdjacentElement('afterend', orderChip);
+
+            itemReasonGroups.forEach(function(itemGroup) {
+              var itemChip = document.createElement('button');
+              itemChip.type = 'button';
+              itemChip.className = 'chip order-item-reason-chip';
+              itemChip.dataset.itemReason = trimmedReason;
+              itemChip.textContent = trimmedReason;
+              itemGroup.appendChild(itemChip);
+            });
+
+            orderChip.addEventListener('click', function() {
+              var isSelected = !orderChip.classList.contains('selected');
+              orderChip.classList.toggle('selected', isSelected);
+              itemReasonGroups.forEach(function(itemGroup) {
+                toggleItemReason(itemGroup, trimmedReason, isSelected);
+              });
+            });
+          });
+        }
+
+        itemReasonGroups.forEach(function(itemGroup) {
+          itemGroup.addEventListener('click', function(event) {
+            var target = event.target;
+            if (!target.classList.contains('order-item-reason-chip')) {
+              return;
+            }
+            target.classList.toggle('selected');
+          });
+        });
+      };
+
+      document.querySelectorAll('.order-block').forEach(function(orderBlock) {
+        bindOrderReasonGroup(orderBlock);
       });
     });
   </script>

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1221,7 +1221,7 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["order_numbers_text"], "ORDER-B ORDER-A")
 
-    def test_ignore_button_hidden_when_order_has_referrer(self):
+    def test_no_ignore_button_rendered(self):
         self.product.retail_price = Decimal("100")
         self.product.save(update_fields=["retail_price"])
         referrer = Referrer.objects.create(name="Coach")
@@ -1249,12 +1249,7 @@ class SalesViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         html = response.content.decode("utf-8")
-        self.assertEqual(
-            html.count(
-                'class="order-topline__action order-topline__action--no-referrer ignore-order-button"'
-            ),
-            1,
-        )
+        self.assertNotIn("ignore-order-button", html)
 
     def test_discount_slider_renders_single_track_with_endpoints(self):
         self.product.retail_price = Decimal("100")
@@ -1281,7 +1276,7 @@ class SalesViewTests(TestCase):
         self.assertIn(">0%</span>", html)
         self.assertIn(">100%</span>", html)
 
-    def test_order_topline_actions_use_add_and_no_referrer_labels(self):
+    def test_order_topline_actions_use_no_referrer_text_and_add_icon(self):
         self.product.retail_price = Decimal("100")
         self.product.save(update_fields=["retail_price"])
         Sale.objects.create(
@@ -1299,9 +1294,9 @@ class SalesViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         html = response.content.decode("utf-8")
-        self.assertIn("Add Referrer", html)
-        self.assertIn("No Referrer", html)
-        self.assertIn('class="order-topline__separator">|</span>', html)
+        self.assertIn("No referrer", html)
+        self.assertIn('title="Add referrer"', html)
+        self.assertNotIn("Add Referrer", html)
 
     def test_order_topline_shows_assigned_referrer_name(self):
         self.product.retail_price = Decimal("100")
@@ -1323,9 +1318,32 @@ class SalesViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         html = response.content.decode("utf-8")
-        self.assertIn("Referrer: Coach Sora", html)
+        self.assertIn("Coach Sora", html)
+        self.assertIn('title="Edit referrer"', html)
         self.assertNotIn("Add Referrer", html)
         self.assertNotIn("No Referrer", html)
+
+    def test_discount_reason_controls_render_on_order_and_items(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        Sale.objects.create(
+            order_number="DISCOUNT-REASON-ORDER",
+            date=date(2024, 4, 11),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+        )
+
+        response = self.client.get(
+            reverse("sales_assign_referrers"),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode("utf-8")
+        self.assertIn("Add reason for discount", html)
+        self.assertIn('data-discount-reason="淘金币"', html)
+        self.assertIn('data-item-reason="淘金币"', html)
 
 
 class SalesBucketDetailViewTests(TestCase):


### PR DESCRIPTION
### Motivation
- Update the Assign Referrers workflow to simplify referrer actions in the order topline and provide a way to tag orders/items with a "reason for discount" so reasons can be applied at order level and adjusted per item. 
- Replace the previous "Add Referrer" / "No Referrer" action pair with a cleaner name + edit/add icon UX and introduce discount-reason chips for the broader set of tasks described.

### Description
- Updated `inventory/templates/inventory/sales_assign_referrers.html` to change the order topline layout so the order/date is on the left, a new order-level discount-reason control sits in the middle, and referrer controls are on the right, rendering assigned referrers as `{{ order.referrer.name }}` plus an edit (pen) icon and unassigned orders as plain `No referrer` text plus a `+` icon.
- Added order-level discount-reason chips (`淘金币`, `Gift`, `Coupon`) and an `Add reason for discount` link; added per-line-item reason chips so each item can be toggled independently.
- Implemented client-side JavaScript to sync order-level chip selection across all line items for that order, allow per-item toggling, and support dynamically adding a custom reason chip via a prompt.
- Adjusted tests in `inventory/tests.py` to expect the new topline markup and added a test that the discount-reason controls render on orders and items.

### Testing
- Attempted to run `python manage.py test inventory.tests.SalesAssignReferrersViewTests` in this environment but it failed because Django is not installed (`ModuleNotFoundError: No module named 'django'`), so the updated tests could not be executed here.
- Template/JS changes were smoke-checked locally in the repository (static inspection and unit-test updates), but full automated test run was not possible due to the missing Django runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3583118b4832cbce7fa361745bf0d)