### PR TITLE
Add Discount model and render discount chips; ingest coupon codes in sales upload

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -10,6 +10,7 @@ from .models import (
     Series,
     RestockSetting,
     Referrer,
+    Discount,
 )
 
 from datetime import datetime, timedelta, date
@@ -430,6 +431,12 @@ class RestockSettingAdmin(admin.ModelAdmin):
 class ReferrerAdmin(admin.ModelAdmin):
     list_display = ("name",)
     search_fields = ("name",)
+
+
+@admin.register(Discount)
+class DiscountAdmin(admin.ModelAdmin):
+    list_display = ("name", "code")
+    search_fields = ("name", "code")
 
 
 class OrderItemInline(admin.TabularInline):

--- a/inventory/migrations/0023_discount_sale_discounts.py
+++ b/inventory/migrations/0023_discount_sale_discounts.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0022_sale_discount_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Discount",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("name", models.CharField(max_length=255)),
+                ("code", models.CharField(db_index=True, max_length=255, unique=True)),
+            ],
+            options={
+                "ordering": ["name"],
+            },
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="discounts",
+            field=models.ManyToManyField(blank=True, related_name="sales", to="inventory.discount"),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -310,6 +310,17 @@ class Referrer(models.Model):
         return self.name
 
 
+class Discount(models.Model):
+    name = models.CharField(max_length=255)
+    code = models.CharField(max_length=255, unique=True, db_index=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:
+        return self.name
+
+
 class Sale(models.Model):
     sale_id = models.AutoField(primary_key=True)
     order_number = models.CharField(max_length=50, db_index=True)  # the 内部订单号
@@ -328,6 +339,11 @@ class Sale(models.Model):
     discount_reasons = models.JSONField(default=list, blank=True)
     seller_note = models.TextField(blank=True, null=True)
     coupon_name_raw = models.CharField(max_length=255, blank=True, null=True)
+    discounts = models.ManyToManyField(
+        Discount,
+        blank=True,
+        related_name="sales",
+    )
     product_short_name = models.CharField(max_length=255, blank=True, null=True)
     manual_discount_flag = models.BooleanField(blank=True, null=True)
     discount_notes = models.TextField(blank=True, null=True)

--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -1351,6 +1351,58 @@ vertical-align: middle;
   gap: 0.35rem;
 }
 
+.sale-discount-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.25rem;
+}
+
+.sale-discount-chip {
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 0.74rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin: 0;
+  padding: 0.28rem 0.58rem;
+  white-space: nowrap;
+}
+
+.sale-discount-chip.tone-0 {
+  background: #ede9fe;
+  color: #5b4ad8;
+}
+
+.sale-discount-chip.tone-1 {
+  background: #fff7d6;
+  color: #b77a00;
+}
+
+.sale-discount-chip.tone-2 {
+  background: #ffe8ef;
+  color: #d64f79;
+}
+
+.sale-discount-chip.tone-3 {
+  background: #e6f8ed;
+  color: #1a9b5f;
+}
+
+.sale-discount-chip.tone-4 {
+  background: #e8f7ff;
+  color: #177bb7;
+}
+
+.sale-discount-chip.tone-5 {
+  background: #f3e8ff;
+  color: #7a3ec8;
+}
+
+.discount-reason-chip-list--subtle {
+  opacity: 0.8;
+}
+
 .discount-reason-chip {
   border-radius: 999px;
   display: inline-flex;

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -199,8 +199,15 @@
                   <td>x{{ item.sold_quantity }}</td>
                   <td>¥{{ item.actual_total|floatformat:2 }}</td>
                   <td>
+                    {% if item.discount_chips %}
+                      <div class="sale-discount-chip-list">
+                        {% for discount in item.discount_chips %}
+                          <span class="sale-discount-chip {{ discount.tone }}">{{ discount.label }}</span>
+                        {% endfor %}
+                      </div>
+                    {% endif %}
                     {% if item.discount_reason_chips %}
-                      <div class="discount-reason-chip-list">
+                      <div class="discount-reason-chip-list discount-reason-chip-list--subtle">
                         {% for reason in item.discount_reason_chips %}
                           <span class="discount-reason-chip {{ reason.tone }}">{{ reason.label }}</span>
                         {% endfor %}

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -28,6 +28,7 @@ from .models import (
     Group,
     RestockSetting,
     Referrer,
+    Discount,
 )
 from django.urls import reverse
 from .admin import SaleAdmin, SaleDateEqualsFilter
@@ -1221,6 +1222,31 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["order_numbers_text"], "ORDER-B ORDER-A")
 
+    def test_assign_referrers_view_renders_sale_discount_chips(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        discount_one = Discount.objects.create(name="Tao Jin Bi", code="taojinbi")
+        discount_two = Discount.objects.create(name="Tmall Red Packet", code="天猫红包优惠")
+        sale = Sale.objects.create(
+            order_number="ORDER-CHIPS",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+        )
+        sale.discounts.add(discount_one, discount_two)
+
+        response = self.client.get(
+            reverse("sales_assign_referrers"),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode("utf-8")
+        self.assertIn("sale-discount-chip-list", html)
+        self.assertIn("Tao Jin Bi", html)
+        self.assertIn("Tmall Red Packet", html)
+
     def test_ignore_button_hidden_when_order_has_referrer(self):
         self.product.retail_price = Decimal("100")
         self.product.save(update_fields=["retail_price"])
@@ -2207,3 +2233,29 @@ class ProductCanvasImageTests(TestCase):
         self.assertEqual(response.status_code, 200)
         with Image.open(BytesIO(response.content)) as img:
             self.assertEqual(img.size, (PRODUCT_CANVAS_MAX_DIMENSION, PRODUCT_CANVAS_MAX_DIMENSION))
+
+
+class SaleDiscountRelationshipTests(TestCase):
+    def test_sale_can_store_multiple_discounts(self):
+        product = Product.objects.create(product_id="P-DIS", product_name="Discounted Product")
+        variant = ProductVariant.objects.create(
+            product=product,
+            variant_code="V-DIS",
+            primary_color="#000000",
+        )
+        sale = Sale.objects.create(
+            order_number="ORD-DIS-1",
+            date=date.today(),
+            variant=variant,
+            sold_quantity=1,
+            sold_value=Decimal("100.00"),
+        )
+        discount_one = Discount.objects.create(name="Tao Jin Bi", code="taojinbi")
+        discount_two = Discount.objects.create(name="Tmall Red Packet", code="天猫红包优惠")
+
+        sale.discounts.add(discount_one, discount_two)
+
+        self.assertCountEqual(
+            sale.discounts.values_list("code", flat=True),
+            ["taojinbi", "天猫红包优惠"],
+        )

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -354,6 +354,30 @@ def _get_sale_discount_reason_chips(sale) -> list[dict[str, str]]:
     return chips
 
 
+def _get_sale_discount_chips(sale) -> list[dict[str, str]]:
+    chips = []
+    seen_labels = set()
+
+    for index, discount in enumerate(sale.discounts.all()):
+        label = str(discount.name).strip()
+        if not label:
+            continue
+
+        normalized_key = label.casefold()
+        if normalized_key in seen_labels:
+            continue
+        seen_labels.add(normalized_key)
+
+        chips.append(
+            {
+                "label": label,
+                "tone": f"tone-{index % 6}",
+            }
+        )
+
+    return chips
+
+
 # — Helper to bucket types into our four categories —
 def _simplify_type(type_code):
     tc = (type_code or "").lower()
@@ -5440,6 +5464,7 @@ def sales_assign_referrers(request):
         sales_qs.filter(Q(return_quantity__isnull=True) | Q(return_quantity=0))
         .filter(sold_quantity__gt=0)
         .select_related("variant__product", "referrer")
+        .prefetch_related("discounts")
     )
 
     filtered_sales = []
@@ -5504,7 +5529,11 @@ def sales_assign_referrers(request):
             order_filter = filters[0]
             for clause in filters[1:]:
                 order_filter |= clause
-            all_order_sales = list(sales_qs.filter(order_filter).select_related("variant__product", "referrer"))
+            all_order_sales = list(
+                sales_qs.filter(order_filter)
+                .select_related("variant__product", "referrer")
+                .prefetch_related("discounts")
+            )
 
         sales_by_order = defaultdict(list)
         for sale in all_order_sales:
@@ -5569,6 +5598,7 @@ def sales_assign_referrers(request):
                         "return_value": return_value,
                         "is_filtered_item": sale.pk in filtered_sale_ids,
                         "discount_percentage": _calculate_sale_discount_percentage(sale),
+                        "discount_chips": _get_sale_discount_chips(sale),
                         "discount_reason_chips": _get_sale_discount_reason_chips(sale),
                     }
                 )

--- a/scripts/upload_sales.py
+++ b/scripts/upload_sales.py
@@ -16,7 +16,7 @@ from datetime import datetime, date
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from django.db import transaction
 from django.conf import settings
-from inventory.models import Sale, ProductVariant
+from inventory.models import Discount, Sale, ProductVariant
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +150,14 @@ def _calculate_discount_fields(list_price, sold_value, coupon_name):
     return discount_amount, is_discounted, reasons, manual_discount_flag, discount_notes
 
 
+def _parse_coupon_codes(coupon_name_raw):
+    if coupon_name_raw is None:
+        return []
+
+    normalized_raw = str(coupon_name_raw).replace("；", ";")
+    return [code.strip() for code in normalized_raw.split(";") if code.strip()]
+
+
 
 def _parse_order_date(raw_value):
     if pd.isnull(raw_value):
@@ -191,6 +199,10 @@ def upload_sales(test=False, diff=False):
     should_save = not test and not diff
 
     try:
+        discount_by_code = {
+            discount.code: discount for discount in Discount.objects.all()
+        }
+
         for index, row in df.iterrows():
             try:
                 # ---- parse fields from each row ----
@@ -228,7 +240,7 @@ def upload_sales(test=False, diff=False):
 
                 # ---- create the Sale record ----
                 if should_save:
-                    Sale.objects.create(
+                    sale = Sale.objects.create(
                         order_number   = order_number,
                         date           = order_date,
                         variant        = variant,
@@ -246,6 +258,13 @@ def upload_sales(test=False, diff=False):
                         discount_notes = discount_notes,
                         return_value   = return_value,
                     )
+                    matched_discounts = [
+                        discount_by_code[code]
+                        for code in _parse_coupon_codes(coupon_name_raw)
+                        if code in discount_by_code
+                    ]
+                    if matched_discounts:
+                        sale.discounts.add(*matched_discounts)
 
                 if diff and order_number and order_date and variant:
                     exists = Sale.objects.filter(


### PR DESCRIPTION
### Motivation

- Introduce a first-class `Discount` entity so sales can reference multiple discount types and display them in the admin UI and reports.  
- Surface sale-level discount metadata in the `sales_assign_referrers` view and templates to help identify discounted orders at-a-glance.  

### Description

- Add a new `Discount` model and a migration to create the table and a many-to-many field `Sale.discounts`.  
- Register `Discount` in the admin via `DiscountAdmin` and prefetch `discounts` for relevant queries in `sales_assign_referrers`.  
- Add `_get_sale_discount_chips` helper and include `discount_chips` in the order item context, update the `sales_assign_referrers` template to render discount chips, and add corresponding styles in `inventory/static/styles.css`.  
- Enhance `scripts/upload_sales.py` with `_parse_coupon_codes`, lookup of `Discount` by `code`, and attaching matched discounts to created `Sale` records.  
- Add tests: `test_assign_referrers_view_renders_sale_discount_chips` and `SaleDiscountRelationshipTests.test_sale_can_store_multiple_discounts`, and update imports throughout code and tests to include `Discount`.  

### Testing

- Ran the Django test suite for the `inventory` app via `python manage.py test inventory`, which executed the new and existing unit tests and completed successfully.  
- New tests verify that discount chips are rendered in the `sales_assign_referrers` view and that a `Sale` can relate to multiple `Discount` records, and both assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e384607ac4832ca165e4c4bf0d6280)