### PR TITLE
Add no-restock POST toggle from product scorecards

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -213,6 +213,11 @@ main {
   color: #c62828;
 }
 
+.signal-badge--no-restock {
+  background: #f3e5f5;
+  color: #6a1b9a;
+}
+
 .signal-card__body {
   display: none;
 }
@@ -227,6 +232,8 @@ main {
 .signal-card__status-row {
   display: flex;
   justify-content: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
   margin-bottom: 8px;
 }
 

--- a/inventory/templates/inventory/snippets/product_card_default.html
+++ b/inventory/templates/inventory/snippets/product_card_default.html
@@ -108,6 +108,23 @@
               <p class="metric-value">¥{{ product.average_cost_price|floatformat:2|default_if_none:"-" }}</p>
             </div>
           </div>
+          <div class="row" style="margin-bottom: 0;">
+            <div class="col s12" style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+              {% if product.no_restock %}
+                <span class="signal-badge signal-badge--no-restock">No restock</span>
+              {% endif %}
+              <form method="post" action="{% url 'product_toggle_no_restock' product.id %}">
+                {% csrf_token %}
+                {% if request.GET.urlencode %}
+                  <input type="hidden" name="redirect_querystring" value="{{ request.GET.urlencode }}">
+                {% endif %}
+                <input type="hidden" name="no_restock" value="{% if product.no_restock %}0{% else %}1{% endif %}">
+                <button type="submit" class="btn-small {% if product.no_restock %}grey lighten-1{% else %}orange lighten-1{% endif %}">
+                  {% if product.no_restock %}Undo no restock{% else %}No restock{% endif %}
+                </button>
+              </form>
+            </div>
+          </div>
         </div>
       </div>
     </li>

--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -98,11 +98,24 @@
                   <span class="signal-badge signal-badge--{{ product.status_signal|default:'monitor'|slugify }}">
                     {{ product.status_signal|default:"Monitor" }}
                   </span>
+                  {% if product.no_restock %}
+                    <span class="signal-badge signal-badge--no-restock">No restock</span>
+                  {% endif %}
                 </div>
 
                 <div class="signal-splits">
                   <p class="signal-line"><span class="signal-label">Quality</span> <strong>{{ product.stock_quality_signal|default:"Mixed" }}</strong></p>
                 </div>
+                <form method="post" action="{% url 'product_toggle_no_restock' product.id %}" style="margin-top: 12px;">
+                  {% csrf_token %}
+                  {% if request.GET.urlencode %}
+                    <input type="hidden" name="redirect_querystring" value="{{ request.GET.urlencode }}">
+                  {% endif %}
+                  <input type="hidden" name="no_restock" value="{% if product.no_restock %}0{% else %}1{% endif %}">
+                  <button type="submit" class="btn-small {% if product.no_restock %}grey lighten-1{% else %}orange lighten-1{% endif %}">
+                    {% if product.no_restock %}Undo no restock{% else %}No restock{% endif %}
+                  </button>
+                </form>
               </div>
           </div>
           <!-- END ACTIONS SECTION -->

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -5,6 +5,11 @@ urlpatterns = [
     path('', views.home, name='home'),
     path('products/', views.product_list, name='product_list'),
     path('products/filtered/', views.product_filtered, name='product_filtered'),
+    path(
+        'products/<int:product_id>/toggle-no-restock/',
+        views.product_toggle_no_restock,
+        name='product_toggle_no_restock',
+    ),
     path('products/type/<str:type_code>/', views.product_type_list, name='product_type_list'),
     path('products/style/<str:style_code>/', views.product_style_list, name='product_style_list'),
     path('products/group/<int:group_id>/', views.product_group_list, name='product_group_list'),

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -2897,6 +2897,26 @@ def product_filtered(request):
     return _render_filtered_products(request, category=primary_category)
 
 
+@require_POST
+def product_toggle_no_restock(request, product_id: int):
+    product = get_object_or_404(Product, pk=product_id)
+
+    explicit_state = request.POST.get("no_restock")
+    if explicit_state is None:
+        product.no_restock = not product.no_restock
+    else:
+        product.no_restock = explicit_state.lower() in {"1", "true", "yes", "on"}
+
+    product.save(update_fields=["no_restock"])
+
+    redirect_querystring = request.POST.get("redirect_querystring", "").strip()
+    redirect_url = reverse("product_filtered")
+    if redirect_querystring:
+        redirect_url = f"{redirect_url}?{redirect_querystring}"
+
+    return redirect(redirect_url)
+
+
 def product_type_list(request, type_code: str):
     label = _choice_label(PRODUCT_TYPE_CHOICES, type_code)
     if not label:


### PR DESCRIPTION
### Motivation
- Provide a quick, safe way to exclude/restore products from reorder recommendations directly from the Products screen.
- Make the action idempotent when explicit state is posted to avoid accidental double-click reversals and preserve the current filtered view when returning.

### Description
- Add a new POST route `products/<int:product_id>/toggle-no-restock/` wired to `product_toggle_no_restock` in `inventory/urls.py`.
- Implement `product_toggle_no_restock` in `inventory/views.py` with `@require_POST` to load the `Product`, apply an explicit `no_restock` state when provided or toggle as a fallback, save with `update_fields=["no_restock"]`, and redirect back to `product_filtered` while preserving the current querystring via a `redirect_querystring` POST field.
- Update `inventory/templates/inventory/snippets/product_scorecard.html` to show a visible "No restock" badge when active and add a CSRF-protected POST form/button per product that posts an explicit `no_restock` value (`1` or `0`) and the current request querystring for redirect.
- Add lightweight styling in `inventory/static/styles.css` for `.signal-badge--no-restock` and small layout tweaks to the status row for better scanability.

### Testing
- Ran `python manage.py check` in this environment, which failed due to Django not being installed here (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74ddd8878832cb5cceb5e6f4507f8)