### PR TITLE
Fix anomalous zero sold values in upload_sales

### DIFF
--- a/scripts/upload_sales.py
+++ b/scripts/upload_sales.py
@@ -178,6 +178,8 @@ def upload_sales(test=False, diff=False):
                 sold_value     = float(row['实发金额'])   if not pd.isnull(row['实发金额'])   else 0.00
                 return_quantity= int(row['实退数量'])   if not pd.isnull(row['实退数量']) else 0
                 return_value   = float(row['退货金额'])   if not pd.isnull(row['退货金额'])   else 0.00
+                if sold_value == 0.0 and return_value != 0.0:
+                    sold_value = return_value
                 list_price = _to_decimal(_get_row_value(row, "基本售价"))
                 coupon_name_raw = _get_row_value(row, "优惠券名称")
                 seller_note = _get_row_value(row, "卖家备注")


### PR DESCRIPTION
### Motivation
- Some spreadsheet rows contain a data anomaly where `sold_value` is `0.00` but `return_value` is non-zero, so the sold amount should reflect the return amount in those cases.

### Description
- In `scripts/upload_sales.py` assign `sold_value = return_value` when `sold_value == 0.0` and `return_value != 0.0` immediately after parsing the row fields, leaving all other behavior unchanged.

### Testing
- Ran `python -m py_compile scripts/upload_sales.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b1aedc60832ca6857dde0f1e8e4a)