### PR TITLE
Resolve coupon name mappings and fix zero sold_value handling in upload_sales

### DIFF
--- a/scripts/upload_sales.py
+++ b/scripts/upload_sales.py
@@ -115,6 +115,22 @@ def _parse_coupon_codes(coupon_name_raw):
     return [code.strip() for code in normalized_raw.split(";") if code.strip()]
 
 
+def _resolve_discount_codes(coupon_name_raw):
+    parsed_codes = _parse_coupon_codes(coupon_name_raw)
+    resolved_codes = []
+
+    for code in parsed_codes:
+        resolved_codes.append(code)
+
+        if code.startswith("套装"):
+            resolved_codes.append("taozhuang")
+
+        if code.startswith("清仓"):
+            resolved_codes.append("clearance")
+
+    return resolved_codes
+
+
 def _parse_coupon_codes(coupon_name_raw):
     if coupon_name_raw is None:
         return []
@@ -178,6 +194,8 @@ def upload_sales(test=False, diff=False):
                 sold_value     = float(row['实发金额'])   if not pd.isnull(row['实发金额'])   else 0.00
                 return_quantity= int(row['实退数量'])   if not pd.isnull(row['实退数量']) else 0
                 return_value   = float(row['退货金额'])   if not pd.isnull(row['退货金额'])   else 0.00
+                if sold_value == 0.0 and return_value != 0.0:
+                    sold_value = return_value
                 list_price = _to_decimal(_get_row_value(row, "基本售价"))
                 coupon_name_raw = _get_row_value(row, "优惠券名称")
                 seller_note = _get_row_value(row, "卖家备注")
@@ -208,7 +226,7 @@ def upload_sales(test=False, diff=False):
                     )
                     matched_discounts = [
                         discount_by_code[code]
-                        for code in _parse_coupon_codes(coupon_name_raw)
+                        for code in dict.fromkeys(_resolve_discount_codes(coupon_name_raw))
                         if code in discount_by_code
                     ]
                     if matched_discounts:


### PR DESCRIPTION
### Motivation
- Ensure discount matching handles coupon name variants and prefix-based mappings, and make sure sales rows with zero `sold_value` but non-zero `return_value` are not treated as zero-value sales.

### Description
- Add `_resolve_discount_codes` to parse coupon names and map prefixes like `套装` to `taozhuang` and `清仓` to `clearance` while preserving original codes.
- Use `dict.fromkeys(_resolve_discount_codes(...))` when matching discounts so mapped and original codes are deduplicated and ordering is preserved.
- When `sold_value == 0.0` and `return_value != 0.0`, set `sold_value = return_value` before creating the `Sale` record.

### Testing
- Ran the project's test suite with `pytest` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b1aedc60832ca6857dde0f1e8e4a)