### PR TITLE
Allow removing a discount chip from a single sale item on assign-referrers page

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -1369,6 +1369,26 @@ vertical-align: middle;
   white-space: nowrap;
 }
 
+.sale-discount-chip-remove {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
+  margin-left: 0.35rem;
+  opacity: 0.9;
+  padding: 0;
+}
+
+.sale-discount-chip-remove:hover,
+.sale-discount-chip-remove:focus {
+  opacity: 1;
+}
+
 .order-item-product {
   align-items: center;
   display: flex;

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -224,7 +224,19 @@
                     {% if item.discount_chips %}
                       <div class="sale-discount-chip-list">
                         {% for discount in item.discount_chips %}
-                          <span class="sale-discount-chip {{ discount.tone }}">{{ discount.label }}</span>
+                          <span
+                            class="sale-discount-chip {{ discount.tone }}"
+                            data-discount-id="{{ discount.id }}"
+                            {% if discount.color %}style="--discount-chip-color: {{ discount.color }};"{% endif %}
+                          >
+                            <span>{{ discount.label }}</span>
+                            <button
+                              type="button"
+                              class="sale-discount-chip-remove"
+                              aria-label="Remove {{ discount.label }} from this sale item"
+                              title="Remove discount"
+                            >&times;</button>
+                          </span>
                         {% endfor %}
                       </div>
                     {% endif %}
@@ -482,13 +494,72 @@
         }
         var html = '<div class="sale-discount-chip-list">';
         chips.forEach(function(chip) {
-          html += '<span class="sale-discount-chip ' + escapeHtml(chip.tone || '') + '">'
-            + escapeHtml(chip.label || '')
+          var colorStyle = chip.color ? ' style="--discount-chip-color: ' + escapeHtml(chip.color) + ';"' : '';
+          html += '<span class="sale-discount-chip ' + escapeHtml(chip.tone || '') + '" data-discount-id="' + escapeHtml(String(chip.id || '')) + '"' + colorStyle + '>'
+            + '<span>' + escapeHtml(chip.label || '') + '</span>'
+            + '<button type="button" class="sale-discount-chip-remove" aria-label="Remove ' + escapeHtml(chip.label || 'discount') + ' from this sale item" title="Remove discount">&times;</button>'
             + '</span>';
         });
         html += '</div>';
         container.innerHTML = html;
       };
+
+      document.querySelectorAll('.order-block').forEach(function(orderBlock) {
+        orderBlock.addEventListener('click', function(event) {
+          var removeButton = event.target.closest('.sale-discount-chip-remove');
+          if (!removeButton || removeButton.disabled) {
+            return;
+          }
+
+          var saleCell = removeButton.closest('.sale-discount-cell');
+          var chip = removeButton.closest('.sale-discount-chip');
+          var saleId = saleCell ? (saleCell.dataset.saleId || '') : '';
+          var discountId = chip ? (chip.dataset.discountId || '') : '';
+          var orderNumber = orderBlock.dataset.orderNumber || '';
+          if (!orderNumber || !saleId || !discountId) {
+            return;
+          }
+
+          removeButton.disabled = true;
+          fetch("{% url 'assign_order_discount_reason' %}", {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+              'X-CSRFToken': getCookie('csrftoken'),
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: new URLSearchParams({
+              order_number: orderNumber,
+              sale_id: saleId,
+              discount_id: discountId,
+              selected: '0',
+            }).toString(),
+          })
+            .then(function(response) {
+              if (!response.ok) {
+                throw new Error('Request failed');
+              }
+              return response.json();
+            })
+            .then(function(data) {
+              if (!data.ok) {
+                throw new Error(data.error || 'Unable to remove discount');
+              }
+              if (data.sale_discounts) {
+                Object.keys(data.sale_discounts).forEach(function(updatedSaleId) {
+                  var cell = orderBlock.querySelector('.sale-discount-cell[data-sale-id="' + updatedSaleId + '"]');
+                  renderDiscountChips(cell, data.sale_discounts[updatedSaleId]);
+                });
+              }
+            })
+            .catch(function() {
+              // noop: keep previous state on failure
+            })
+            .finally(function() {
+              removeButton.disabled = false;
+            });
+        });
+      });
 
       var discountGroups = document.querySelectorAll('.discount-reason-chip-group');
       discountGroups.forEach(function(group) {

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1489,6 +1489,7 @@ class SalesViewTests(TestCase):
         self.assertIn("sale-discount-chip-list", html)
         self.assertIn("Tao Jin Bi", html)
         self.assertIn("Tmall Red Packet", html)
+        self.assertIn("sale-discount-chip-remove", html)
         self.assertIn("discount-reason-chip-group", html)
 
     def test_assign_referrers_view_marks_only_shared_order_discounts_selected(self):
@@ -1598,6 +1599,46 @@ class SalesViewTests(TestCase):
         sale_two.refresh_from_db()
         self.assertNotIn(discount.id, sale_one.discounts.values_list("id", flat=True))
         self.assertNotIn(discount.id, sale_two.discounts.values_list("id", flat=True))
+
+    def test_assign_order_discount_reason_removes_discount_from_single_sale(self):
+        discount = Discount.objects.create(name="Flash Coupon", code="flash-coupon")
+        sale_one = Sale.objects.create(
+            order_number="ORDER-DISC-SINGLE-REMOVE",
+            date=date(2024, 4, 10),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("90.00"),
+        )
+        sale_two = Sale.objects.create(
+            order_number="ORDER-DISC-SINGLE-REMOVE",
+            date=date(2024, 4, 11),
+            variant=self.variant,
+            sold_quantity=1,
+            sold_value=Decimal("85.00"),
+        )
+        sale_one.discounts.add(discount)
+        sale_two.discounts.add(discount)
+
+        response = self.client.post(
+            reverse("assign_order_discount_reason"),
+            {
+                "order_number": "ORDER-DISC-SINGLE-REMOVE",
+                "sale_id": str(sale_one.id),
+                "discount_id": str(discount.id),
+                "selected": "0",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["selected"])
+
+        sale_one.refresh_from_db()
+        sale_two.refresh_from_db()
+        self.assertNotIn(discount.id, sale_one.discounts.values_list("id", flat=True))
+        self.assertIn(discount.id, sale_two.discounts.values_list("id", flat=True))
 
     def test_discount_slider_renders_single_track_with_endpoints(self):
         self.product.retail_price = Decimal("100")

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -426,9 +426,11 @@ def _get_discount_type_summary_rows(filtered_sales_qs) -> tuple[int, list[dict[s
 
 
 def _get_sale_discount_chips(sale) -> list[dict[str, str]]:
+    discounts = list(sale.discounts.all())
+    chips = resolve_discount_chip_colors(discounts)
     return [
-        {"label": chip.label, "color": chip.color}
-        for chip in resolve_discount_chip_colors(sale.discounts.all())
+        {"id": discount.id, "label": chip.label, "color": chip.color}
+        for discount, chip in zip(discounts, chips)
     ]
 
 
@@ -5913,14 +5915,24 @@ def assign_order_discount_reason(request):
     if selected_value not in {"1", "0", "true", "false"}:
         return JsonResponse({"ok": False, "error": "Missing selected value"}, status=400)
     should_select = selected_value in {"1", "true"}
+    sale_id = (request.POST.get("sale_id") or "").strip()
 
     discount = get_object_or_404(Discount, pk=discount_id)
     sales_qs = Sale.objects.filter(order_number=order_number)
     if not sales_qs.exists():
         return JsonResponse({"ok": False, "error": "Order not found"}, status=404)
 
+    target_sales = sales_qs
+    if sale_id:
+        target_sales = sales_qs.filter(pk=sale_id)
+        if not target_sales.exists():
+            return JsonResponse(
+                {"ok": False, "error": "Sale item not found for this order"},
+                status=404,
+            )
+
     with transaction.atomic():
-        for sale in sales_qs:
+        for sale in target_sales:
             if should_select:
                 sale.discounts.add(discount)
             else:


### PR DESCRIPTION
### Motivation
- Enable removing a discount chip for a specific sale item (not the whole order) from the sales assign-referrers UI by exposing a small remove control on each sale-level discount chip.

### Description
- Add per-sale discount metadata to the chip payload by changing `_get_sale_discount_chips` to return `id`, `label`, and `color` for each sale discount.  (backend: `inventory/views.py`)
- Extend `assign_order_discount_reason` to accept an optional `sale_id` POST parameter and, when present, add/remove the discount only on that sale; fallback preserves existing order-wide behavior.  (backend: `inventory/views.py`)
- Render an inline remove button (`×`) inside each sale-discount chip and preserve chip color styling, and update client-side `renderDiscountChips` to include the remove control.  (template: `inventory/templates/inventory/sales_assign_referrers.html`)
- Add a click handler on the order block that sends `order_number + sale_id + discount_id` to the existing endpoint and refreshes sale-level discount cells from the AJAX response, and add CSS rules for the remove button.  (JS/CSS: `inventory/templates/inventory/sales_assign_referrers.html`, `inventory/static/styles.css`)
- Add tests verifying the remove control is rendered and that removing a discount can be targeted to a single sale item.  (`inventory/tests.py`)

### Testing
- `python -m py_compile inventory/views.py` succeeded (syntax check passed). 
- `python manage.py test inventory.tests.SalesAssignReferrersViewTests --verbosity 2` could not run in this environment because Django is not installed, so unit tests were not executed here (test attempt failed with ImportError).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e891913940832cb91501c9db37d689)