### PR TITLE
Enforce referrer-category discount policy in assignment flows

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -345,7 +345,13 @@ class SaleAdmin(admin.ModelAdmin):
             form = AssignReferrerForm(request.POST)
             if form.is_valid():
                 referrer = form.cleaned_data["referrer"]
-                updated = queryset.update(referrer=referrer)
+                updated = 0
+                for sale in queryset.select_related("variant__product", "referrer"):
+                    sale.apply_referrer_discount_policy(
+                        referrer=referrer,
+                        manual_discount_locked=False,
+                    )
+                    updated += 1
                 self.message_user(
                     request,
                     f"Successfully assigned {referrer} to {updated} sale(s).",

--- a/inventory/management/commands/backfill_referrer_discounts.py
+++ b/inventory/management/commands/backfill_referrer_discounts.py
@@ -1,0 +1,32 @@
+from django.core.management.base import BaseCommand
+
+from inventory.models import Sale
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill sale pricing for referrer rules. "
+        "Gym code referrers are set to 10% discount and wholesale to at least 25% "
+        "unless sale is manual_discount_locked."
+    )
+
+    def handle(self, *args, **options):
+        sales = (
+            Sale.objects.filter(referrer__isnull=False)
+            .select_related("variant__product", "referrer")
+            .order_by("pk")
+        )
+
+        updated = 0
+        inspected = 0
+        for sale in sales:
+            inspected += 1
+            changed = sale.apply_referrer_discount_policy(save=True)
+            if changed:
+                updated += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Backfill complete. Inspected {inspected} sale(s); updated {updated}."
+            )
+        )

--- a/inventory/migrations/0026_referrer_discount_policy.py
+++ b/inventory/migrations/0026_referrer_discount_policy.py
@@ -1,0 +1,75 @@
+from decimal import Decimal, ROUND_HALF_UP
+
+from django.db import migrations, models
+
+
+def backfill_referrer_discount_policy(apps, schema_editor):
+    Sale = apps.get_model("inventory", "Sale")
+
+    for sale in (
+        Sale.objects.filter(referrer__isnull=False, manual_discount_locked=False)
+        .select_related("variant__product", "referrer")
+        .iterator()
+    ):
+        referrer = sale.referrer
+        if not referrer:
+            continue
+
+        category = getattr(referrer, "category", "other")
+        if category not in {"gym_code", "wholesale"}:
+            continue
+
+        sold_quantity = sale.sold_quantity or 0
+        retail_price = sale.variant.product.retail_price or Decimal("0")
+        if sold_quantity <= 0 or retail_price <= 0:
+            continue
+
+        current_discount = Decimal("0")
+        actual_total = sale.sold_value or Decimal("0")
+        actual_unit_price = actual_total / sold_quantity
+        current_discount = ((retail_price - actual_unit_price) / retail_price) * Decimal("100")
+
+        if category == "gym_code":
+            target_discount = Decimal("10")
+        else:
+            target_discount = max(current_discount, Decimal("25"))
+
+        multiplier = (Decimal("100") - target_discount) / Decimal("100")
+        sale.sold_value = (retail_price * sold_quantity * multiplier).quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_UP
+        )
+        sale.save(update_fields=["sold_value"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0025_discountchipsetting"),
+        ("inventory", "0025_migrate_no_referrer_to_null"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="referrer",
+            name="category",
+            field=models.CharField(
+                choices=[
+                    ("other", "Other"),
+                    ("gym_code", "Gym code"),
+                    ("wholesale", "Wholesale"),
+                ],
+                db_index=True,
+                default="other",
+                max_length=32,
+            ),
+        ),
+        migrations.AddField(
+            model_name="sale",
+            name="manual_discount_locked",
+            field=models.BooleanField(
+                default=False,
+                help_text="Keep existing sale pricing when assigning/changing referrer discount rules.",
+            ),
+        ),
+        migrations.RunPython(backfill_referrer_discount_policy, migrations.RunPython.noop),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -1,7 +1,9 @@
 from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Iterable, Optional
 
 from django.db import models
+from django.core.exceptions import ValidationError
 
 # ---------------------------------------------------------------------------
 # Choice constants shared by Product and ProductVariant
@@ -301,7 +303,22 @@ class ProductVariant(models.Model):
 
 
 class Referrer(models.Model):
+    CATEGORY_OTHER = "other"
+    CATEGORY_GYM_CODE = "gym_code"
+    CATEGORY_WHOLESALE = "wholesale"
+    CATEGORY_CHOICES = [
+        (CATEGORY_OTHER, "Other"),
+        (CATEGORY_GYM_CODE, "Gym code"),
+        (CATEGORY_WHOLESALE, "Wholesale"),
+    ]
+
     name = models.CharField(max_length=255, unique=True)
+    category = models.CharField(
+        max_length=32,
+        choices=CATEGORY_CHOICES,
+        default=CATEGORY_OTHER,
+        db_index=True,
+    )
 
     class Meta:
         ordering = ["name"]
@@ -386,11 +403,130 @@ class Sale(models.Model):
         blank=True,
         null=True,
     )
+    manual_discount_locked = models.BooleanField(
+        default=False,
+        help_text="Keep existing sale pricing when assigning/changing referrer discount rules.",
+    )
+
+    REFERRER_DISCOUNT_RULES = {
+        Referrer.CATEGORY_GYM_CODE: {
+            "default_percent": Decimal("10"),
+            "minimum_percent": Decimal("10"),
+            "enforce_exact_default": True,
+        },
+        Referrer.CATEGORY_WHOLESALE: {
+            "default_percent": Decimal("25"),
+            "minimum_percent": Decimal("25"),
+            "enforce_exact_default": False,
+        },
+    }
 
     def __str__(self):
         return (
             f"Sale {self.sale_id} - Variant {self.variant.variant_code} on {self.date}"
         )
+
+    def calculate_discount_percentage(self) -> Optional[Decimal]:
+        sold_quantity = self.sold_quantity or 0
+        if sold_quantity <= 0:
+            return None
+
+        retail_price = self.variant.product.retail_price or Decimal("0")
+        if retail_price <= 0:
+            return None
+
+        actual_total = self.sold_value or Decimal("0")
+        actual_unit_price = actual_total / sold_quantity
+        discount_percentage = ((retail_price - actual_unit_price) / retail_price) * Decimal("100")
+        return discount_percentage.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+    def get_referrer_discount_rule(self, referrer: Optional["Referrer"] = None) -> Optional[dict]:
+        active_referrer = referrer if referrer is not None else self.referrer
+        if not active_referrer:
+            return None
+        return self.REFERRER_DISCOUNT_RULES.get(active_referrer.category)
+
+    def apply_referrer_discount_policy(
+        self,
+        *,
+        referrer: Optional["Referrer"] = None,
+        clear_referrer: bool = False,
+        manual_discount_locked: Optional[bool] = None,
+        save: bool = True,
+    ) -> bool:
+        if manual_discount_locked is not None:
+            self.manual_discount_locked = bool(manual_discount_locked)
+        if clear_referrer:
+            self.referrer = None
+        elif referrer is not None:
+            self.referrer = referrer
+
+        if self.manual_discount_locked:
+            if save:
+                self.full_clean()
+                self.save(update_fields=["referrer", "manual_discount_locked"])
+            return False
+
+        rule = self.get_referrer_discount_rule()
+        if not rule:
+            if save:
+                self.full_clean()
+                self.save(update_fields=["referrer", "manual_discount_locked"])
+            return False
+
+        sold_quantity = self.sold_quantity or 0
+        retail_price = self.variant.product.retail_price or Decimal("0")
+        if sold_quantity <= 0 or retail_price <= 0:
+            if save:
+                self.full_clean()
+                self.save(update_fields=["referrer", "manual_discount_locked"])
+            return False
+
+        current_discount = self.calculate_discount_percentage() or Decimal("0")
+        default_percent = rule["default_percent"]
+        minimum_percent = rule["minimum_percent"]
+        if rule.get("enforce_exact_default"):
+            target_discount = default_percent
+        else:
+            target_discount = max(current_discount, default_percent, minimum_percent)
+
+        multiplier = (Decimal("100") - target_discount) / Decimal("100")
+        target_total = (retail_price * sold_quantity * multiplier).quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_UP
+        )
+
+        updated = (self.sold_value != target_total) or (referrer is not None)
+        self.sold_value = target_total
+        if save:
+            self.full_clean()
+            self.save(update_fields=["referrer", "sold_value", "manual_discount_locked"])
+        return updated
+
+    def clean(self):
+        super().clean()
+        if not self.referrer or self.manual_discount_locked:
+            return
+
+        rule = self.get_referrer_discount_rule()
+        if not rule:
+            return
+
+        discount_percentage = self.calculate_discount_percentage()
+        if discount_percentage is None:
+            return
+
+        minimum = rule["minimum_percent"]
+        if discount_percentage < minimum:
+            raise ValidationError(
+                {"sold_value": f"{self.referrer.get_category_display()} referrer requires at least {minimum}% discount."}
+            )
+
+        if rule.get("enforce_exact_default"):
+            default_percent = rule["default_percent"]
+            if discount_percentage != default_percent:
+                raise ValidationError(
+                    {"sold_value": f"{self.referrer.get_category_display()} referrer requires exactly {default_percent}% discount unless manually locked."}
+                )
 
 
 class InventorySnapshot(models.Model):

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -229,16 +229,25 @@
               <div class="modal-content">
                 <h4>Assign referrer</h4>
                 <input type="hidden" name="referrer_id" value="{% if order.referrer %}{{ order.referrer.id }}{% endif %}" />
+                <p class="grey-text text-darken-1 modal-helper-text" data-referrer-rule-text>
+                  Selecting a referrer can auto-apply discount policy (Gym code: 10%; Wholesale: minimum 25%).
+                </p>
                 <div class="referrer-chip-group">
-                  <div class="chip referrer-chip {% if not order.referrer %}selected{% endif %}" data-referrer-id="" tabindex="0">
+                  <div class="chip referrer-chip {% if not order.referrer %}selected{% endif %}" data-referrer-id="" data-referrer-category="" tabindex="0">
                     No referrer
                   </div>
                   {% for referrer in referrers %}
-                    <div class="chip referrer-chip {% if order.referrer and order.referrer.id == referrer.id %}selected{% endif %}" data-referrer-id="{{ referrer.id }}" tabindex="0">
+                    <div class="chip referrer-chip {% if order.referrer and order.referrer.id == referrer.id %}selected{% endif %}" data-referrer-id="{{ referrer.id }}" data-referrer-category="{{ referrer.category }}" tabindex="0">
                       {{ referrer.name }}
                     </div>
                   {% endfor %}
                 </div>
+                <p>
+                  <label>
+                    <input type="checkbox" name="manual_discount_locked" value="1" />
+                    <span>Keep existing custom discount (lock discount for this assignment)</span>
+                  </label>
+                </p>
               </div>
               <div class="modal-footer">
                 <button type="submit" class="btn waves-effect waves-light">Save</button>
@@ -308,6 +317,21 @@
         }
 
         var hiddenInput = form.querySelector('input[name="referrer_id"]');
+        var ruleText = form.querySelector('[data-referrer-rule-text]');
+        var lockInput = form.querySelector('input[name="manual_discount_locked"]');
+        var updateRuleText = function(targetChip) {
+          if (!ruleText) {
+            return;
+          }
+          var category = (targetChip.dataset.referrerCategory || '').toLowerCase();
+          if (category === 'gym_code') {
+            ruleText.textContent = 'Gym code referrers enforce a 10% discount unless you lock the current discount.';
+          } else if (category === 'wholesale') {
+            ruleText.textContent = 'Wholesale referrers enforce at least a 25% discount unless you lock the current discount.';
+          } else {
+            ruleText.textContent = 'No automatic referrer discount policy applies to this selection.';
+          }
+        };
         var setActiveChip = function(targetChip) {
           chips.forEach(function(chip) {
             chip.classList.remove('selected');
@@ -316,6 +340,10 @@
           if (hiddenInput) {
             hiddenInput.value = targetChip.dataset.referrerId || '';
           }
+          if (lockInput) {
+            lockInput.checked = false;
+          }
+          updateRuleText(targetChip);
         };
 
         chips.forEach(function(chip) {
@@ -329,6 +357,11 @@
             }
           });
         });
+
+        var selectedChip = group.querySelector('.referrer-chip.selected');
+        if (selectedChip) {
+          updateRuleText(selectedChip);
+        }
       });
 
       var escapeHtml = function(value) {

--- a/inventory/templates/inventory/sales_bucket_detail.html
+++ b/inventory/templates/inventory/sales_bucket_detail.html
@@ -175,7 +175,7 @@
                 />
                 {% if referrers %}
                   <p class="grey-text text-darken-1 modal-helper-text">
-                    Select a referrer below.
+                    Select a referrer below. Gym code defaults to 10% discount, wholesale enforces minimum 25%.
                   </p>
                 {% else %}
                   <p class="grey-text text-darken-1 modal-helper-text">
@@ -186,6 +186,7 @@
                   <div
                     class="chip referrer-chip {% if not order.referrer %}selected{% endif %}"
                     data-referrer-id=""
+                    data-referrer-category=""
                     tabindex="0"
                   >
                     No referrer
@@ -194,12 +195,19 @@
                     <div
                       class="chip referrer-chip {% if order.referrer and order.referrer.id == referrer.id %}selected{% endif %}"
                       data-referrer-id="{{ referrer.id }}"
+                      data-referrer-category="{{ referrer.category }}"
                       tabindex="0"
                     >
                       {{ referrer.name }}
                     </div>
                   {% endfor %}
                 </div>
+                <p>
+                  <label>
+                    <input type="checkbox" name="manual_discount_locked" value="1" />
+                    <span>Keep existing custom discount (lock discount for this assignment)</span>
+                  </label>
+                </p>
               </div>
               <div class="modal-footer">
                 <button

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -15,6 +15,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.exceptions import ValidationError
 
 from PIL import Image
 
@@ -1063,7 +1064,11 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.context["orders"][0]["order_number"], "IN-RANGE")
 
     def test_assign_referrer_discount_range_updates_all_sales(self):
-        referrer = Referrer.objects.create(name="Referrer A")
+        referrer = Referrer.objects.create(
+            name="Referrer A", category=Referrer.CATEGORY_GYM_CODE
+        )
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
         first_sale = Sale.objects.create(
             order_number="ASSIGN-RANGE",
             date=date(2024, 4, 5),
@@ -1098,6 +1103,109 @@ class SalesViewTests(TestCase):
         second_sale.refresh_from_db()
         self.assertEqual(first_sale.referrer, referrer)
         self.assertEqual(second_sale.referrer, referrer)
+        self.assertEqual(first_sale.sold_value, Decimal("90.00"))
+        self.assertEqual(second_sale.sold_value, Decimal("90.00"))
+
+    def test_wholesale_referrer_enforces_minimum_discount(self):
+        wholesale_referrer = Referrer.objects.create(
+            name="Wholesale Partner", category=Referrer.CATEGORY_WHOLESALE
+        )
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        sale = Sale.objects.create(
+            order_number="WHOLESALE-MIN",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("90.00"),  # 10%, below wholesale minimum.
+        )
+
+        response = self.client.post(
+            reverse("assign_order_referrer_discount_range"),
+            {"order_number": "WHOLESALE-MIN", "referrer_id": str(wholesale_referrer.id)},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        sale.refresh_from_db()
+        self.assertEqual(sale.referrer, wholesale_referrer)
+        self.assertEqual(sale.sold_value, Decimal("75.00"))
+
+    def test_editing_referrer_reapplies_discount_policy(self):
+        gym_referrer = Referrer.objects.create(
+            name="Gym Affiliate", category=Referrer.CATEGORY_GYM_CODE
+        )
+        wholesale_referrer = Referrer.objects.create(
+            name="Wholesale Partner 2", category=Referrer.CATEGORY_WHOLESALE
+        )
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        sale = Sale.objects.create(
+            order_number="EDIT-REFERRER",
+            date=date(2024, 4, 8),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("100.00"),
+        )
+
+        self.client.post(
+            reverse("assign_order_referrer_discount_range"),
+            {"order_number": "EDIT-REFERRER", "referrer_id": str(gym_referrer.id)},
+        )
+        sale.refresh_from_db()
+        self.assertEqual(sale.sold_value, Decimal("90.00"))
+
+        self.client.post(
+            reverse("assign_order_referrer_discount_range"),
+            {"order_number": "EDIT-REFERRER", "referrer_id": str(wholesale_referrer.id)},
+        )
+        sale.refresh_from_db()
+        self.assertEqual(sale.referrer, wholesale_referrer)
+        self.assertEqual(sale.sold_value, Decimal("75.00"))
+
+    def test_locked_discount_is_not_overridden_by_referrer_policy(self):
+        gym_referrer = Referrer.objects.create(
+            name="Gym Lock Test", category=Referrer.CATEGORY_GYM_CODE
+        )
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        sale = Sale.objects.create(
+            order_number="LOCK-ORDER",
+            date=date(2024, 4, 12),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+        )
+
+        self.client.post(
+            reverse("assign_order_referrer_discount_range"),
+            {
+                "order_number": "LOCK-ORDER",
+                "referrer_id": str(gym_referrer.id),
+                "manual_discount_locked": "1",
+            },
+        )
+        sale.refresh_from_db()
+        self.assertEqual(sale.referrer, gym_referrer)
+        self.assertTrue(sale.manual_discount_locked)
+        self.assertEqual(sale.sold_value, Decimal("80.00"))
+
+    def test_server_side_validation_rejects_wholesale_discount_below_minimum(self):
+        wholesale_referrer = Referrer.objects.create(
+            name="Wholesale Validation", category=Referrer.CATEGORY_WHOLESALE
+        )
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        sale = Sale(
+            order_number="VALIDATION-ORDER",
+            date=date(2024, 4, 12),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("90.00"),  # 10% only
+            referrer=wholesale_referrer,
+        )
+
+        with self.assertRaises(ValidationError):
+            sale.full_clean()
 
     def test_assign_referrer_discount_range_ajax_returns_json(self):
         referrer = Referrer.objects.create(name="Referrer Ajax")

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -5373,8 +5373,17 @@ def assign_order_referrer(request, bucket_key: str):
     referrer = None
     if referrer_id:
         referrer = get_object_or_404(Referrer, pk=referrer_id)
+    manual_discount_locked = str(request.POST.get("manual_discount_locked", "")).strip().lower() in {
+        "1",
+        "true",
+        "on",
+    }
 
-    sales_qs.update(referrer=referrer)
+    for sale in sales_qs.select_related("variant__product", "referrer"):
+        sale.apply_referrer_discount_policy(
+            referrer=referrer,
+            manual_discount_locked=manual_discount_locked,
+        )
 
     redirect_url = reverse("sales_bucket_detail", args=[bucket_key])
     date_querystring = request.POST.get("date_querystring")
@@ -5607,8 +5616,17 @@ def assign_order_referrer_discount_range(request):
     referrer = None
     if referrer_id:
         referrer = get_object_or_404(Referrer, pk=referrer_id)
+    manual_discount_locked = str(request.POST.get("manual_discount_locked", "")).strip().lower() in {
+        "1",
+        "true",
+        "on",
+    }
 
-    sales_qs.update(referrer=referrer)
+    for sale in sales_qs.select_related("variant__product", "referrer"):
+        sale.apply_referrer_discount_policy(
+            referrer=referrer,
+            manual_discount_locked=manual_discount_locked,
+        )
 
     is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
     if is_ajax:
@@ -5618,6 +5636,7 @@ def assign_order_referrer_discount_range(request):
                 "order_number": order_number,
                 "referrer_id": referrer.id if referrer else None,
                 "referrer_name": referrer.name if referrer else "",
+                "manual_discount_locked": manual_discount_locked,
             }
         )
 
@@ -5639,7 +5658,8 @@ def ignore_order_referrer_discount_range(request):
     if not sales_qs.exists():
         return JsonResponse({"ok": False, "error": "Order not found"}, status=404)
 
-    sales_qs.update(referrer=None)
+    for sale in sales_qs.select_related("variant__product", "referrer"):
+        sale.apply_referrer_discount_policy(clear_referrer=True, manual_discount_locked=False)
     return JsonResponse({"ok": True, "order_number": order_number})
 
 


### PR DESCRIPTION
### Motivation
- Introduce deterministic discount behavior mapped to referrer categories so referrer assignments consistently affect pricing (Gym code → 10%; Wholesale → ≥25%).
- Prevent clients or direct API calls from bypassing rules by enforcing them server-side and providing a lock to preserve manual discounts.
- Ensure existing data is migration-safe by backfilling/repairing existing sales that have referrers but no matching discount behavior.
- Surface policy to users in the UI and admin so assignments are transparent and editable.

### Description
- Added `Referrer.category` with choices `gym_code`, `wholesale`, and `other`, and added `Sale.manual_discount_locked` to represent lock/precedence.
- Implemented sale-side policy APIs on `Sale`: `calculate_discount_percentage`, `get_referrer_discount_rule`, `apply_referrer_discount_policy`, and `clean` validation to enforce category rules and server-side protection.
- Replaced raw bulk `update(...)` referrer assignments with per-sale policy application in views `assign_order_referrer`, `assign_order_referrer_discount_range`, and `ignore_order_referrer_discount_range` using `sale.apply_referrer_discount_policy(...)` so rules cannot be bypassed.
- Updated the admin action `assign_referrer` to use the same policy-aware assignment path via `apply_referrer_discount_policy`.
- Updated assignment UI templates `sales_assign_referrers.html` and `sales_bucket_detail.html` to include referrer category metadata on chips, explanatory helper text, and a `manual_discount_locked` checkbox, plus JS to display rule text dynamically.
- Added migration `0026_referrer_discount_policy.py` to add the new fields and run a backfill, and added a management command `inventory/management/commands/backfill_referrer_discounts.py` for manual / post-deploy repair.
- Added tests in `inventory/tests.py` covering assignment application, wholesale minimum enforcement, editing referrer behavior, lock precedence, and server-side validation.

### Testing
- Added automated tests to `inventory/tests.py` for the new behaviors (assignment applies discounts, wholesale minimum, referrer edits, lock precedence, and model validation); these tests were added but not executed in this environment.
- Ran `python -m compileall inventory` successfully to verify modules compile after changes.
- Attempting to run `python manage.py makemigrations inventory` / the Django test suite failed in this environment due to missing Django (`ModuleNotFoundError: No module named 'django'`), so database migration/application tests and `manage.py test` were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60b1b85d0832c8d80424142b35285)