### PR TITLE
Add per-order/item discount reason UI and simplify referrer actions

### DIFF
--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -91,8 +91,43 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+      gap: 16px;
       font-weight: 600;
       margin-bottom: 16px;
+    }
+
+    .order-topline__meta {
+      flex: 0 0 auto;
+    }
+
+    .order-topline__discount-reasons {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-left: auto;
+      margin-right: 12px;
+      font-weight: 500;
+    }
+
+    .order-topline__discount-link {
+      font-size: 0.95rem;
+      color: #00897b;
+      text-decoration: underline;
+      cursor: pointer;
+    }
+
+    .discount-reason-chip {
+      border: 1px solid #b2dfdb;
+      background: #ffffff;
+      color: #00695c;
+      cursor: pointer;
+      user-select: none;
+      margin: 0;
+    }
+
+    .discount-reason-chip.selected {
+      background: #e0f2f1;
     }
 
     .order-topline__actions {
@@ -114,12 +149,53 @@
       line-height: 1.2;
     }
 
-    .order-topline__action--no-referrer {
-      color: #e53935;
+    .order-topline__referrer-muted {
+      color: #616161;
+      font-weight: 500;
     }
 
-    .order-topline__separator {
-      color: #9e9e9e;
+    .order-topline__referrer-name {
+      color: #00695c;
+      font-weight: 600;
+    }
+
+    .discount-reason-cell {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+      min-height: 32px;
+    }
+
+    .discount-reason-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: #e0f2f1;
+      color: #00695c;
+      border-radius: 16px;
+      padding: 4px 10px;
+      font-size: 0.95rem;
+      font-weight: 600;
+    }
+
+    .discount-reason-pill__remove {
+      border: 0;
+      background: transparent;
+      color: #00695c;
+      cursor: pointer;
+      font-size: 0.9rem;
+      line-height: 1;
+      padding: 0;
+      font-weight: 700;
+    }
+
+    .discount-reason-add {
+      color: #00897b;
+      background: transparent;
+      border: 0;
+      cursor: pointer;
+      padding: 0 4px;
     }
   </style>
   <div class="section">
@@ -228,24 +304,24 @@
       {% for order in orders %}
         <div class="order-block" data-order-number="{{ order.order_number }}">
           <div class="order-topline">
-            <span>#{{ order.order_number }} · {{ order.date|date:"F j, Y" }}</span>
+            <span class="order-topline__meta">#{{ order.order_number }} · {{ order.date|date:"F j, Y" }}</span>
+            <span class="order-topline__discount-reasons" data-order-discount-reasons>
+              <a href="#!" class="order-topline__discount-link" data-add-discount-reason>Add reason for discount</a>
+              <button type="button" class="chip discount-reason-chip" data-discount-reason="淘金币">淘金币</button>
+              <button type="button" class="chip discount-reason-chip" data-discount-reason="Gift">Gift</button>
+              <button type="button" class="chip discount-reason-chip" data-discount-reason="Coupon">Coupon</button>
+            </span>
             <span class="order-topline__actions">
               {% if order.referrer %}
-                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action">
-                  Referrer: {{ order.referrer.name }}
+                <span class="order-topline__referrer-name">{{ order.referrer.name }}</span>
+                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action" title="Edit referrer">
+                  <i class="material-icons tiny">edit</i>
                 </a>
               {% else %}
-                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action">
-                  Add Referrer
+                <span class="order-topline__referrer-muted">No referrer</span>
+                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action" title="Add referrer">
+                  <i class="material-icons tiny">add</i>
                 </a>
-                <span class="order-topline__separator">|</span>
-                <button
-                  type="button"
-                  class="order-topline__action order-topline__action--no-referrer ignore-order-button"
-                  data-order-number="{{ order.order_number }}"
-                >
-                  No Referrer
-                </button>
               {% endif %}
             </span>
           </div>
@@ -259,12 +335,13 @@
                 <th>Actual price</th>
                 <th>Total paid</th>
                 <th>Refunded</th>
+                <th>Discount reason</th>
                 <th>Status</th>
               </tr>
             </thead>
             <tbody>
               {% for item in order.items %}
-                <tr class="{% if not item.is_filtered_item %}grey-text text-lighten-1{% endif %}">
+                <tr class="{% if not item.is_filtered_item %}grey-text text-lighten-1{% endif %}" data-sale-id="{{ item.sale.id }}">
                   <td>
                     <div class="order-item-product">
                       {% if item.sale.variant.product.product_photo %}
@@ -318,6 +395,19 @@
                     {% endif %}
                   </td>
                   <td>
+                    <div class="discount-reason-cell" data-item-discount-reason-cell>
+                      <button
+                        type="button"
+                        class="discount-reason-add"
+                        data-add-item-reason
+                        title="Add discount reason for this item"
+                        aria-label="Add discount reason for this item"
+                      >
+                        <i class="material-icons tiny">add</i>
+                      </button>
+                    </div>
+                  </td>
+                  <td>
                     {% if item.returned %}
                       <span class="chip return-chip red lighten-5 red-text text-darken-2">Returned</span>
                     {% else %}
@@ -337,6 +427,7 @@
                     <span class="order-returns red-text text-darken-1">-¥{{ order.returns_value|floatformat:2 }}</span>
                   {% endif %}
                 </td>
+                <td></td>
                 <td></td>
               </tr>
             </tbody>
@@ -394,48 +485,6 @@
 
       var modalElems = document.querySelectorAll('.modal');
       M.Modal.init(modalElems);
-
-      var bindIgnoreButton = function(button) {
-        if (!button || button.dataset.ignoreBound === '1') {
-          return;
-        }
-        button.dataset.ignoreBound = '1';
-        button.addEventListener('click', function() {
-          var orderNumber = button.dataset.orderNumber || '';
-          if (!orderNumber || button.disabled) {
-            return;
-          }
-
-          button.disabled = true;
-          fetch("{% url 'ignore_order_referrer_discount_range' %}", {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-              'X-CSRFToken': getCookie('csrftoken'),
-              'X-Requested-With': 'XMLHttpRequest',
-            },
-            body: new URLSearchParams({ order_number: orderNumber }).toString(),
-          })
-            .then(function(response) {
-              if (!response.ok) {
-                throw new Error('Request failed');
-              }
-              return response.json();
-            })
-            .then(function(data) {
-              if (!data.ok) {
-                throw new Error(data.error || 'Unable to ignore order');
-              }
-              var orderBlock = button.closest('.order-block');
-              if (orderBlock) {
-                orderBlock.remove();
-              }
-            })
-            .catch(function() {
-              button.disabled = false;
-            });
-        });
-      };
 
       var chipGroups = document.querySelectorAll('.referrer-chip-group');
       chipGroups.forEach(function(group) {
@@ -512,16 +561,14 @@
                 if (actionsContainer) {
                   if (data.referrer_name) {
                     actionsContainer.innerHTML =
-                      '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action">Referrer: '
-                      + escapeHtml(data.referrer_name) + '</a>';
+                      '<span class="order-topline__referrer-name">' + escapeHtml(data.referrer_name) + '</span>'
+                      + '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action" title="Edit referrer">'
+                      + '<i class="material-icons tiny">edit</i></a>';
                   } else {
-                    var orderNumber = orderBlock.dataset.orderNumber || '';
                     actionsContainer.innerHTML =
-                      '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action">Add Referrer</a>'
-                      + '<span class="order-topline__separator">|</span>'
-                      + '<button type="button" class="order-topline__action order-topline__action--no-referrer ignore-order-button" data-order-number="'
-                      + escapeHtml(orderNumber) + '">No Referrer</button>';
-                    bindIgnoreButton(actionsContainer.querySelector('.ignore-order-button'));
+                      '<span class="order-topline__referrer-muted">No referrer</span>'
+                      + '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action" title="Add referrer">'
+                      + '<i class="material-icons tiny">add</i></a>';
                   }
                 }
               }
@@ -590,9 +637,163 @@
       }
       updateLabel();
 
-      var ignoreButtons = document.querySelectorAll('.ignore-order-button');
-      ignoreButtons.forEach(function(button) {
-        bindIgnoreButton(button);
+      var bindOrderReasonGroup = function(orderBlock) {
+        if (!orderBlock) {
+          return;
+        }
+
+        var orderReasonChips = orderBlock.querySelectorAll('.discount-reason-chip');
+        var addReasonLink = orderBlock.querySelector('[data-add-discount-reason]');
+        var itemRows = orderBlock.querySelectorAll('tr[data-sale-id]');
+        var saleReasonMap = new Map();
+        var availableReasons = ['淘金币', 'Gift', 'Coupon'];
+
+        var createReasonPill = function(reason, cell) {
+          var pill = document.createElement('span');
+          pill.className = 'discount-reason-pill';
+          pill.dataset.reason = reason;
+          pill.innerHTML = escapeHtml(reason) + '<button type="button" class="discount-reason-pill__remove" title="Remove reason" aria-label="Remove reason">×</button>';
+          cell.insertBefore(pill, cell.querySelector('[data-add-item-reason]'));
+        };
+
+        var renderReasonsForRow = function(row) {
+          var saleId = row.dataset.saleId || '';
+          var selectedReasons = saleReasonMap.get(saleId) || new Set();
+          var cell = row.querySelector('[data-item-discount-reason-cell]');
+          if (!cell) {
+            return;
+          }
+          cell.querySelectorAll('.discount-reason-pill').forEach(function(pill) {
+            pill.remove();
+          });
+          Array.from(selectedReasons).sort().forEach(function(reason) {
+            createReasonPill(reason, cell);
+          });
+        };
+
+        var renderAllRows = function() {
+          itemRows.forEach(function(row) {
+            renderReasonsForRow(row);
+          });
+        };
+
+        var setReasonOnAllRows = function(reason, selected) {
+          itemRows.forEach(function(row) {
+            var saleId = row.dataset.saleId || '';
+            if (!saleId) {
+              return;
+            }
+            var selectedReasons = saleReasonMap.get(saleId) || new Set();
+            if (selected) {
+              selectedReasons.add(reason);
+            } else {
+              selectedReasons.delete(reason);
+            }
+            saleReasonMap.set(saleId, selectedReasons);
+          });
+          renderAllRows();
+        };
+
+        orderReasonChips.forEach(function(chip) {
+          chip.addEventListener('click', function() {
+            var reason = chip.dataset.discountReason || '';
+            if (!reason) {
+              return;
+            }
+
+            var isSelected = !chip.classList.contains('selected');
+            chip.classList.toggle('selected', isSelected);
+            setReasonOnAllRows(reason, isSelected);
+          });
+        });
+
+        if (addReasonLink) {
+          addReasonLink.addEventListener('click', function(event) {
+            event.preventDefault();
+            var reason = window.prompt('Add a discount reason chip (e.g. 淘金币):');
+            if (!reason) {
+              return;
+            }
+            var trimmedReason = reason.trim();
+            if (!trimmedReason) {
+              return;
+            }
+
+            if (availableReasons.indexOf(trimmedReason) === -1) {
+              availableReasons.push(trimmedReason);
+            }
+
+            var existingOrderChip = orderBlock.querySelector('[data-discount-reason="' + trimmedReason + '"]');
+            if (existingOrderChip) {
+              return;
+            }
+
+            var orderChip = document.createElement('button');
+            orderChip.type = 'button';
+            orderChip.className = 'chip discount-reason-chip';
+            orderChip.dataset.discountReason = trimmedReason;
+            orderChip.textContent = trimmedReason;
+            addReasonLink.insertAdjacentElement('afterend', orderChip);
+
+            orderChip.addEventListener('click', function() {
+              var isSelected = !orderChip.classList.contains('selected');
+              orderChip.classList.toggle('selected', isSelected);
+              setReasonOnAllRows(trimmedReason, isSelected);
+            });
+          });
+        }
+
+        orderBlock.addEventListener('click', function(event) {
+          var removeButton = event.target.closest('.discount-reason-pill__remove');
+          if (removeButton) {
+            var pill = removeButton.closest('.discount-reason-pill');
+            var row = removeButton.closest('tr[data-sale-id]');
+            var reason = pill ? (pill.dataset.reason || '') : '';
+            var saleId = row ? (row.dataset.saleId || '') : '';
+            if (!reason || !saleId) {
+              return;
+            }
+            var selectedReasons = saleReasonMap.get(saleId) || new Set();
+            selectedReasons.delete(reason);
+            saleReasonMap.set(saleId, selectedReasons);
+            renderReasonsForRow(row);
+            return;
+          }
+
+          var addItemReasonButton = event.target.closest('[data-add-item-reason]');
+          if (!addItemReasonButton) {
+            return;
+          }
+          var row = addItemReasonButton.closest('tr[data-sale-id]');
+          var saleId = row ? (row.dataset.saleId || '') : '';
+          if (!saleId) {
+            return;
+          }
+
+          var suggestionText = availableReasons.join(', ');
+          var reason = window.prompt('Add reason for this item. Available: ' + suggestionText, availableReasons[0] || '');
+          if (!reason) {
+            return;
+          }
+          var trimmedReason = reason.trim();
+          if (!trimmedReason) {
+            return;
+          }
+
+          if (availableReasons.indexOf(trimmedReason) === -1) {
+            availableReasons.push(trimmedReason);
+          }
+          var selectedReasons = saleReasonMap.get(saleId) || new Set();
+          selectedReasons.add(trimmedReason);
+          saleReasonMap.set(saleId, selectedReasons);
+          renderReasonsForRow(row);
+        });
+
+        renderAllRows();
+      };
+
+      document.querySelectorAll('.order-block').forEach(function(orderBlock) {
+        bindOrderReasonGroup(orderBlock);
       });
     });
   </script>

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1221,7 +1221,7 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["order_numbers_text"], "ORDER-B ORDER-A")
 
-    def test_ignore_button_hidden_when_order_has_referrer(self):
+    def test_no_ignore_button_rendered(self):
         self.product.retail_price = Decimal("100")
         self.product.save(update_fields=["retail_price"])
         referrer = Referrer.objects.create(name="Coach")
@@ -1249,12 +1249,7 @@ class SalesViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         html = response.content.decode("utf-8")
-        self.assertEqual(
-            html.count(
-                'class="order-topline__action order-topline__action--no-referrer ignore-order-button"'
-            ),
-            1,
-        )
+        self.assertNotIn("ignore-order-button", html)
 
     def test_discount_slider_renders_single_track_with_endpoints(self):
         self.product.retail_price = Decimal("100")
@@ -1281,7 +1276,7 @@ class SalesViewTests(TestCase):
         self.assertIn(">0%</span>", html)
         self.assertIn(">100%</span>", html)
 
-    def test_order_topline_actions_use_add_and_no_referrer_labels(self):
+    def test_order_topline_actions_use_no_referrer_text_and_add_icon(self):
         self.product.retail_price = Decimal("100")
         self.product.save(update_fields=["retail_price"])
         Sale.objects.create(
@@ -1299,9 +1294,9 @@ class SalesViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         html = response.content.decode("utf-8")
-        self.assertIn("Add Referrer", html)
-        self.assertIn("No Referrer", html)
-        self.assertIn('class="order-topline__separator">|</span>', html)
+        self.assertIn("No referrer", html)
+        self.assertIn('title="Add referrer"', html)
+        self.assertNotIn("Add Referrer", html)
 
     def test_order_topline_shows_assigned_referrer_name(self):
         self.product.retail_price = Decimal("100")
@@ -1323,9 +1318,35 @@ class SalesViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         html = response.content.decode("utf-8")
-        self.assertIn("Referrer: Coach Sora", html)
+        self.assertIn("Coach Sora", html)
+        self.assertIn('title="Edit referrer"', html)
         self.assertNotIn("Add Referrer", html)
         self.assertNotIn("No Referrer", html)
+
+    def test_discount_reason_controls_render_on_order_and_items(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        Sale.objects.create(
+            order_number="DISCOUNT-REASON-ORDER",
+            date=date(2024, 4, 11),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+        )
+
+        response = self.client.get(
+            reverse("sales_assign_referrers"),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode("utf-8")
+        self.assertIn("Add reason for discount", html)
+        self.assertIn("<th>Discount reason</th>", html)
+        self.assertIn('data-discount-reason="淘金币"', html)
+        self.assertIn('data-item-discount-reason-cell', html)
+        self.assertIn('data-add-item-reason', html)
+        self.assertNotIn("discount-reason-pill", html)
 
 
 class SalesBucketDetailViewTests(TestCase):


### PR DESCRIPTION
### Motivation

- Introduce UI to capture discount reasons at the order and item level and make the order topline clearer by showing referrer name and compact edit/add icons.  
- Remove the legacy "ignore order" control and its associated behavior to simplify actions and flow when no referrer is assigned.  

### Description

- Added CSS and HTML to render a discount-reason control area per order with clickable reason chips and per-item reason pills, and added a new table column `Discount reason`.  
- Added `data-sale-id` attributes to item rows and new markup for order topline: show referrer name with `order-topline__referrer-name`, use icon buttons for edit/add, and replace the old `No Referrer` button with muted text and an icon link.  
- Implemented client-side JS to manage discount-reason chips and per-item reason pills (`bindOrderReasonGroup`), handle adding custom reasons, and render/remove pills; removed the `bindIgnoreButton` logic and related `ignore-order-button` behavior.  
- Updated the referrer-assignment JS to render the new topline HTML (name + edit icon or muted text + add icon) and to close the modal on success.  
- Updated server-side tests in `inventory/tests.py` to reflect the markup changes and added `test_discount_reason_controls_render_on_order_and_items` to verify presence of the new controls.  

### Testing

- Ran the inventory test suite with `python manage.py test inventory` and the modified `SalesViewTests` passed.  
- Verified `test_no_ignore_button_rendered`, `test_order_topline_actions_use_no_referrer_text_and_add_icon`, `test_order_topline_shows_assigned_referrer_name`, and the new `test_discount_reason_controls_render_on_order_and_items` all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3583118b4832cbce7fa361745bf0d)