### PR TITLE
Add async 'Add discounts' modal to sales assign-referrers page

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -1478,6 +1478,28 @@ vertical-align: middle;
   outline-offset: 2px;
 }
 
+.discount-reason-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.discount-reason-chip {
+  border: 0;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+}
+
+.discount-reason-chip.selected {
+  background-color: #00897b;
+  color: #ffffff;
+}
+
+.discount-reason-chip:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
 @media (max-width: 600px) {
   .filter-toolbar,
   .page-summary {

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -122,7 +122,9 @@
                   Add referrer
                 </a>
                 <span class="order-topline__separator">|</span>
-                <a href="">Add Discounts</a>
+                <a href="#discount-modal-{{ forloop.counter }}" class="modal-trigger order-topline__action">
+                  Add discounts
+                </a>
               {% endif %}
             </span>
             <!-- END ACTIONS -->
@@ -195,7 +197,7 @@
                   </td>
                   <td>x{{ item.sold_quantity }}</td>
                   <td>¥{{ item.actual_total|floatformat:2 }}</td>
-                  <td>
+                  <td class="sale-discount-cell" data-sale-id="{{ item.sale.pk }}">
                     {% if item.discount_chips %}
                       <div class="sale-discount-chip-list">
                         {% for discount in item.discount_chips %}
@@ -257,6 +259,29 @@
             </form>
           </div>
           <!-- END REFERRER MODAL -->
+
+          <div id="discount-modal-{{ forloop.counter }}" class="modal">
+            <div class="modal-content">
+              <h4>Add discounts</h4>
+              <p class="grey-text text-darken-1 modal-helper-text">Select one or more discount reasons. Changes save automatically.</p>
+              <div class="discount-reason-chip-group" data-order-number="{{ order.order_number }}">
+                {% for discount in discount_reasons %}
+                  <button
+                    type="button"
+                    class="chip discount-reason-chip {% if discount.id in order.available_discount_ids %}selected{% endif %}"
+                    data-discount-id="{{ discount.id }}"
+                  >
+                    {{ discount.name }}
+                  </button>
+                {% empty %}
+                  <p class="grey-text text-darken-1">No discount reasons configured yet.</p>
+                {% endfor %}
+              </div>
+            </div>
+            <div class="modal-footer">
+              <a href="#!" class="modal-close btn-flat">Done</a>
+            </div>
+          </div>
 
         </div>
         <!-- END SALE -->
@@ -435,6 +460,88 @@
                 submitButton.disabled = false;
               }
             });
+        });
+      });
+
+      var renderDiscountChips = function(container, chips) {
+        if (!container) {
+          return;
+        }
+        if (!chips || !chips.length) {
+          container.innerHTML = '';
+          return;
+        }
+        var html = '<div class="sale-discount-chip-list">';
+        chips.forEach(function(chip) {
+          html += '<span class="sale-discount-chip ' + escapeHtml(chip.tone || '') + '">'
+            + escapeHtml(chip.label || '')
+            + '</span>';
+        });
+        html += '</div>';
+        container.innerHTML = html;
+      };
+
+      var discountGroups = document.querySelectorAll('.discount-reason-chip-group');
+      discountGroups.forEach(function(group) {
+        var orderNumber = group.dataset.orderNumber || '';
+        var orderBlock = group.closest('.order-block');
+        if (!orderNumber) {
+          return;
+        }
+        var chips = group.querySelectorAll('.discount-reason-chip');
+        chips.forEach(function(chip) {
+          chip.addEventListener('click', function() {
+            if (chip.disabled || chip.dataset.pending === '1') {
+              return;
+            }
+
+            var shouldSelect = !chip.classList.contains('selected');
+            var discountId = chip.dataset.discountId || '';
+            if (!discountId) {
+              return;
+            }
+
+            chip.dataset.pending = '1';
+            chip.disabled = true;
+            fetch("{% url 'assign_order_discount_reason' %}", {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+                'X-CSRFToken': getCookie('csrftoken'),
+                'X-Requested-With': 'XMLHttpRequest',
+              },
+              body: new URLSearchParams({
+                order_number: orderNumber,
+                discount_id: discountId,
+                selected: shouldSelect ? '1' : '0',
+              }).toString(),
+            })
+              .then(function(response) {
+                if (!response.ok) {
+                  throw new Error('Request failed');
+                }
+                return response.json();
+              })
+              .then(function(data) {
+                if (!data.ok) {
+                  throw new Error(data.error || 'Unable to update discount');
+                }
+                chip.classList.toggle('selected', !!data.selected);
+                if (orderBlock && data.sale_discounts) {
+                  Object.keys(data.sale_discounts).forEach(function(saleId) {
+                    var cell = orderBlock.querySelector('.sale-discount-cell[data-sale-id="' + saleId + '"]');
+                    renderDiscountChips(cell, data.sale_discounts[saleId]);
+                  });
+                }
+              })
+              .catch(function() {
+                // noop: keep previous state on failure
+              })
+              .finally(function() {
+                chip.dataset.pending = '0';
+                chip.disabled = false;
+              });
+          });
         });
       });
 

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1246,6 +1246,115 @@ class SalesViewTests(TestCase):
         self.assertIn("sale-discount-chip-list", html)
         self.assertIn("Tao Jin Bi", html)
         self.assertIn("Tmall Red Packet", html)
+        self.assertIn("discount-reason-chip-group", html)
+
+    def test_assign_referrers_view_marks_only_shared_order_discounts_selected(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        discount_one = Discount.objects.create(name="Shared", code="shared")
+        discount_two = Discount.objects.create(name="Not Shared", code="not-shared")
+        sale_one = Sale.objects.create(
+            order_number="ORDER-SHARED",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+        )
+        sale_two = Sale.objects.create(
+            order_number="ORDER-SHARED",
+            date=date(2024, 4, 11),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+        )
+        sale_one.discounts.add(discount_one, discount_two)
+        sale_two.discounts.add(discount_one)
+
+        response = self.client.get(
+            reverse("sales_assign_referrers"),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        orders = response.context["orders"]
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(orders[0]["available_discount_ids"], [discount_one.id])
+
+    def test_assign_order_discount_reason_adds_discount_to_all_sales(self):
+        discount = Discount.objects.create(name="Flash Coupon", code="flash-coupon")
+        sale_one = Sale.objects.create(
+            order_number="ORDER-DISC-ADD",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("90.00"),
+        )
+        sale_two = Sale.objects.create(
+            order_number="ORDER-DISC-ADD",
+            date=date(2024, 4, 11),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("85.00"),
+        )
+
+        response = self.client.post(
+            reverse("assign_order_discount_reason"),
+            {
+                "order_number": "ORDER-DISC-ADD",
+                "discount_id": str(discount.id),
+                "selected": "1",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["selected"])
+
+        sale_one.refresh_from_db()
+        sale_two.refresh_from_db()
+        self.assertIn(discount.id, sale_one.discounts.values_list("id", flat=True))
+        self.assertIn(discount.id, sale_two.discounts.values_list("id", flat=True))
+
+    def test_assign_order_discount_reason_removes_discount_from_all_sales(self):
+        discount = Discount.objects.create(name="Flash Coupon", code="flash-coupon")
+        sale_one = Sale.objects.create(
+            order_number="ORDER-DISC-REMOVE",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("90.00"),
+        )
+        sale_two = Sale.objects.create(
+            order_number="ORDER-DISC-REMOVE",
+            date=date(2024, 4, 11),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("85.00"),
+        )
+        sale_one.discounts.add(discount)
+        sale_two.discounts.add(discount)
+
+        response = self.client.post(
+            reverse("assign_order_discount_reason"),
+            {
+                "order_number": "ORDER-DISC-REMOVE",
+                "discount_id": str(discount.id),
+                "selected": "0",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["selected"])
+
+        sale_one.refresh_from_db()
+        sale_two.refresh_from_db()
+        self.assertNotIn(discount.id, sale_one.discounts.values_list("id", flat=True))
+        self.assertNotIn(discount.id, sale_two.discounts.values_list("id", flat=True))
 
     def test_ignore_button_hidden_when_order_has_referrer(self):
         self.product.retail_price = Decimal("100")

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
         views.ignore_order_referrer_discount_range,
         name='ignore_order_referrer_discount_range',
     ),
+    path(
+        'sales/assign-referrers/discount/',
+        views.assign_order_discount_reason,
+        name='assign_order_discount_reason',
+    ),
     path('sales/price-group/<str:bucket_key>/', views.sales_bucket_detail, name='sales_bucket_detail'),
     path(
         'sales/price-group/<str:bucket_key>/assign-referrer/',

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -54,6 +54,7 @@ from django.views.decorators.http import require_GET, require_POST, require_http
 from PIL import Image, ImageOps
 
 from .models import (
+    Discount,
     Group,
     InventorySnapshot,
     Order,
@@ -5545,6 +5546,8 @@ def sales_assign_referrers(request):
             latest_date = meta["date"]
             referrer = meta.get("referrer")
             items = []
+            order_available_discount_ids = set()
+            initialized_available_discounts = False
 
             for sale in order_sales:
                 if sale.date and latest_date:
@@ -5586,6 +5589,13 @@ def sales_assign_referrers(request):
                     }
                 )
 
+                sale_discount_ids = set(sale.discounts.values_list("id", flat=True))
+                if not initialized_available_discounts:
+                    order_available_discount_ids = sale_discount_ids
+                    initialized_available_discounts = True
+                else:
+                    order_available_discount_ids &= sale_discount_ids
+
             orders.append(
                 {
                     "order_number": order_number,
@@ -5595,6 +5605,7 @@ def sales_assign_referrers(request):
                     "retail_total": retail_total,
                     "referrer": referrer,
                     "items": items,
+                    "available_discount_ids": sorted(order_available_discount_ids),
                 }
             )
 
@@ -5632,6 +5643,7 @@ def sales_assign_referrers(request):
             "referrers": Referrer.objects.exclude(name__iexact="no_referrer").order_by(
                 "name"
             ),
+            "discount_reasons": Discount.objects.order_by("name"),
             "min_discount": min_discount,
             "max_discount": max_discount,
             "order_numbers_text": order_numbers_text,
@@ -5695,6 +5707,53 @@ def ignore_order_referrer_discount_range(request):
 
     sales_qs.update(referrer=no_referrer)
     return JsonResponse({"ok": True, "order_number": order_number})
+
+
+@require_POST
+def assign_order_discount_reason(request):
+    order_number = (request.POST.get("order_number") or "").strip()
+    if not order_number:
+        return JsonResponse({"ok": False, "error": "Missing order number"}, status=400)
+
+    discount_id = request.POST.get("discount_id")
+    if not discount_id:
+        return JsonResponse({"ok": False, "error": "Missing discount id"}, status=400)
+
+    selected_value = str(request.POST.get("selected", "")).strip().lower()
+    if selected_value not in {"1", "0", "true", "false"}:
+        return JsonResponse({"ok": False, "error": "Missing selected value"}, status=400)
+    should_select = selected_value in {"1", "true"}
+
+    discount = get_object_or_404(Discount, pk=discount_id)
+    sales_qs = Sale.objects.filter(order_number=order_number)
+    if not sales_qs.exists():
+        return JsonResponse({"ok": False, "error": "Order not found"}, status=404)
+
+    with transaction.atomic():
+        for sale in sales_qs:
+            if should_select:
+                sale.discounts.add(discount)
+            else:
+                sale.discounts.remove(discount)
+
+    refreshed_sales = (
+        Sale.objects.filter(order_number=order_number)
+        .prefetch_related("discounts")
+        .order_by("pk")
+    )
+    sale_discounts = {
+        str(sale.pk): _get_sale_discount_chips(sale) for sale in refreshed_sales
+    }
+
+    return JsonResponse(
+        {
+            "ok": True,
+            "order_number": order_number,
+            "discount_id": discount.id,
+            "selected": should_select,
+            "sale_discounts": sale_discounts,
+        }
+    )
 
 
 # a small helper to keep (date, change) pairs


### PR DESCRIPTION
### Motivation
- Provide a quick way to add/remove discount reasons for an entire order from the Assign Referrers UI using a chip-based modal without a separate Save action, so selections persist immediately and the UI updates in-place.

### Description
- Add a new `Add discounts` modal to `sales_assign_referrers` that shows discount reasons as selectable chips and opens per-order (`inventory/templates/inventory/sales_assign_referrers.html`).
- Implement client-side logic to toggle chips and perform async POSTs to a new endpoint, update chip state while requests are pending, and re-render per-sale discount chips from the response (`inventory/templates/inventory/sales_assign_referrers.html` JS changes).
- Add a new view `assign_order_discount_reason` that validates input, adds/removes the `Discount` across all `Sale` rows for the order inside a DB transaction, and returns updated per-sale discount chip data as JSON (`inventory/views.py`).
- Compute `available_discount_ids` per order (intersection of discounts common to all sales in the order) and expose `discount_reasons` in the template context for initial modal state (`inventory/views.py`).
- Add URL route `sales/assign-referrers/discount/` for the new endpoint (`inventory/urls.py`) and add CSS for discount-reason chip styles (`inventory/static/styles.css`).
- Add unit tests for rendering the modal and chip group, computing shared selected discounts, and the add/remove endpoint behavior (`inventory/tests.py`).

### Testing
- Added tests `test_assign_referrers_view_renders_sale_discount_chips`, `test_assign_referrers_view_marks_only_shared_order_discounts_selected`, `test_assign_order_discount_reason_adds_discount_to_all_sales`, and `test_assign_order_discount_reason_removes_discount_from_all_sales` in `inventory.tests` but they were not runnable in this environment.
- Attempted to run the tests with `python manage.py test ...` but the test runner failed with `ModuleNotFoundError: No module named 'django'`, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52d50678c832cab7fbaf877f0283d)