### PR TITLE
Add Discount model and map known coupon codes during sales upload

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -10,6 +10,7 @@ from .models import (
     Series,
     RestockSetting,
     Referrer,
+    Discount,
 )
 
 from datetime import datetime, timedelta, date
@@ -430,6 +431,12 @@ class RestockSettingAdmin(admin.ModelAdmin):
 class ReferrerAdmin(admin.ModelAdmin):
     list_display = ("name",)
     search_fields = ("name",)
+
+
+@admin.register(Discount)
+class DiscountAdmin(admin.ModelAdmin):
+    list_display = ("name", "code")
+    search_fields = ("name", "code")
 
 
 class OrderItemInline(admin.TabularInline):

--- a/inventory/migrations/0023_discount_sale_discounts.py
+++ b/inventory/migrations/0023_discount_sale_discounts.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0022_sale_discount_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Discount",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("name", models.CharField(max_length=255)),
+                ("code", models.CharField(db_index=True, max_length=255, unique=True)),
+            ],
+            options={
+                "ordering": ["name"],
+            },
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="discounts",
+            field=models.ManyToManyField(blank=True, related_name="sales", to="inventory.discount"),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -310,6 +310,17 @@ class Referrer(models.Model):
         return self.name
 
 
+class Discount(models.Model):
+    name = models.CharField(max_length=255)
+    code = models.CharField(max_length=255, unique=True, db_index=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:
+        return self.name
+
+
 class Sale(models.Model):
     sale_id = models.AutoField(primary_key=True)
     order_number = models.CharField(max_length=50, db_index=True)  # the 内部订单号
@@ -328,6 +339,11 @@ class Sale(models.Model):
     discount_reasons = models.JSONField(default=list, blank=True)
     seller_note = models.TextField(blank=True, null=True)
     coupon_name_raw = models.CharField(max_length=255, blank=True, null=True)
+    discounts = models.ManyToManyField(
+        Discount,
+        blank=True,
+        related_name="sales",
+    )
     product_short_name = models.CharField(max_length=255, blank=True, null=True)
     manual_discount_flag = models.BooleanField(blank=True, null=True)
     discount_notes = models.TextField(blank=True, null=True)

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -28,6 +28,7 @@ from .models import (
     Group,
     RestockSetting,
     Referrer,
+    Discount,
 )
 from django.urls import reverse
 from .admin import SaleAdmin, SaleDateEqualsFilter
@@ -2207,3 +2208,29 @@ class ProductCanvasImageTests(TestCase):
         self.assertEqual(response.status_code, 200)
         with Image.open(BytesIO(response.content)) as img:
             self.assertEqual(img.size, (PRODUCT_CANVAS_MAX_DIMENSION, PRODUCT_CANVAS_MAX_DIMENSION))
+
+
+class SaleDiscountRelationshipTests(TestCase):
+    def test_sale_can_store_multiple_discounts(self):
+        product = Product.objects.create(product_id="P-DIS", product_name="Discounted Product")
+        variant = ProductVariant.objects.create(
+            product=product,
+            variant_code="V-DIS",
+            primary_color="#000000",
+        )
+        sale = Sale.objects.create(
+            order_number="ORD-DIS-1",
+            date=date.today(),
+            variant=variant,
+            sold_quantity=1,
+            sold_value=Decimal("100.00"),
+        )
+        discount_one = Discount.objects.create(name="Tao Jin Bi", code="taojinbi")
+        discount_two = Discount.objects.create(name="Tmall Red Packet", code="天猫红包优惠")
+
+        sale.discounts.add(discount_one, discount_two)
+
+        self.assertCountEqual(
+            sale.discounts.values_list("code", flat=True),
+            ["taojinbi", "天猫红包优惠"],
+        )

--- a/scripts/upload_sales.py
+++ b/scripts/upload_sales.py
@@ -16,7 +16,7 @@ from datetime import datetime, date
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from django.db import transaction
 from django.conf import settings
-from inventory.models import Sale, ProductVariant
+from inventory.models import Discount, Sale, ProductVariant
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +150,14 @@ def _calculate_discount_fields(list_price, sold_value, coupon_name):
     return discount_amount, is_discounted, reasons, manual_discount_flag, discount_notes
 
 
+def _parse_coupon_codes(coupon_name_raw):
+    if coupon_name_raw is None:
+        return []
+
+    normalized_raw = str(coupon_name_raw).replace("；", ";")
+    return [code.strip() for code in normalized_raw.split(";") if code.strip()]
+
+
 
 def _parse_order_date(raw_value):
     if pd.isnull(raw_value):
@@ -191,6 +199,10 @@ def upload_sales(test=False, diff=False):
     should_save = not test and not diff
 
     try:
+        discount_by_code = {
+            discount.code: discount for discount in Discount.objects.all()
+        }
+
         for index, row in df.iterrows():
             try:
                 # ---- parse fields from each row ----
@@ -228,7 +240,7 @@ def upload_sales(test=False, diff=False):
 
                 # ---- create the Sale record ----
                 if should_save:
-                    Sale.objects.create(
+                    sale = Sale.objects.create(
                         order_number   = order_number,
                         date           = order_date,
                         variant        = variant,
@@ -246,6 +258,13 @@ def upload_sales(test=False, diff=False):
                         discount_notes = discount_notes,
                         return_value   = return_value,
                     )
+                    matched_discounts = [
+                        discount_by_code[code]
+                        for code in _parse_coupon_codes(coupon_name_raw)
+                        if code in discount_by_code
+                    ]
+                    if matched_discounts:
+                        sale.discounts.add(*matched_discounts)
 
                 if diff and order_number and order_date and variant:
                     exists = Sale.objects.filter(


### PR DESCRIPTION
### Motivation
- Incoming `优惠券名称` values contain semicolon-separated coupon tokens and should be preserved raw in `Sale.coupon_name_raw` while allowing known platform/product coupons to be mapped to structured records. 
- Provide a managed place (`Discount`) to store human-friendly names and the exact incoming `code` so known coupons can be attached to `Sale` records automatically during upload.

### Description
- Added a new `Discount` model with `name` and unique `code` and registered it in the admin (`inventory/models.py`, `inventory/admin.py`).
- Added a `Sale.discounts` many-to-many relation so a sale can be linked to zero or more known discounts (`inventory/models.py`) and created migration `0023_discount_sale_discounts.py` to create the model and M2M field (`inventory/migrations/0023_discount_sale_discounts.py`).
- Updated `scripts/upload_sales.py` to parse `优惠券名称` tokens via a new `_parse_coupon_codes` helper, load existing `Discount` records, and attach only matching `Discount.code` entries to newly created `Sale` instances while leaving `Sale.coupon_name_raw` unchanged. 
- Added a small test `SaleDiscountRelationshipTests.test_sale_can_store_multiple_discounts` that verifies a sale can be linked to multiple discounts (`inventory/tests.py`).

### Testing
- Compiled modified modules with `python -m compileall inventory/models.py inventory/admin.py scripts/upload_sales.py inventory/migrations/0023_discount_sale_discounts.py inventory/tests.py` and the files compiled successfully. 
- Attempted `python manage.py makemigrations inventory` in this environment but it failed because Django is not installed here, so migration autogeneration/runtime checks were not executed. 
- Created and committed changes (commit message: "Add Discount model and link matched coupon codes to sales").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e384607ac4832ca165e4c4bf0d6280)