### PR TITLE
Refine assign-referrer sales table with reusable global styles

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -1137,9 +1137,197 @@ vertical-align: middle;
   font-size: 0.95rem;
 }
 
+
+
+.discount-range-slider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 340px;
+}
+
+.discount-range-track-wrap {
+  position: relative;
+  width: 320px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+}
+
+.discount-range-track-bg,
+.discount-range-track-fill {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 4px;
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+.discount-range-track-bg {
+  background: #cfcfd4;
+}
+
+.discount-range-track-fill {
+  background: #26a69a;
+}
+
+.discount-range-track-wrap input[type="range"] {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+  margin: 0;
+  background: transparent;
+  pointer-events: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.discount-range-track-wrap input[type="range"]::-webkit-slider-thumb {
+  pointer-events: auto;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #26a69a;
+  border: 0;
+  cursor: pointer;
+}
+
+.discount-range-track-wrap input[type="range"]::-moz-range-thumb {
+  pointer-events: auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #26a69a;
+  border: 0;
+  cursor: pointer;
+}
+
+.discount-range-track-wrap input[type="range"]::-webkit-slider-runnable-track,
+.discount-range-track-wrap input[type="range"]::-moz-range-track {
+  background: transparent;
+}
+
+.discount-range-values {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  font-size: 0.85rem;
+  color: #616161;
+}
+
+.order-topline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.order-topline__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: inherit;
+}
+
+.order-topline__action {
+  color: #00897b;
+  text-transform: none;
+  font-size: inherit;
+  font-weight: inherit;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1.2;
+}
+
+.order-topline__action--no-referrer {
+  color: #e53935;
+}
+
+.order-topline__separator {
+  color: #9e9e9e;
+}
+
 .order-items-table th,
 .order-items-table td {
   vertical-align: middle;
+}
+
+.sales-table {
+  border: 1px solid #e6e7eb;
+  border-radius: 14px;
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: hidden;
+}
+
+.sales-table thead tr {
+  background: #f6f7f9;
+}
+
+.sales-table thead th {
+  color: #616161;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 0.9rem 0.9rem;
+  text-transform: uppercase;
+}
+
+.sales-table tbody tr {
+  border-bottom: 1px solid #eeeff2;
+  transition: background-color 0.2s ease;
+}
+
+.sales-table tbody tr:hover {
+  background-color: #fafafb;
+}
+
+.sales-table tbody td {
+  border-bottom: 1px solid #eeeff2;
+  padding: 0.85rem 0.9rem;
+}
+
+.sales-table tbody tr:last-child td {
+  border-bottom: 0;
+  background: #fbfcfe;
+}
+
+.sales-table .variant-code {
+  color: #1f2937;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.sales-table .order-total {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.sales-table .return-chip {
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.sales-table .discount-percentage {
+  background: #f1f5f9;
+  border-radius: 999px;
+  color: #546e7a;
+  display: inline-flex;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
 }
 
 .order-item-product {

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -3,125 +3,6 @@
 {% block title %}Assign Referrers{% endblock %}
 
 {% block content %}
-  <style>
-    .discount-range-slider {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      min-width: 340px;
-    }
-
-    .discount-range-track-wrap {
-      position: relative;
-      width: 320px;
-      height: 32px;
-      display: flex;
-      align-items: center;
-    }
-
-    .discount-range-track-bg,
-    .discount-range-track-fill {
-      position: absolute;
-      left: 0;
-      right: 0;
-      height: 4px;
-      border-radius: 999px;
-      pointer-events: none;
-    }
-
-    .discount-range-track-bg {
-      background: #cfcfd4;
-    }
-
-    .discount-range-track-fill {
-      background: #26a69a;
-    }
-
-    .discount-range-track-wrap input[type="range"] {
-      position: absolute;
-      left: 0;
-      top: 50%;
-      transform: translateY(-50%);
-      width: 100%;
-      margin: 0;
-      background: transparent;
-      pointer-events: none;
-      -webkit-appearance: none;
-      appearance: none;
-    }
-
-    .discount-range-track-wrap input[type="range"]::-webkit-slider-thumb {
-      pointer-events: auto;
-      -webkit-appearance: none;
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-      background: #26a69a;
-      border: 0;
-      cursor: pointer;
-    }
-
-    .discount-range-track-wrap input[type="range"]::-moz-range-thumb {
-      pointer-events: auto;
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-      background: #26a69a;
-      border: 0;
-      cursor: pointer;
-    }
-
-    .discount-range-track-wrap input[type="range"]::-webkit-slider-runnable-track {
-      background: transparent;
-    }
-
-    .discount-range-track-wrap input[type="range"]::-moz-range-track {
-      background: transparent;
-    }
-
-    .discount-range-values {
-      display: flex;
-      justify-content: space-between;
-      margin-top: 4px;
-      font-size: 0.85rem;
-      color: #616161;
-    }
-
-    .order-topline {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      font-weight: 600;
-      margin-bottom: 16px;
-    }
-
-    .order-topline__actions {
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      font-size: inherit;
-    }
-
-    .order-topline__action {
-      color: #00897b;
-      text-transform: none;
-      font-size: inherit;
-      font-weight: inherit;
-      background: none;
-      border: 0;
-      cursor: pointer;
-      padding: 0;
-      line-height: 1.2;
-    }
-
-    .order-topline__action--no-referrer {
-      color: #e53935;
-    }
-
-    .order-topline__separator {
-      color: #9e9e9e;
-    }
-  </style>
   <div class="section">
 
     <h3 class="page-title">
@@ -250,7 +131,7 @@
             </span>
           </div>
 
-          <table class="highlight order-items-table">
+          <table class="highlight order-items-table sales-table">
             <thead>
               <tr>
                 <th>Item</th>


### PR DESCRIPTION
### Motivation
- Improve the visual design of the sales table on the assign-referrer page and make the slider/topline/table styles reusable across the app instead of being page-local.

### Description
- Remove the inline `<style>` block from `inventory/templates/inventory/sales_assign_referrers.html` and centralize those rules into `inventory/static/styles.css`.
- Add a reusable `.sales-table` style layer in `inventory/static/styles.css` (rounded bordered container, muted uppercase header row, subtle row separators and hover states, and stronger emphasis for variant codes, totals, discount badges, and return chips).
- Apply the `.sales-table` class to the order items table in the assign-referrers template without changing the table HTML structure or content.

### Testing
- Attempted to run `python manage.py check`, but it failed in this environment due to a missing Django dependency (`ModuleNotFoundError: No module named 'django'`).
- Changes were validated by editing the template and stylesheet files and verifying the updated CSS and template references; no additional automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3740b9e04832c9ce55d4d936657d9)