### PR TITLE
Render discount reasons as colored chips on assign referrers table

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -1345,6 +1345,53 @@ vertical-align: middle;
   padding: 0.25rem 0.5rem;
 }
 
+.discount-reason-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.discount-reason-chip {
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 0.74rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin: 0;
+  padding: 0.28rem 0.58rem;
+  white-space: nowrap;
+}
+
+.discount-reason-chip.tone-0 {
+  background: #ede9fe;
+  color: #5b4ad8;
+}
+
+.discount-reason-chip.tone-1 {
+  background: #fff7d6;
+  color: #b77a00;
+}
+
+.discount-reason-chip.tone-2 {
+  background: #ffe8ef;
+  color: #d64f79;
+}
+
+.discount-reason-chip.tone-3 {
+  background: #e6f8ed;
+  color: #1a9b5f;
+}
+
+.discount-reason-chip.tone-4 {
+  background: #e8f7ff;
+  color: #177bb7;
+}
+
+.discount-reason-chip.tone-5 {
+  background: #f3e8ff;
+  color: #7a3ec8;
+}
+
 .order-item-product {
   align-items: center;
   display: flex;

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -198,7 +198,17 @@
                     </div>
                   </td>
                   <td>¥{{ item.actual_total|floatformat:2 }}</td>
-                  <td></td>
+                  <td>
+                    {% if item.discount_reason_chips %}
+                      <div class="discount-reason-chip-list">
+                        {% for reason in item.discount_reason_chips %}
+                          <span class="discount-reason-chip {{ reason.tone }}">{{ reason.label }}</span>
+                        {% endfor %}
+                      </div>
+                    {% else %}
+                      &mdash;
+                    {% endif %}
+                  </td>
                   <td>
                     {% if item.return_value %}
                       <span class="red-text text-darken-2">¥{{ item.return_value|floatformat:2 }} (x{{ item.return_quantity }})</span>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -314,6 +314,46 @@ def _parse_discount_percent(param: Optional[str], default: int) -> int:
     return min(100, max(0, value))
 
 
+def _get_sale_discount_reason_chips(sale) -> list[dict[str, str]]:
+    raw_reasons = sale.discount_reasons
+    if not raw_reasons:
+        return []
+
+    if isinstance(raw_reasons, str):
+        reasons = [raw_reasons]
+    elif isinstance(raw_reasons, (list, tuple, set)):
+        reasons = list(raw_reasons)
+    else:
+        return []
+
+    chips = []
+    seen_labels = set()
+    for index, reason in enumerate(reasons):
+        if reason is None:
+            continue
+        label = str(reason).strip()
+        if not label:
+            continue
+
+        normalized_label = " ".join(label.replace("_", " ").replace("-", " ").split())
+        if not normalized_label:
+            continue
+
+        normalized_key = normalized_label.casefold()
+        if normalized_key in seen_labels:
+            continue
+        seen_labels.add(normalized_key)
+
+        chips.append(
+            {
+                "label": normalized_label.title(),
+                "tone": f"tone-{index % 6}",
+            }
+        )
+
+    return chips
+
+
 # — Helper to bucket types into our four categories —
 def _simplify_type(type_code):
     tc = (type_code or "").lower()
@@ -5529,6 +5569,7 @@ def sales_assign_referrers(request):
                         "return_value": return_value,
                         "is_filtered_item": sale.pk in filtered_sale_ids,
                         "discount_percentage": _calculate_sale_discount_percentage(sale),
+                        "discount_reason_chips": _get_sale_discount_reason_chips(sale),
                     }
                 )
 


### PR DESCRIPTION
### Motivation
- The assign-referrer sales table currently leaves the "Discount reason" column empty; the goal is to surface `Sale.discount_reasons` as visible, colored chips matching the existing category-chip style for easier scanning.

### Description
- Added a helper ` _get_sale_discount_reason_chips(sale)` to normalize, dedupe, title-case, and assign tone classes to values from `Sale.discount_reasons` in `inventory/views.py`.
- Included `discount_reason_chips` in each sale `item` payload in the `sales_assign_referrers` view so the template has rendered data available.
- Updated `inventory/templates/inventory/sales_assign_referrers.html` to render a chip list for the Discount reason cell (falls back to an em dash when no reasons exist).
- Added chip list and tone styles to `inventory/static/styles.css` (pill shape, spacing, and six soft tone variants) so reasons visually match the category chips.

### Testing
- Ran `python manage.py check` in the container and it failed with `ModuleNotFoundError: No module named 'django'` so framework-level checks could not be completed in this environment.
- A commit was created with the changes and the working tree contains the updated files: `inventory/views.py`, `inventory/templates/inventory/sales_assign_referrers.html`, and `inventory/static/styles.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37d186ba8832c830e171ba228a069)