### PR TITLE
Update assign referrer actions on sales assignment page

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -1244,12 +1244,30 @@ vertical-align: middle;
   line-height: 1.2;
 }
 
+.order-topline__action--edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .order-topline__action--no-referrer {
   color: #e53935;
 }
 
 .order-topline__separator {
   color: #9e9e9e;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .order-items-table th,

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -110,12 +110,14 @@
             <span>#{{ order.order_number }} · {{ order.date|date:"F j, Y" }}</span>
             <span class="order-topline__actions">
               {% if order.referrer %}
-                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action">
-                  Referrer: {{ order.referrer.name }}
+                <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action order-topline__action--edit">
+                  <span>{{ order.referrer.name }}</span>
+                  <i class="material-icons tiny" aria-hidden="true">edit</i>
+                  <span class="sr-only">Edit referrer</span>
                 </a>
               {% else %}
                 <a href="#referrer-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action">
-                  Add Referrer
+                  Referrer: Add
                 </a>
                 <span class="order-topline__separator">|</span>
                 <button
@@ -123,7 +125,7 @@
                   class="order-topline__action order-topline__action--no-referrer ignore-order-button"
                   data-order-number="{{ order.order_number }}"
                 >
-                  No Referrer
+                  None
                 </button>
               {% endif %}
             </span>
@@ -391,15 +393,18 @@
                 if (actionsContainer) {
                   if (data.referrer_name) {
                     actionsContainer.innerHTML =
-                      '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action">Referrer: '
-                      + escapeHtml(data.referrer_name) + '</a>';
+                      '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action order-topline__action--edit">'
+                      + '<span>' + escapeHtml(data.referrer_name) + '</span>'
+                      + '<i class="material-icons tiny" aria-hidden="true">edit</i>'
+                      + '<span class="sr-only">Edit referrer</span>'
+                      + '</a>';
                   } else {
                     var orderNumber = orderBlock.dataset.orderNumber || '';
                     actionsContainer.innerHTML =
-                      '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action">Add Referrer</a>'
+                      '<a href="' + escapeHtml(modalHref) + '" class="modal-trigger order-topline__action">Referrer: Add</a>'
                       + '<span class="order-topline__separator">|</span>'
                       + '<button type="button" class="order-topline__action order-topline__action--no-referrer ignore-order-button" data-order-number="'
-                      + escapeHtml(orderNumber) + '">No Referrer</button>';
+                      + escapeHtml(orderNumber) + '">None</button>';
                     bindIgnoreButton(actionsContainer.querySelector('.ignore-order-button'));
                   }
                 }


### PR DESCRIPTION
### Motivation
- Change the assign-referrer UI on the sales list so unassigned orders read `Referrer: Add | None` and assigned orders show just the referrer name with an edit icon, matching the requested UX and preserving the existing behaviors for opening the modal or marking `no_referrer`.

### Description
- Updated the order action markup in `inventory/templates/inventory/sales_assign_referrers.html` to show `Referrer: Add | None` when no referrer is assigned and to display the referrer name plus an edit icon (no `Referrer:` prefix) when assigned.
- Updated the client-side AJAX success rendering in the same template so the DOM is replaced with the new formats immediately after assignment changes.
- Added `.order-topline__action--edit` and a reusable `.sr-only` utility to `inventory/static/styles.css` to align the referrer name and edit icon and to provide an accessible label for the edit action.
- Kept existing behaviors: the modal-trigger still opens the assign-referrer dialog and the ignore/no-referrer button still assigns the `no_referrer` state.

### Testing
- Attempted to run targeted Django tests (`inventory.tests.SalesPageTests.test_assign_referrers_view_defaults_to_ten_to_fifty_discount` and `inventory.tests.SalesPageTests.test_assign_referrer_discount_range_ajax_returns_json`) but the test run failed because Django is not available in the execution environment (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3784081c0832c93c89cdb937590ed)