### PR TITLE
Persist stable discount chip colors via DiscountChipSetting and resolver

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -11,6 +11,7 @@ from .models import (
     RestockSetting,
     Referrer,
     Discount,
+    DiscountChipSetting,
 )
 
 from datetime import datetime, timedelta, date
@@ -397,6 +398,21 @@ class SeriesAdmin(admin.ModelAdmin):
 @admin.register(RestockSetting)
 class RestockSettingAdmin(admin.ModelAdmin):
     filter_horizontal = ("groups",)
+
+
+
+
+@admin.register(DiscountChipSetting)
+class DiscountChipSettingAdmin(admin.ModelAdmin):
+    list_display = ("id", "updated_at")
+    fields = ("palette", "discount_color_map", "updated_at")
+    readonly_fields = ("updated_at",)
+
+    def has_add_permission(self, request):
+        return not DiscountChipSetting.objects.exists()
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 @admin.register(Referrer)

--- a/inventory/discount_chip_colors.py
+++ b/inventory/discount_chip_colors.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from django.db import transaction
+
+from .models import DiscountChipSetting
+
+DEFAULT_DISCOUNT_CHIP_PALETTE: tuple[str, ...] = (
+    "#1E88E5",
+    "#43A047",
+    "#FB8C00",
+    "#8E24AA",
+    "#E53935",
+    "#00897B",
+    "#5E35B1",
+    "#3949AB",
+    "#6D4C41",
+    "#039BE5",
+    "#7CB342",
+    "#F4511E",
+    "#546E7A",
+    "#C2185B",
+    "#FDD835",
+)
+DEFAULT_NEUTRAL_DISCOUNT_COLOR = "#9E9E9E"
+
+
+@dataclass(frozen=True)
+class ResolvedDiscountChip:
+    label: str
+    color: str
+
+
+def _normalize_discount_key(discount_code: str | None) -> str:
+    if not discount_code:
+        return ""
+    return str(discount_code).strip().casefold()
+
+
+def _normalize_palette(values: Iterable[str]) -> list[str]:
+    palette: list[str] = []
+    for value in values:
+        candidate = str(value or "").strip()
+        if not candidate:
+            continue
+        if not candidate.startswith("#"):
+            candidate = f"#{candidate}"
+        palette.append(candidate.upper())
+    return palette
+
+
+def _get_or_create_discount_chip_setting() -> DiscountChipSetting:
+    setting = DiscountChipSetting.objects.order_by("id").first()
+    if setting:
+        return setting
+    return DiscountChipSetting.objects.create()
+
+
+def _ensure_discount_color_mapping(discount_keys: Iterable[str]) -> dict[str, str]:
+    normalized_keys = sorted({key for key in discount_keys if key})
+    if not normalized_keys:
+        return {}
+
+    with transaction.atomic():
+        setting = _get_or_create_discount_chip_setting()
+        palette = _normalize_palette(setting.palette or DEFAULT_DISCOUNT_CHIP_PALETTE)
+        if not palette:
+            palette = list(DEFAULT_DISCOUNT_CHIP_PALETTE)
+
+        mapping = {
+            _normalize_discount_key(key): str(value).upper()
+            for key, value in (setting.discount_color_map or {}).items()
+            if _normalize_discount_key(key)
+        }
+        used_colors = {color for color in mapping.values() if color}
+
+        changed = False
+        for key in normalized_keys:
+            if key in mapping:
+                continue
+            available_color = next((color for color in palette if color not in used_colors), None)
+            mapping[key] = available_color or DEFAULT_NEUTRAL_DISCOUNT_COLOR
+            if available_color:
+                used_colors.add(available_color)
+            changed = True
+
+        if changed:
+            setting.discount_color_map = mapping
+            setting.save(update_fields=["discount_color_map", "updated_at"])
+
+        return mapping
+
+
+def resolve_discount_chip_colors(discounts: Iterable) -> list[ResolvedDiscountChip]:
+    """Resolve stable chip colors for discount objects.
+
+    Colors are keyed by discount code and persisted in `DiscountChipSetting`.
+    """
+
+    normalized: list[tuple[str, str]] = []
+    seen_labels: set[str] = set()
+
+    for discount in discounts:
+        label = str(getattr(discount, "name", "") or "").strip()
+        if not label:
+            continue
+        normalized_label = label.casefold()
+        if normalized_label in seen_labels:
+            continue
+        seen_labels.add(normalized_label)
+
+        discount_code = getattr(discount, "code", "")
+        normalized.append((label, _normalize_discount_key(discount_code)))
+
+    mapping = _ensure_discount_color_mapping(key for _label, key in normalized)
+
+    chips: list[ResolvedDiscountChip] = []
+    for label, key in normalized:
+        color = mapping.get(key) if key else None
+        chips.append(ResolvedDiscountChip(label=label, color=color or DEFAULT_NEUTRAL_DISCOUNT_COLOR))
+    return chips

--- a/inventory/migrations/0025_discountchipsetting.py
+++ b/inventory/migrations/0025_discountchipsetting.py
@@ -1,0 +1,51 @@
+from django.db import migrations, models
+
+
+def seed_discount_chip_setting(apps, schema_editor):
+    DiscountChipSetting = apps.get_model("inventory", "DiscountChipSetting")
+    if DiscountChipSetting.objects.exists():
+        return
+    DiscountChipSetting.objects.create(
+        palette=[
+            "#1E88E5",
+            "#43A047",
+            "#FB8C00",
+            "#8E24AA",
+            "#E53935",
+            "#00897B",
+            "#5E35B1",
+            "#3949AB",
+            "#6D4C41",
+            "#039BE5",
+            "#7CB342",
+            "#F4511E",
+            "#546E7A",
+            "#C2185B",
+            "#FDD835",
+        ],
+        discount_color_map={},
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0024_remove_sale_legacy_discount_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DiscountChipSetting",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("palette", models.JSONField(blank=True, default=list)),
+                ("discount_color_map", models.JSONField(blank=True, default=dict)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "verbose_name": "Discount Chip Setting",
+                "verbose_name_plural": "Settings",
+            },
+        ),
+        migrations.RunPython(seed_discount_chip_setting, migrations.RunPython.noop),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -321,6 +321,42 @@ class Discount(models.Model):
         return self.name
 
 
+class DiscountChipSetting(models.Model):
+    """Singleton-ish settings for discount chip color mapping."""
+
+    palette = models.JSONField(default=list, blank=True)
+    discount_color_map = models.JSONField(default=dict, blank=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Discount Chip Setting"
+        verbose_name_plural = "Settings"
+
+    def save(self, *args, **kwargs):
+        if not self.palette:
+            self.palette = [
+                "#1E88E5",
+                "#43A047",
+                "#FB8C00",
+                "#8E24AA",
+                "#E53935",
+                "#00897B",
+                "#5E35B1",
+                "#3949AB",
+                "#6D4C41",
+                "#039BE5",
+                "#7CB342",
+                "#F4511E",
+                "#546E7A",
+                "#C2185B",
+                "#FDD835",
+            ]
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return "Discount chip colors"
+
+
 class Sale(models.Model):
     sale_id = models.AutoField(primary_key=True)
     order_number = models.CharField(max_length=50, db_index=True)  # the 内部订单号

--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -1353,7 +1353,10 @@ vertical-align: middle;
 }
 
 .sale-discount-chip {
+  --discount-chip-color: #9e9e9e;
+  background: var(--discount-chip-color);
   border-radius: 999px;
+  color: #fff;
   display: inline-flex;
   font-size: 0.74rem;
   font-weight: 700;
@@ -1361,36 +1364,6 @@ vertical-align: middle;
   margin: 0;
   padding: 0.28rem 0.58rem;
   white-space: nowrap;
-}
-
-.sale-discount-chip.tone-0 {
-  background: #ede9fe;
-  color: #5b4ad8;
-}
-
-.sale-discount-chip.tone-1 {
-  background: #fff7d6;
-  color: #b77a00;
-}
-
-.sale-discount-chip.tone-2 {
-  background: #ffe8ef;
-  color: #d64f79;
-}
-
-.sale-discount-chip.tone-3 {
-  background: #e6f8ed;
-  color: #1a9b5f;
-}
-
-.sale-discount-chip.tone-4 {
-  background: #e8f7ff;
-  color: #177bb7;
-}
-
-.sale-discount-chip.tone-5 {
-  background: #f3e8ff;
-  color: #7a3ec8;
 }
 
 .order-item-product {

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -201,7 +201,7 @@
                     {% if item.discount_chips %}
                       <div class="sale-discount-chip-list">
                         {% for discount in item.discount_chips %}
-                          <span class="sale-discount-chip {{ discount.tone }}">{{ discount.label }}</span>
+                          <span class="sale-discount-chip" style="--discount-chip-color: {{ discount.color|default:'#9E9E9E' }};">{{ discount.label }}</span>
                         {% endfor %}
                       </div>
                     {% endif %}
@@ -473,7 +473,7 @@
         }
         var html = '<div class="sale-discount-chip-list">';
         chips.forEach(function(chip) {
-          html += '<span class="sale-discount-chip ' + escapeHtml(chip.tone || '') + '">'
+          html += '<span class="sale-discount-chip" style="--discount-chip-color: ' + escapeHtml(chip.color || '#9E9E9E') + ';">'
             + escapeHtml(chip.label || '')
             + '</span>';
         });

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -29,6 +29,7 @@ from .models import (
     RestockSetting,
     Referrer,
     Discount,
+    DiscountChipSetting,
 )
 from django.urls import reverse
 from .admin import SaleAdmin, SaleDateEqualsFilter
@@ -38,6 +39,7 @@ from .utils import (
     calculate_variant_sales_speed,
     get_category_speed_stats,
 )
+from .discount_chip_colors import resolve_discount_chip_colors
 from .views import (
     PRODUCT_CANVAS_MAX_DIMENSION,
     DEFAULT_PRODUCT_IMAGE,
@@ -2368,3 +2370,40 @@ class SaleDiscountRelationshipTests(TestCase):
             sale.discounts.values_list("code", flat=True),
             ["taojinbi", "天猫红包优惠"],
         )
+
+
+class DiscountChipColorResolverTests(TestCase):
+    def test_color_resolution_is_deterministic_by_discount_code(self):
+        first = Discount.objects.create(name="A Discount", code="code_a")
+        second = Discount.objects.create(name="B Discount", code="code_b")
+
+        first_pass = resolve_discount_chip_colors([second, first])
+        second_pass = resolve_discount_chip_colors([first, second])
+
+        first_lookup = {chip.label: chip.color for chip in first_pass}
+        second_lookup = {chip.label: chip.color for chip in second_pass}
+
+        self.assertEqual(first_lookup["A Discount"], second_lookup["A Discount"])
+        self.assertEqual(first_lookup["B Discount"], second_lookup["B Discount"])
+
+    def test_mapping_is_persisted_for_future_sessions(self):
+        discount = Discount.objects.create(name="VIP", code="vip")
+
+        resolve_discount_chip_colors([discount])
+        setting = DiscountChipSetting.objects.get()
+        self.assertIn("vip", setting.discount_color_map)
+
+        stored_color = setting.discount_color_map["vip"]
+        chips = resolve_discount_chip_colors([discount])
+
+        self.assertEqual(chips[0].color, stored_color)
+
+    def test_unknown_or_blank_discount_code_uses_neutral_color(self):
+        class AnonymousDiscount:
+            name = "Unknown"
+            code = ""
+
+        chips = resolve_discount_chip_colors([AnonymousDiscount()])
+
+        self.assertEqual(len(chips), 1)
+        self.assertEqual(chips[0].color, "#9E9E9E")

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -77,6 +77,7 @@ from .models import (
     get_type_choices_for_styles,
     get_subtype_choices_for_types,
 )
+from .discount_chip_colors import resolve_discount_chip_colors
 from .utils import (
     calculate_size_order_mix,
     compute_safe_stock,
@@ -316,51 +317,10 @@ def _parse_discount_percent(param: Optional[str], default: int) -> int:
 
 
 def _get_sale_discount_chips(sale) -> list[dict[str, str]]:
-    chips = []
-    seen_labels = set()
-
-    for index, discount in enumerate(sale.discounts.all()):
-        label = str(discount.name).strip()
-        if not label:
-            continue
-
-        normalized_key = label.casefold()
-        if normalized_key in seen_labels:
-            continue
-        seen_labels.add(normalized_key)
-
-        chips.append(
-            {
-                "label": label,
-                "tone": f"tone-{index % 6}",
-            }
-        )
-
-    return chips
-
-
-def _get_sale_discount_chips(sale) -> list[dict[str, str]]:
-    chips = []
-    seen_labels = set()
-
-    for index, discount in enumerate(sale.discounts.all()):
-        label = str(discount.name).strip()
-        if not label:
-            continue
-
-        normalized_key = label.casefold()
-        if normalized_key in seen_labels:
-            continue
-        seen_labels.add(normalized_key)
-
-        chips.append(
-            {
-                "label": label,
-                "tone": f"tone-{index % 6}",
-            }
-        )
-
-    return chips
+    return [
+        {"label": chip.label, "color": chip.color}
+        for chip in resolve_discount_chip_colors(sale.discounts.all())
+    ]
 
 
 # — Helper to bucket types into our four categories —


### PR DESCRIPTION
### Motivation

- Remove fragile index-based cycling (`tone-{index % 6}`) for sale discount chips and provide stable, meaningful colors keyed by discount code.
- Expose a managed palette of 15 fixed colors so discount types map deterministically to a color and UI is consistent across pages.
- Persist the code→color mapping so colors remain stable across sessions and users, and provide a neutral fallback for unknown/blank codes.

### Description

- Added a centralized resolver module `inventory/discount_chip_colors.py` that normalizes discount keys by `code`, applies a 15-color palette, assigns the next available palette slot deterministically, and falls back to `#9E9E9E` when necessary via `resolve_discount_chip_colors`.
- Introduced a new model `DiscountChipSetting` to persist `palette` and `discount_color_map`, added a migration `0025_discountchipsetting.py` which seeds the default 15-color palette, and added an admin UI `DiscountChipSettingAdmin` that enforces a singleton-like entry.
- Replaced the old `_get_sale_discount_chips` implementation in `inventory/views.py` to use the resolver and return `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cbca298c832cb4cc340d3e5e688e)