### PR TITLE
Add guarded product decommission workflow on Products page

### DIFF
--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -120,6 +120,52 @@
                     {% if product.no_restock %}Undo no restock{% else %}No restock{% endif %}
                   </button>
                 </form>
+
+                <form method="post" action="{% url 'product_decommission' product.id %}" style="margin-top: 8px;">
+                  {% csrf_token %}
+                  {% if request.GET.urlencode %}
+                    <input type="hidden" name="redirect_querystring" value="{{ request.GET.urlencode }}">
+                  {% endif %}
+                  <input type="hidden" name="decommissioned" value="{% if product.decommissioned %}0{% else %}1{% endif %}">
+                  <button type="submit" class="btn-small {% if product.decommissioned %}blue-grey lighten-1{% else %}red lighten-1{% endif %}">
+                    {% if product.decommissioned %}Undo decommission{% else %}Decommission{% endif %}
+                  </button>
+                </form>
+
+                {% if not product.decommissioned and product.total_inventory|default:0 > 0 %}
+                  <form method="post" action="{% url 'product_decommission' product.id %}" style="margin-top: 6px;">
+                    {% csrf_token %}
+                    {% if request.GET.urlencode %}
+                      <input type="hidden" name="redirect_querystring" value="{{ request.GET.urlencode }}">
+                    {% endif %}
+                    <input type="hidden" name="decommissioned" value="1">
+                    <input type="hidden" name="force" value="true">
+                    <button type="submit" class="btn-small red darken-2">
+                      Force decommission ({{ product.total_inventory|default:0 }} in stock)
+                    </button>
+                  </form>
+                {% endif %}
+
+                {% if request.GET.decommission_product == product.id|stringformat:"s" %}
+                  {% if request.GET.decommission_notice == "blocked_stock" %}
+                    <p class="orange-text text-darken-3" style="margin-top: 8px;">
+                      Blocked: {{ request.GET.decommission_stock|default:"0" }} units in stock. Use force decommission to continue.
+                    </p>
+                  {% elif request.GET.decommission_notice == "retired" %}
+                    <p class="green-text text-darken-2" style="margin-top: 8px;">Product marked as decommissioned.</p>
+                  {% elif request.GET.decommission_notice == "reinstated" %}
+                    <p class="green-text text-darken-2" style="margin-top: 8px;">Product restored from decommissioned state.</p>
+                  {% endif %}
+                {% endif %}
+
+                <div style="margin-top: 8px;">
+                  <a
+                    class="btn-flat teal-text text-darken-2"
+                    href="{% url 'product_filtered' %}?{% if request.GET.urlencode %}{{ request.GET.urlencode }}&{% endif %}show_retired=true"
+                  >
+                    Show retired
+                  </a>
+                </div>
               </div>
           </div>
           <!-- END ACTIONS SECTION -->

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -2615,3 +2615,82 @@ class DiscountChipColorResolverTests(TestCase):
 
         self.assertEqual(len(chips), 1)
         self.assertEqual(chips[0].color, "#9E9E9E")
+
+
+class ProductDecommissionWorkflowTests(TestCase):
+    def setUp(self):
+        self.product = Product.objects.create(product_id="P-DEC", product_name="Decom Product")
+        self.variant = ProductVariant.objects.create(
+            product=self.product,
+            variant_code="P-DEC-S",
+            primary_color="#111111",
+        )
+        self.url = reverse("product_decommission", args=[self.product.id])
+
+    def test_decommission_blocks_when_stock_exists_without_force(self):
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date.today(),
+            inventory_count=7,
+        )
+
+        response = self.client.post(
+            self.url,
+            {"decommissioned": "1", "redirect_querystring": "style_filter=ng"},
+        )
+
+        self.product.refresh_from_db()
+        self.assertFalse(self.product.decommissioned)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("style_filter=ng", response["Location"])
+        self.assertIn("decommission_notice=blocked_stock", response["Location"])
+        self.assertIn("decommission_stock=7", response["Location"])
+
+    def test_decommission_allows_force_when_stock_exists(self):
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date.today(),
+            inventory_count=3,
+        )
+
+        response = self.client.post(
+            self.url,
+            {"decommissioned": "1", "force": "true", "redirect_querystring": "style_filter=ng"},
+        )
+
+        self.product.refresh_from_db()
+        self.assertTrue(self.product.decommissioned)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("style_filter=ng", response["Location"])
+        self.assertIn("decommission_notice=retired", response["Location"])
+
+    def test_decommission_allows_when_latest_inventory_is_zero(self):
+        old_date = date.today() - timedelta(days=30)
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=old_date,
+            inventory_count=5,
+        )
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date.today(),
+            inventory_count=0,
+        )
+
+        response = self.client.post(self.url, {"decommissioned": "1"})
+
+        self.product.refresh_from_db()
+        self.assertTrue(self.product.decommissioned)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("decommission_notice=retired", response["Location"])
+
+    def test_undo_decommission_restores_product(self):
+        self.product.decommissioned = True
+        self.product.save(update_fields=["decommissioned"])
+
+        response = self.client.post(self.url, {"decommissioned": "0"})
+
+        self.product.refresh_from_db()
+        self.assertFalse(self.product.decommissioned)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("decommission_notice=reinstated", response["Location"])

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -10,6 +10,11 @@ urlpatterns = [
         views.product_toggle_no_restock,
         name='product_toggle_no_restock',
     ),
+    path(
+        'products/<int:product_id>/decommission/',
+        views.product_decommission,
+        name='product_decommission',
+    ),
     path('products/type/<str:type_code>/', views.product_type_list, name='product_type_list'),
     path('products/style/<str:style_code>/', views.product_style_list, name='product_style_list'),
     path('products/group/<int:group_id>/', views.product_group_list, name='product_group_list'),

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -7,7 +7,7 @@ from collections import defaultdict, namedtuple, OrderedDict
 import calendar
 import statistics
 import math
-from urllib.parse import urlencode
+from urllib.parse import urlencode, parse_qsl
 import logging
 from io import BytesIO
 import os
@@ -2924,6 +2924,68 @@ def product_toggle_no_restock(request, product_id: int):
         redirect_url = f"{redirect_url}?{redirect_querystring}"
 
     return redirect(redirect_url)
+
+
+def _redirect_to_product_filtered_with_query(redirect_querystring: str, **extra_params):
+    redirect_url = reverse("product_filtered")
+    query_items = []
+
+    if redirect_querystring:
+        query_items.extend(parse_qsl(redirect_querystring, keep_blank_values=True))
+
+    for key, value in extra_params.items():
+        if value is not None:
+            query_items.append((key, str(value)))
+
+    if query_items:
+        redirect_url = f"{redirect_url}?{urlencode(query_items, doseq=True)}"
+
+    return redirect(redirect_url)
+
+
+@require_POST
+def product_decommission(request, product_id: int):
+    product = get_object_or_404(Product, pk=product_id)
+    redirect_querystring = request.POST.get("redirect_querystring", "").strip()
+
+    explicit_state = request.POST.get("decommissioned")
+    if explicit_state is None:
+        should_decommission = not product.decommissioned
+    else:
+        should_decommission = explicit_state.lower() in {"1", "true", "yes", "on"}
+
+    if should_decommission:
+        latest_snapshot = (
+            InventorySnapshot.objects.filter(product_variant=OuterRef("pk"))
+            .order_by("-date")
+            .values("inventory_count")[:1]
+        )
+        total_inventory = (
+            ProductVariant.objects.filter(product=product)
+            .annotate(latest_inventory=Coalesce(Subquery(latest_snapshot), 0))
+            .aggregate(total=Coalesce(Sum("latest_inventory"), 0))
+            .get("total", 0)
+            or 0
+        )
+
+        force_requested = str(request.POST.get("force", "")).lower() == "true"
+        if total_inventory > 0 and not force_requested:
+            return _redirect_to_product_filtered_with_query(
+                redirect_querystring,
+                decommission_notice="blocked_stock",
+                decommission_product=product.id,
+                decommission_stock=total_inventory,
+            )
+
+    product.decommissioned = should_decommission
+    product.save(update_fields=["decommissioned"])
+
+    notice = "retired" if should_decommission else "reinstated"
+    return _redirect_to_product_filtered_with_query(
+        redirect_querystring,
+        decommission_notice=notice,
+        decommission_product=product.id,
+    )
 
 
 def product_type_list(request, type_code: str):


### PR DESCRIPTION
### Motivation

- Provide a safe, in-UI way to retire (decommission) products from the Products list while preventing accidental retirement when stock exists. 
- Preserve the existing review flow by returning users to the `product_filtered` view with the original querystring and surface notices so teams can review and recover easily.

### Description

- Added a POST endpoint `product_decommission` in `inventory/views.py` that marks `Product.decommissioned` and enforces a guardrail based on the latest per-variant `InventorySnapshot` totals, with an explicit `force=true` override when non-zero stock exists.
- Implemented `_redirect_to_product_filtered_with_query` to preserve the original `product_filtered` querystring and append action notices such as `decommission_notice`, `decommission_product`, and `decommission_stock`.
- Wired the endpoint in `inventory/urls.py` as `products/<int:product_id>/decommission/`.
- Updated the product scorecard UI in `inventory/templates/inventory/snippets/product_scorecard.html` to add `Decommission` / `Undo decommission` buttons, a conditional `Force decommission` action when current stock is non-zero, inline outcome messages, and a quick `Show retired` (`show_retired=true`) link.
- Added tests in `inventory/tests.py` (`ProductDecommissionWorkflowTests`) covering blocked decommission without force, forced decommission, decommission when latest inventory is zero, and undoing a decommission; and added `parse_qsl` import usage and minor template logic to surface notices.

### Testing

- Ran `python -m py_compile inventory/views.py inventory/tests.py` to validate Python syntax, which succeeded.
- Attempted to run `python manage.py test inventory.tests.ProductDecommissionWorkflowTests`, but automated test execution failed in this environment because Django is not installed (ImportError), so the new tests could not be executed here.
- The new tests are included and will run in CI or a developer environment with Django available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7866ad5f4832c93fa25c486528206)