### PR TITLE
Add discount type & percentage-range filters and scoped summaries to Sales and Assign Referrers pages

### DIFF
--- a/inventory/templates/inventory/sales.html
+++ b/inventory/templates/inventory/sales.html
@@ -12,6 +12,7 @@
         <div class="filter-section-header">
           <p class="filter-showing">
             Showing: {{ start_date|date:"M j, Y" }} to {{ end_date|date:"M j, Y" }}
+            | Discount {{ min_discount }}%–{{ max_discount }}%
           </p>
           <button type="submit" class="btn filter-apply-button">
             Apply
@@ -42,6 +43,50 @@
             </div>
           </div>
           <div class="card-panel filter-card filter-card--compact">
+            <p class="filter-card__title">Discount filters</p>
+            <div class="filter-toolbar__field">
+              <label for="min_discount" class="active">Min discount %</label>
+              <input
+                type="number"
+                id="min_discount"
+                name="min_discount"
+                min="0"
+                max="100"
+                value="{{ min_discount }}"
+                class="browser-default"
+              />
+            </div>
+            <div class="filter-toolbar__field">
+              <label for="max_discount" class="active">Max discount %</label>
+              <input
+                type="number"
+                id="max_discount"
+                name="max_discount"
+                min="0"
+                max="100"
+                value="{{ max_discount }}"
+                class="browser-default"
+              />
+            </div>
+            <div class="filter-toolbar__field">
+              <span class="grey-text text-darken-1">Presets:</span>
+              <button type="button" class="btn-flat js-discount-preset" data-min="0" data-max="100">All</button>
+              <button type="button" class="btn-flat js-discount-preset" data-min="10" data-max="50">10–50%</button>
+              <button type="button" class="btn-flat js-discount-preset" data-min="25" data-max="50">Wholesale</button>
+            </div>
+            <div class="filter-toolbar__field">
+              <span class="grey-text text-darken-1">Discount type</span>
+              {% for code, label in discount_type_filters %}
+                <p style="margin: 4px 0;">
+                  <label>
+                    <input type="checkbox" name="discount_type" value="{{ code }}" {% if code in selected_discount_types %}checked{% endif %} />
+                    <span>{{ label }}</span>
+                  </label>
+                </p>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="card-panel filter-card filter-card--compact">
             <p class="filter-card__title">Referrer Tools</p>
             <div class="filter-toolbar__aside">
               <ul>
@@ -67,6 +112,24 @@
     <div class="row">
 
     {% if has_sales_data %}
+      <div class="card-panel blue lighten-5">
+        <h6 class="grey-text text-darken-2" style="margin-top: 0;">Discount scope summary</h6>
+        <p>Total orders in current scope: <strong>{{ discount_scope_summary.total_orders }}</strong></p>
+        <table class="striped">
+          <thead><tr><th>Discount type</th><th>Orders</th><th>Percent</th></tr></thead>
+          <tbody>
+            {% for row in discount_scope_summary.rows %}
+              <tr>
+                <td>{{ row.label }}</td>
+                <td>{{ row.order_count }}</td>
+                <td>{{ row.percentage|floatformat:2 }}%</td>
+              </tr>
+            {% empty %}
+              <tr><td colspan="3" class="grey-text">No rows in current filter scope.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
       <div class="col s12 m4">
         <div class="card-panel" style="padding: 0; overflow: hidden;">
           <div style="display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: auto auto;">
@@ -319,6 +382,14 @@
         });
 
       const referrerDetailSelect = document.getElementById("referrerDetailSelect");
+      const minDiscountInput = document.getElementById("min_discount");
+      const maxDiscountInput = document.getElementById("max_discount");
+      document.querySelectorAll(".js-discount-preset").forEach((button) => {
+        button.addEventListener("click", function () {
+          if (minDiscountInput) minDiscountInput.value = button.dataset.min || "";
+          if (maxDiscountInput) maxDiscountInput.value = button.dataset.max || "";
+        });
+      });
       if (referrerDetailSelect) {
         const dateQuerystring = "{{ date_querystring|default:''|escapejs }}";
         referrerDetailSelect.addEventListener("change", function () {

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -22,6 +22,13 @@
             Showing: {{ start_date|date:"M j Y" }} to {{ end_date|date:"M j Y" }}
             |
             {{ min_discount }}%–{{ max_discount }}%
+            {% if selected_discount_types %}
+              |
+              Types:
+              {% for code in selected_discount_types %}
+                <span class="chip">{{ code }}</span>
+              {% endfor %}
+            {% endif %}
             |
             <strong>{{ orders_count }}</strong> order{{ orders_count|pluralize }}
             |
@@ -71,6 +78,25 @@
             </div>
           </div>
           <!-- END DISCOUNT SLIDER -->
+          <div class="card-panel filter-card filter-card--compact">
+            <p class="filter-card__title">Discount type</p>
+            <div class="filter-toolbar__field">
+              {% for code, label in discount_type_filters %}
+                <p style="margin:4px 0;">
+                  <label>
+                    <input type="checkbox" name="discount_type" value="{{ code }}" {% if code in selected_discount_types %}checked{% endif %} />
+                    <span>{{ label }}</span>
+                  </label>
+                </p>
+              {% endfor %}
+            </div>
+            <div class="filter-toolbar__field">
+              <span class="grey-text text-darken-1">Presets:</span>
+              <button type="button" class="btn-flat js-discount-preset" data-min="10" data-max="50">Default</button>
+              <button type="button" class="btn-flat js-discount-preset" data-min="25" data-max="50">Wholesale</button>
+              <button type="button" class="btn-flat js-discount-preset" data-min="0" data-max="100">All</button>
+            </div>
+          </div>
 
         </div>
       </form>
@@ -78,6 +104,20 @@
 
     <div class="filter-divider"></div>
     <!-- END FILTER BAR -->
+    <div class="card-panel blue lighten-5">
+      <h6 class="grey-text text-darken-2" style="margin-top: 0;">Discount scope summary</h6>
+      <p>Total orders in current scope: <strong>{{ discount_scope_summary.total_orders }}</strong></p>
+      <table class="striped">
+        <thead><tr><th>Discount type</th><th>Orders</th><th>Percent</th></tr></thead>
+        <tbody>
+          {% for row in discount_scope_summary.rows %}
+            <tr><td>{{ row.label }}</td><td>{{ row.order_count }}</td><td>{{ row.percentage|floatformat:2 }}%</td></tr>
+          {% empty %}
+            <tr><td colspan="3" class="grey-text">No rows in current filter scope.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
 
     <div class="card-panel">
       <label for="orderNumbersText" class="active">Order numbers (copy list)</label>
@@ -558,6 +598,16 @@
           updateLabel(maxInput);
         });
       }
+      document.querySelectorAll('.js-discount-preset').forEach(function(button) {
+        button.addEventListener('click', function() {
+          if (!minInput || !maxInput) {
+            return;
+          }
+          minInput.value = button.dataset.min || minInput.value;
+          maxInput.value = button.dataset.max || maxInput.value;
+          updateLabel(maxInput);
+        });
+      });
       updateLabel();
 
       var ignoreButtons = document.querySelectorAll('.ignore-order-button');

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -771,6 +771,101 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.context["net_sales_value"], Decimal("75"))
         self.assertTrue(response.context["has_sales_data"])
 
+    def test_sales_discount_filters_support_type_and_percentage_ranges(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        gym_referrer = Referrer.objects.create(
+            name="Gym Partner", category=Referrer.CATEGORY_GYM_CODE
+        )
+        wholesale_referrer = Referrer.objects.create(
+            name="Wholesale Partner", category=Referrer.CATEGORY_WHOLESALE
+        )
+        Sale.objects.create(
+            order_number="GYM-20",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            referrer=gym_referrer,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),  # 20%
+        )
+        Sale.objects.create(
+            order_number="WHOLE-30",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            referrer=wholesale_referrer,
+            sold_quantity=1,
+            sold_value=Decimal("70.00"),  # 30%
+        )
+
+        response = self.client.get(
+            reverse("sales"),
+            {
+                "start_date": "2024-04-01",
+                "end_date": "2024-04-30",
+                "min_discount": "15",
+                "max_discount": "25",
+                "discount_type": [Referrer.CATEGORY_GYM_CODE],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["orders_count"], 1)
+        self.assertEqual(response.context["discount_scope_summary"]["total_orders"], 1)
+        self.assertEqual(
+            response.context["discount_scope_summary"]["rows"][0]["type"],
+            Referrer.CATEGORY_GYM_CODE,
+        )
+
+    def test_sales_discount_summary_percentages_use_active_filters(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        gym_referrer = Referrer.objects.create(
+            name="Gym 1", category=Referrer.CATEGORY_GYM_CODE
+        )
+        wholesale_referrer = Referrer.objects.create(
+            name="Wholesale 1", category=Referrer.CATEGORY_WHOLESALE
+        )
+        Sale.objects.create(
+            order_number="GYM-A",
+            date=date(2024, 4, 11),
+            variant=self.variant,
+            referrer=gym_referrer,
+            sold_quantity=1,
+            sold_value=Decimal("90.00"),
+        )
+        Sale.objects.create(
+            order_number="WHOLE-A",
+            date=date(2024, 4, 11),
+            variant=self.variant,
+            referrer=wholesale_referrer,
+            sold_quantity=1,
+            sold_value=Decimal("70.00"),
+        )
+        Sale.objects.create(
+            order_number="WHOLE-B",
+            date=date(2024, 4, 12),
+            variant=self.variant,
+            referrer=wholesale_referrer,
+            sold_quantity=1,
+            sold_value=Decimal("75.00"),
+        )
+
+        response = self.client.get(
+            reverse("sales"),
+            {"start_date": "2024-04-01", "end_date": "2024-04-30"},
+        )
+        self.assertEqual(response.status_code, 200)
+        summary_rows = {
+            row["type"]: row for row in response.context["discount_scope_summary"]["rows"]
+        }
+        self.assertEqual(response.context["discount_scope_summary"]["total_orders"], 3)
+        self.assertEqual(summary_rows[Referrer.CATEGORY_GYM_CODE]["order_count"], 1)
+        self.assertEqual(summary_rows[Referrer.CATEGORY_WHOLESALE]["order_count"], 2)
+        self.assertEqual(
+            summary_rows[Referrer.CATEGORY_WHOLESALE]["percentage"],
+            Decimal("66.67"),
+        )
+
     def test_sales_includes_top_five_referrers_by_value(self):
         referrers = [
             Referrer.objects.create(name="Alpha"),
@@ -1062,6 +1157,52 @@ class SalesViewTests(TestCase):
         self.assertEqual(response.context["max_discount"], 50)
         self.assertEqual(response.context["orders_count"], 1)
         self.assertEqual(response.context["orders"][0]["order_number"], "IN-RANGE")
+
+    def test_assign_referrers_view_filters_by_discount_type_and_updates_summary(self):
+        self.product.retail_price = Decimal("100")
+        self.product.save(update_fields=["retail_price"])
+        gym_referrer = Referrer.objects.create(
+            name="Gym Assign", category=Referrer.CATEGORY_GYM_CODE
+        )
+        wholesale_referrer = Referrer.objects.create(
+            name="Wholesale Assign", category=Referrer.CATEGORY_WHOLESALE
+        )
+        Sale.objects.create(
+            order_number="ASSIGN-GYM",
+            date=date(2024, 4, 5),
+            variant=self.variant,
+            referrer=gym_referrer,
+            sold_quantity=1,
+            sold_value=Decimal("80.00"),
+        )
+        Sale.objects.create(
+            order_number="ASSIGN-WHOLE",
+            date=date(2024, 4, 6),
+            variant=self.variant,
+            referrer=wholesale_referrer,
+            sold_quantity=1,
+            sold_value=Decimal("70.00"),
+        )
+
+        response = self.client.get(
+            reverse("sales_assign_referrers"),
+            {
+                "start_date": "2024-04-01",
+                "end_date": "2024-04-30",
+                "min_discount": "15",
+                "max_discount": "35",
+                "discount_type": [Referrer.CATEGORY_GYM_CODE],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["orders_count"], 1)
+        self.assertEqual(response.context["orders"][0]["order_number"], "ASSIGN-GYM")
+        self.assertEqual(response.context["discount_scope_summary"]["total_orders"], 1)
+        self.assertEqual(
+            response.context["discount_scope_summary"]["rows"][0]["percentage"],
+            Decimal("100.00"),
+        )
 
     def test_assign_referrer_discount_range_updates_all_sales(self):
         referrer = Referrer.objects.create(

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -316,6 +316,115 @@ def _parse_discount_percent(param: Optional[str], default: int) -> int:
     return min(100, max(0, value))
 
 
+NO_REFERRER_FILTER_VALUE = "no_referrer"
+
+
+def _available_discount_type_filters() -> list[tuple[str, str]]:
+    return [
+        *Referrer.CATEGORY_CHOICES,
+        (NO_REFERRER_FILTER_VALUE, "No referrer"),
+    ]
+
+
+def _parse_discount_type_filters(request) -> list[str]:
+    allowed = {code for code, _label in _available_discount_type_filters()}
+    selected = []
+    for code in request.GET.getlist("discount_type"):
+        normalized = (code or "").strip()
+        if normalized in allowed and normalized not in selected:
+            selected.append(normalized)
+    return selected
+
+
+def _apply_discount_filters_to_sales_queryset(
+    sales_qs,
+    *,
+    min_discount: Optional[int] = None,
+    max_discount: Optional[int] = None,
+    selected_discount_types: Optional[list[str]] = None,
+):
+    selected_discount_types = selected_discount_types or []
+    filtered_qs = sales_qs
+
+    if selected_discount_types:
+        referrer_categories = [
+            discount_type
+            for discount_type in selected_discount_types
+            if discount_type != NO_REFERRER_FILTER_VALUE
+        ]
+        include_no_referrer = NO_REFERRER_FILTER_VALUE in selected_discount_types
+
+        type_filters = Q()
+        if referrer_categories:
+            type_filters |= Q(referrer__category__in=referrer_categories)
+        if include_no_referrer:
+            type_filters |= Q(referrer__isnull=True)
+        if type_filters:
+            filtered_qs = filtered_qs.filter(type_filters)
+
+    if min_discount is None and max_discount is None:
+        return filtered_qs
+
+    min_discount = 0 if min_discount is None else min_discount
+    max_discount = 100 if max_discount is None else max_discount
+    if min_discount > max_discount:
+        min_discount, max_discount = max_discount, min_discount
+
+    retail_total_expression = ExpressionWrapper(
+        F("variant__product__retail_price") * F("sold_quantity"),
+        output_field=DecimalField(max_digits=14, decimal_places=2),
+    )
+    discount_percentage_expression = ExpressionWrapper(
+        (
+            retail_total_expression
+            - Coalesce(F("sold_value"), Value(Decimal("0.00"), output_field=DecimalField()))
+        )
+        * Value(Decimal("100.00"), output_field=DecimalField())
+        / retail_total_expression,
+        output_field=DecimalField(max_digits=8, decimal_places=2),
+    )
+
+    filtered_qs = (
+        filtered_qs.filter(sold_quantity__gt=0, variant__product__retail_price__gt=0)
+        .annotate(discount_percentage_value=discount_percentage_expression)
+        .filter(
+            discount_percentage_value__gte=Decimal(str(min_discount)),
+            discount_percentage_value__lte=Decimal(str(max_discount)),
+        )
+    )
+    return filtered_qs
+
+
+def _get_discount_type_summary_rows(filtered_sales_qs) -> tuple[int, list[dict[str, Any]]]:
+    discount_type_expression = Case(
+        When(referrer__isnull=True, then=Value(NO_REFERRER_FILTER_VALUE)),
+        default=Coalesce(F("referrer__category"), Value(NO_REFERRER_FILTER_VALUE)),
+    )
+    summary_rows = list(
+        filtered_sales_qs.annotate(discount_type=discount_type_expression)
+        .values("discount_type")
+        .annotate(order_count=Count("order_number", distinct=True))
+        .order_by("discount_type")
+    )
+    total_orders = sum(row["order_count"] for row in summary_rows)
+
+    label_map = {code: label for code, label in _available_discount_type_filters()}
+    rows = []
+    for row in summary_rows:
+        order_count = row["order_count"] or 0
+        percentage = (Decimal(order_count) / Decimal(total_orders) * Decimal("100")) if total_orders else Decimal("0")
+        rows.append(
+            {
+                "type": row["discount_type"],
+                "label": label_map.get(row["discount_type"], row["discount_type"]),
+                "order_count": order_count,
+                "percentage": percentage.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP),
+            }
+        )
+    rows.sort(key=lambda summary: summary["order_count"], reverse=True)
+    return total_orders, rows
+
+
 def _get_sale_discount_chips(sale) -> list[dict[str, str]]:
     return [
         {"label": chip.label, "color": chip.color}
@@ -4258,10 +4367,21 @@ def sales(request):
     """Render the sales page with basic order metrics for a date range."""
 
     start_date, end_date = _get_sales_date_range(request)
+    selected_discount_types = _parse_discount_type_filters(request)
+    min_discount = _parse_discount_percent(request.GET.get("min_discount"), default=0)
+    max_discount = _parse_discount_percent(request.GET.get("max_discount"), default=100)
+    if min_discount > max_discount:
+        min_discount, max_discount = max_discount, min_discount
 
     sales_qs = Sale.objects.filter(date__range=(start_date, end_date))
+    filtered_sales_qs = _apply_discount_filters_to_sales_queryset(
+        sales_qs,
+        min_discount=min_discount,
+        max_discount=max_discount,
+        selected_discount_types=selected_discount_types,
+    )
 
-    orders_count = sales_qs.values("order_number").distinct().count()
+    orders_count = filtered_sales_qs.values("order_number").distinct().count()
 
     net_quantity_expr = ExpressionWrapper(
         F("sold_quantity")
@@ -4269,7 +4389,7 @@ def sales(request):
         output_field=IntegerField(),
     )
     total_items = (
-        sales_qs.aggregate(
+        filtered_sales_qs.aggregate(
             total_items=Coalesce(
                 Sum(net_quantity_expr), Value(0, output_field=IntegerField())
             )
@@ -4289,7 +4409,7 @@ def sales(request):
     }
 
     eligible_sales = (
-        sales_qs.filter(Q(return_quantity__isnull=True) | Q(return_quantity=0))
+        filtered_sales_qs.filter(Q(return_quantity__isnull=True) | Q(return_quantity=0))
         .filter(sold_quantity__gt=0)
         .select_related("variant__product")
     )
@@ -4315,7 +4435,7 @@ def sales(request):
         bucket["actual_value"] for bucket in price_breakdown
     )
 
-    value_aggregates = sales_qs.aggregate(
+    value_aggregates = filtered_sales_qs.aggregate(
         gross_sales=Sum("sold_value"),
         returns_total=Sum("return_value"),
     )
@@ -4325,6 +4445,7 @@ def sales(request):
 
     top_referrers = list(
         sales_qs.filter(referrer__isnull=False)
+        .filter(pk__in=filtered_sales_qs.values("pk"))
         .values("referrer_id", "referrer__name")
         .annotate(
             total_sales=Coalesce(
@@ -4361,12 +4482,14 @@ def sales(request):
         for bucket in price_breakdown:
             bucket["actual_percentage"] = Decimal("0")
 
-    date_querystring = urlencode(
-        {
-            "start_date": start_date.isoformat(),
-            "end_date": end_date.isoformat(),
-        }
-    )
+    date_query_items = [
+        ("start_date", start_date.isoformat()),
+        ("end_date", end_date.isoformat()),
+        ("min_discount", min_discount),
+        ("max_discount", max_discount),
+    ]
+    date_query_items.extend(("discount_type", discount_type) for discount_type in selected_discount_types)
+    date_querystring = urlencode(date_query_items, doseq=True)
 
     has_custom_range = bool(
         _parse_sales_date(request.GET.get("start_date"))
@@ -4381,6 +4504,12 @@ def sales(request):
         )
     insights_sales = Sale.objects.filter(
         date__range=(insights_start, insights_end)
+    )
+    insights_sales = _apply_discount_filters_to_sales_queryset(
+        insights_sales,
+        min_discount=min_discount,
+        max_discount=max_discount,
+        selected_discount_types=selected_discount_types,
     ).select_related("variant__product")
     insights_has_data = insights_sales.exists()
 
@@ -4546,6 +4675,9 @@ def sales(request):
         "#c0ca33",
         "#f06292",
     ]
+    total_orders_in_scope, discount_type_summary = _get_discount_type_summary_rows(
+        filtered_sales_qs
+    )
 
     context = {
         "start_date": start_date,
@@ -4577,6 +4709,14 @@ def sales(request):
         "group_chart_labels": json.dumps(group_labels),
         "group_chart_values": json.dumps(group_values),
         "group_chart_colors": json.dumps(group_palette),
+        "discount_type_filters": _available_discount_type_filters(),
+        "selected_discount_types": selected_discount_types,
+        "min_discount": min_discount,
+        "max_discount": max_discount,
+        "discount_scope_summary": {
+            "total_orders": total_orders_in_scope,
+            "rows": discount_type_summary,
+        },
     }
 
     return render(request, "inventory/sales.html", context)
@@ -5399,12 +5539,17 @@ def sales_assign_referrers(request):
     max_discount = _parse_discount_percent(request.GET.get("max_discount"), default=50)
     if min_discount > max_discount:
         min_discount, max_discount = max_discount, min_discount
+    selected_discount_types = _parse_discount_type_filters(request)
 
     sales_qs = Sale.objects.filter(date__range=(start_date, end_date))
-
+    eligible_sales = _apply_discount_filters_to_sales_queryset(
+        sales_qs.filter(Q(return_quantity__isnull=True) | Q(return_quantity=0)),
+        min_discount=min_discount,
+        max_discount=max_discount,
+        selected_discount_types=selected_discount_types,
+    ).filter(sold_quantity__gt=0)
     eligible_sales = (
-        sales_qs.filter(Q(return_quantity__isnull=True) | Q(return_quantity=0))
-        .filter(sold_quantity__gt=0)
+        eligible_sales
         .select_related("variant__product", "referrer")
         .prefetch_related("discounts")
     )
@@ -5416,16 +5561,7 @@ def sales_assign_referrers(request):
     total_retail_value = Decimal("0")
     total_actual_value = Decimal("0")
 
-    min_discount_decimal = Decimal(str(min_discount))
-    max_discount_decimal = Decimal(str(max_discount))
-
     for sale in eligible_sales:
-        discount_percentage = _calculate_sale_discount_percentage(sale)
-        if discount_percentage is None:
-            continue
-        if discount_percentage < min_discount_decimal or discount_percentage > max_discount_decimal:
-            continue
-
         filtered_sales.append(sale)
         filtered_sale_ids.add(sale.pk)
 
@@ -5570,13 +5706,16 @@ def sales_assign_referrers(request):
         if order.get("order_number") is not None and str(order.get("order_number")).strip()
     )
 
-    date_querystring = urlencode(
-        {
-            "start_date": start_date.isoformat(),
-            "end_date": end_date.isoformat(),
-            "min_discount": min_discount,
-            "max_discount": max_discount,
-        }
+    date_query_items = [
+        ("start_date", start_date.isoformat()),
+        ("end_date", end_date.isoformat()),
+        ("min_discount", min_discount),
+        ("max_discount", max_discount),
+    ]
+    date_query_items.extend(("discount_type", discount_type) for discount_type in selected_discount_types)
+    date_querystring = urlencode(date_query_items, doseq=True)
+    total_orders_in_scope, discount_type_summary = _get_discount_type_summary_rows(
+        eligible_sales
     )
 
     return render(
@@ -5598,6 +5737,12 @@ def sales_assign_referrers(request):
             "min_discount": min_discount,
             "max_discount": max_discount,
             "order_numbers_text": order_numbers_text,
+            "discount_type_filters": _available_discount_type_filters(),
+            "selected_discount_types": selected_discount_types,
+            "discount_scope_summary": {
+                "total_orders": total_orders_in_scope,
+                "rows": discount_type_summary,
+            },
         },
     )
 


### PR DESCRIPTION
### Motivation
- Provide first-class filtering by discount type and discount percentage ranges on Sales and Assign Referrers pages so teams can inspect and operate on scoped subsets of orders.  
- Make percentage metrics (counts and % per discount type) recompute against the active filter scope rather than global totals to avoid misleading aggregates.  
- Ensure aggregation is pagination-safe for large datasets by computing summaries server-side from the filtered queryset.

### Description
- Identified data sources: both pages are powered by `Sale` querysets (main Sales page via `sales` and the Assign Referrers page via `sales_assign_referrers` in `inventory/views.py`).
- Added backend helpers: `_parse_discount_type_filters`, `_apply_discount_filters_to_sales_queryset`, and `_get_discount_type_summary_rows` to support multi-select discount type filters, percentage range filtering, and server-side scoped aggregation (in `inventory/views.py`).
- Wired filters into both endpoints (`sales` and `sales_assign_referrers`) and replaced in-loop percentage filtering with queryset-level filtering so all metrics are computed from the same filtered scope; querystrings preserve `min_discount`, `max_discount`, and repeated `discount_type` params.
- Frontend changes: added discount-range inputs, presets, and discount-type multi-checkboxes, plus a new "Discount scope summary" module on both `inventory/templates/inventory/sales.html` and `inventory/templates/inventory/sales_assign_referrers.html` that shows total orders in scope and count/percent per discount type.
- Tests: added unit tests to `inventory/tests.py` that cover filter combinations (type + percentage range) and verify percentage math and scoped-summary behavior.

### Testing
- Static checks: compiled modified modules with `python -m compileall inventory/views.py inventory/tests.py` and compilation succeeded.  
- Unit tests: attempted to run targeted Django tests locally (several `SalesViewTests` methods were invoked), but the test run failed in this environment because Django is not installed (`ModuleNotFoundError: No module named 'django'`).  
- New tests were added (`inventory/tests.py`) covering discount type + percentage range filtering and summary percentage correctness, but they were not executed successfully here due to the missing Django runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61d4e5a34832ca0bbb55c19ef446e)