### PR TITLE
Merge products page KPI cards into two combined summaries

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -347,38 +347,15 @@
   <!-- CATEGORY STATISTICS SECTION -->
   <div class="row">
 
-    <!-- SALES SECTION -->
+    <!-- STOCK SUMMARY SECTION -->
     <div class="col s12 m4">
       <div class="card-panel">
-        <h4 class="teal-text text-darken-2" style="margin-top: 0;">{{ sales_last_year_total }}</h4>
-        <p class="grey-text text-darken-1" style="margin-bottom: 0;">Items sold in the last 12 months</p>
-        <div class="filter-divider"></div>
-        {% if sales_category_values %}
-          <canvas id="salesCategoryChart"></canvas>
-          <p class="grey-text text-darken-1" style="margin-bottom: 0;">{{ sales_category_description|default:"Sales split by product category" }}</p>
-        {% else %}
-          <p class="grey-text text-darken-1" style="margin: 0;">No sales data available.</p>
-        {% endif %}
-      </div>
+        <h4 class="teal-text text-darken-2" style="margin-top: 0; margin-bottom: 4px;">{{ filtered_inventory_total }}</h4>
+        <p class="grey-text text-darken-1" style="margin: 0;">Total in stock across all matching products</p>
 
-      <div class="card-panel">
-        <h4 class="teal-text text-darken-2" style="margin-top: 0;">¥{{ sales_last_year_value_total|floatformat:"0g" }}</h4>
-        <p class="grey-text text-darken-1" style="margin-bottom: 0;">Sales value in the last 12 months (RMB)</p>
-        <div class="filter-divider"></div>
-        {% if sales_value_category_values %}
-          <canvas id="salesValueChart"></canvas>
-          <p class="grey-text text-darken-1" style="margin-bottom: 0;">Sales value split by product category</p>
-        {% else %}
-          <p class="grey-text text-darken-1" style="margin: 0;">No sales value data available.</p>
-        {% endif %}
-      </div>
-    </div>
+        <h4 class="teal-text text-darken-2" style="margin-top: 20px; margin-bottom: 4px;">¥{{ inventory_value_total|floatformat:"0g" }}</h4>
+        <p class="grey-text text-darken-1" style="margin-bottom: 0;">Estimated value of stock (RMB)</p>
 
-    <!-- STOCK SECTION -->
-    <div class="col s12 m4">
-      <div class="card-panel">
-        <h4 class="teal-text text-darken-2" style="margin-top: 0;">{{ filtered_inventory_total }}</h4>
-        <p class="grey-text text-darken-1" style="margin-bottom: 0;">Total in stock across all matching products</p>
         <div class="filter-divider"></div>
         {% if category_breakdown_values %}
           <canvas id="categoryBreakdownChart"></canvas>
@@ -387,19 +364,25 @@
           <p class="grey-text text-darken-1" style="margin: 0;">No category data available.</p>
         {% endif %}
       </div>
+    </div>
 
+    <!-- SALES SUMMARY SECTION -->
+    <div class="col s12 m4">
       <div class="card-panel">
-        <h4 class="teal-text text-darken-2" style="margin-top: 0;">¥{{ inventory_value_total|floatformat:"0g" }}</h4>
-        <p class="grey-text text-darken-1" style="margin-bottom: 0;">Estimated value of stock (RMB)</p>
+        <h4 class="teal-text text-darken-2" style="margin-top: 0; margin-bottom: 4px;">¥{{ inventory_value_total|floatformat:"0g" }}</h4>
+        <p class="grey-text text-darken-1" style="margin: 0;">Estimated value of stock (RMB)</p>
+
+        <h4 class="teal-text text-darken-2" style="margin-top: 20px; margin-bottom: 4px;">¥{{ sales_last_year_value_total|floatformat:"0g" }}</h4>
+        <p class="grey-text text-darken-1" style="margin-bottom: 0;">Sales value in the last 12 months (RMB)</p>
+
         <div class="filter-divider"></div>
-        {% if inventory_value_category_values %}
-          <canvas id="inventoryValueChart"></canvas>
-          <p class="grey-text text-darken-1" style="margin-bottom: 0;">Inventory value split by product category</p>
+        {% if sales_category_values %}
+          <canvas id="salesCategoryChart"></canvas>
+          <p class="grey-text text-darken-1" style="margin-bottom: 0;">{{ sales_category_description|default:"Sales split by product category" }}</p>
         {% else %}
-          <p class="grey-text text-darken-1" style="margin: 0;">No value data available.</p>
+          <p class="grey-text text-darken-1" style="margin: 0;">No sales data available.</p>
         {% endif %}
       </div>
-
     </div>
 
     <!-- NOTES COLUMN -->


### PR DESCRIPTION
### Motivation
- Reduce visual clutter at the top of the filtered products page by combining closely related KPIs into two summary cards while keeping the existing `card-panel` visual style. 
- Group inventory counts/values and sales/value metrics so users can view complementary information and the relevant category pie chart together.

### Description
- Updated the template `inventory/templates/inventory/product_filtered_list.html` to merge the four small KPI card panels into two combined summary cards (stock summary and sales summary). 
- First summary now shows `filtered_inventory_total` and `inventory_value_total` together and retains the existing inventory units pie chart (`categoryBreakdownChart`).
- Second summary shows `inventory_value_total` and `sales_last_year_value_total` together and displays the existing sold-units-by-category pie chart (`salesCategoryChart`).
- No backend logic changes were made; this is a layout-only change that preserves existing classes and styles.

### Testing
- Attempted to run `python manage.py check` in this environment and it failed because Django is not installed (`ModuleNotFoundError: No module named 'django'`).
- Template changes were saved and committed (`git commit`), no other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec78fdf634832cb89a189a51084005)