### PR TITLE
Group size snapshot by Gi/Nogi families and widen layout

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -504,13 +504,13 @@
 
   <div class="row">
 
-    <div class="col s12 m4">
+    <div class="col s12 m8">
       <div class="card-panel" style="margin-top: 16px;">
         <h6 class="grey-text text-darken-1">Size Variant Stock Snapshot</h6>
         <table class="striped" style="font-size: 13px; margin-bottom: 0;">
           <thead>
             <tr>
-              <th>Size</th>
+              <th>Size group</th>
               <th>Status</th>
               <th>In stock</th>
               <th>Net sales (12 mo)</th>
@@ -520,7 +520,10 @@
           <tbody>
             {% for row in size_stock_rows %}
               <tr>
-                <td><strong>{{ row.label }}</strong></td>
+                <td>
+                  <strong>{{ row.label }}</strong><br>
+                  <span class="grey-text text-darken-1">{{ row.sizes }}</span>
+                </td>
                 <td>{{ row.status }}</td>
                 <td>{{ row.inventory }}</td>
                 <td>{{ row.sales }}</td>
@@ -540,12 +543,6 @@
         </p>
       </div>
     </div>
-
-    <div class="col s12 m4">
-
-    </div>
-
-
   </div>
 
   <div class="filter-divider"></div>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -2244,17 +2244,57 @@ def _render_filtered_products(
         for period in yearly_periods
     ]
 
-    size_keys = set(size_totals.keys()) | set(size_sales_totals.keys()) | set(
-        size_oos_counts.keys()
+    size_keys = (
+        set(size_totals.keys())
+        | set(size_sales_totals.keys())
+        | set(size_oos_counts.keys())
     )
-    ordered_size_keys = sorted(
-        size_keys, key=lambda code: SIZE_ORDER.get(code, 9999)
-    )
+
+    size_groups = [
+        {
+            "label": "Nogi (Adults)",
+            "sizes": ["XXS", "XS", "S", "M", "L", "XL", "XXL"],
+        },
+        {
+            "label": "Nogi (Kids)",
+            "sizes": ["KXS", "KS", "KM", "KL", "KXL"],
+        },
+        {
+            "label": "Gi (Men)",
+            "sizes": [
+                code
+                for code, _ in ProductVariant.SIZE_CHOICES
+                if code.startswith("A")
+            ],
+        },
+        {
+            "label": "Gi (Women)",
+            "sizes": [
+                code
+                for code, _ in ProductVariant.SIZE_CHOICES
+                if code.startswith("F")
+            ],
+        },
+        {
+            "label": "Gi (Kids)",
+            "sizes": [
+                code
+                for code, _ in ProductVariant.SIZE_CHOICES
+                if code.startswith("M")
+            ],
+        },
+    ]
+
     size_stock_rows = []
-    for size_code in ordered_size_keys:
-        inventory_qty = size_totals.get(size_code, 0)
-        sales_qty = size_sales_totals.get(size_code, 0)
-        oos_variants = size_oos_counts.get(size_code, 0)
+    for size_group in size_groups:
+        present_sizes = [code for code in size_group["sizes"] if code in size_keys]
+        if not present_sizes:
+            continue
+
+        inventory_qty = sum(size_totals.get(code, 0) for code in present_sizes)
+        sales_qty = sum(size_sales_totals.get(code, 0) for code in present_sizes)
+        oos_variants = sum(size_oos_counts.get(code, 0) for code in present_sizes)
+
         if sales_qty > 0:
             delta = (inventory_qty - sales_qty) / sales_qty * 100
             status = "Overstocked" if delta > 0 else "Understocked"
@@ -2268,7 +2308,8 @@ def _render_filtered_products(
 
         size_stock_rows.append(
             {
-                "label": size_label_map.get(size_code, size_code),
+                "label": size_group["label"],
+                "sizes": ", ".join(present_sizes),
                 "inventory": inventory_qty,
                 "sales": sales_qty,
                 "oos_variants": oos_variants,


### PR DESCRIPTION
### Motivation

- Surface size data in a more useful horizontal layout beneath the two summary charts and present sizes as meaningful families (Gi vs Nogi, adults vs kids) instead of one row per size code.
- Ensure filtered views (for example `Kids`) naturally show only the relevant grouped rows so the snapshot matches the filtered product set.

### Description

- Moved the `Size Variant Stock Snapshot` card from a `m4` column into a wider `m8` column so it displays horizontally under the two pie-chart summary cards (`inventory/templates/inventory/product_filtered_list.html`).
- Changed the table header to `Size group` and updated each row to show the group label plus the included size codes on a separate line in the same cell (`inventory/templates/inventory/product_filtered_list.html`).
- Reworked server-side aggregation in `inventory/views.py` to build `size_stock_rows` from five predefined groups: `Nogi (Adults)` (`XXS`–`XXL`), `Nogi (Kids)` (`KXS, KS, KM, KL, KXL`), `Gi (Men)` (`A*` codes), `Gi (Women)` (`F*` codes) and `Gi (Kids)` (`M*` codes), summing `inventory`, `sales` and `oos_variants` per group and computing the same status logic as before.
- Only groups that contain at least one size present in the current filtered result set are included, so category filters reduce the rows shown as expected.

### Testing

- Ran `python manage.py check`, which failed in this environment due to missing Django (`ModuleNotFoundError: No module named 'django'`).
- No additional automated test suite was executed in this environment because Django is not available to run checks or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7dad21d8832c8fb105bf89a12b99)