### PR TITLE
Group size-variant stock snapshot into size groups and add per-size breakdown

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -504,31 +504,56 @@
 
   <div class="row">
 
-    <div class="col s12 m4">
+    <div class="col s12 m8">
       <div class="card-panel" style="margin-top: 16px;">
         <h6 class="grey-text text-darken-1">Size Variant Stock Snapshot</h6>
         <table class="striped" style="font-size: 13px; margin-bottom: 0;">
           <thead>
             <tr>
-              <th>Size</th>
-              <th>Status</th>
-              <th>In stock</th>
-              <th>Net sales (12 mo)</th>
-              <th>OOS variants</th>
+              <th>Size group</th>
+              <th>Group totals</th>
+              <th>Per-size stock / sales / OOS variants</th>
             </tr>
           </thead>
           <tbody>
             {% for row in size_stock_rows %}
               <tr>
-                <td><strong>{{ row.label }}</strong></td>
-                <td>{{ row.status }}</td>
-                <td>{{ row.inventory }}</td>
-                <td>{{ row.sales }}</td>
-                <td>{{ row.oos_variants }}</td>
+                <td>
+                  <strong>{{ row.label }}</strong><br>
+                  <span class="grey-text text-darken-1">{{ row.sizes }}</span>
+                </td>
+                <td>
+                  <div><strong>Status:</strong> {{ row.status }}</div>
+                  <div><strong>In stock:</strong> {{ row.inventory }}</div>
+                  <div><strong>Net sales (12 mo):</strong> {{ row.sales }}</div>
+                  <div><strong>OOS variants:</strong> {{ row.oos_variants }}</div>
+                </td>
+                <td>
+                  <table style="margin: 0; width: 100%;">
+                    <thead>
+                      <tr>
+                        <th style="padding: 4px 6px;">Size</th>
+                        <th style="padding: 4px 6px;">In stock</th>
+                        <th style="padding: 4px 6px;">Net sales</th>
+                        <th style="padding: 4px 6px;">OOS</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for size_row in row.size_breakdown %}
+                        <tr>
+                          <td style="padding: 4px 6px;"><strong>{{ size_row.label }}</strong></td>
+                          <td style="padding: 4px 6px;">{{ size_row.inventory }}</td>
+                          <td style="padding: 4px 6px;">{{ size_row.sales }}</td>
+                          <td style="padding: 4px 6px;">{{ size_row.oos_variants }}</td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                </td>
               </tr>
             {% empty %}
               <tr>
-                <td colspan="5" class="grey-text text-darken-1">
+                <td colspan="3" class="grey-text text-darken-1">
                   No size data available.
                 </td>
               </tr>
@@ -540,12 +565,6 @@
         </p>
       </div>
     </div>
-
-    <div class="col s12 m4">
-
-    </div>
-
-
   </div>
 
   <div class="filter-divider"></div>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -2244,17 +2244,71 @@ def _render_filtered_products(
         for period in yearly_periods
     ]
 
-    size_keys = set(size_totals.keys()) | set(size_sales_totals.keys()) | set(
-        size_oos_counts.keys()
+    size_keys = (
+        set(size_totals.keys())
+        | set(size_sales_totals.keys())
+        | set(size_oos_counts.keys())
     )
-    ordered_size_keys = sorted(
-        size_keys, key=lambda code: SIZE_ORDER.get(code, 9999)
-    )
+
+    size_groups = [
+        {
+            "label": "Nogi (Adults)",
+            "sizes": ["XXS", "XS", "S", "M", "L", "XL", "XXL"],
+        },
+        {
+            "label": "Nogi (Kids)",
+            "sizes": ["KXS", "KS", "KM", "KL", "KXL"],
+        },
+        {
+            "label": "Gi (Men)",
+            "sizes": [
+                code
+                for code, _ in ProductVariant.SIZE_CHOICES
+                if code.startswith("A")
+            ],
+        },
+        {
+            "label": "Gi (Women)",
+            "sizes": [
+                code
+                for code, _ in ProductVariant.SIZE_CHOICES
+                if code.startswith("F")
+            ],
+        },
+        {
+            "label": "Gi (Kids)",
+            "sizes": [
+                code
+                for code, _ in ProductVariant.SIZE_CHOICES
+                if code.startswith("M")
+            ],
+        },
+    ]
+
     size_stock_rows = []
-    for size_code in ordered_size_keys:
-        inventory_qty = size_totals.get(size_code, 0)
-        sales_qty = size_sales_totals.get(size_code, 0)
-        oos_variants = size_oos_counts.get(size_code, 0)
+    for size_group in size_groups:
+        present_sizes = [code for code in size_group["sizes"] if code in size_keys]
+        if not present_sizes:
+            continue
+
+        inventory_qty = sum(size_totals.get(code, 0) for code in present_sizes)
+        sales_qty = sum(size_sales_totals.get(code, 0) for code in present_sizes)
+        oos_variants = sum(size_oos_counts.get(code, 0) for code in present_sizes)
+        size_breakdown = []
+        for size_code in present_sizes:
+            size_inventory_qty = size_totals.get(size_code, 0)
+            size_sales_qty = size_sales_totals.get(size_code, 0)
+            size_oos_variants = size_oos_counts.get(size_code, 0)
+            size_breakdown.append(
+                {
+                    "code": size_code,
+                    "label": size_label_map.get(size_code, size_code),
+                    "inventory": size_inventory_qty,
+                    "sales": size_sales_qty,
+                    "oos_variants": size_oos_variants,
+                }
+            )
+
         if sales_qty > 0:
             delta = (inventory_qty - sales_qty) / sales_qty * 100
             status = "Overstocked" if delta > 0 else "Understocked"
@@ -2268,7 +2322,9 @@ def _render_filtered_products(
 
         size_stock_rows.append(
             {
-                "label": size_label_map.get(size_code, size_code),
+                "label": size_group["label"],
+                "sizes": ", ".join(present_sizes),
+                "size_breakdown": size_breakdown,
                 "inventory": inventory_qty,
                 "sales": sales_qty,
                 "oos_variants": oos_variants,


### PR DESCRIPTION
### Motivation
- Improve the size-variant stock snapshot by aggregating sizes into logical groups (e.g. Nogi/Gi variants) so inventory and sales are easier to interpret.
- Provide a per-size breakdown within each group so users can inspect specific size-level inventory, sales and OOS counts.
- Adjust the UI layout to better accommodate the richer group and breakdown display.

### Description
- Updated the inventory list template: expanded the main card column from `m4` to `m8`, replaced the flat size table columns with three columns (`Size group`, `Group totals`, `Per-size stock / sales / OOS variants`) and added a nested table to render per-size rows and values.
- Removed an unused empty column in the template to reclaim layout space and adjusted the empty-state colspan accordingly.
- Refactored view logic in `inventory/views.py`: replaced the single-size iteration with `size_groups` definitions and aggregation logic that collects `present_sizes`, sums `inventory`, `sales`, and `oos_variants`, and builds a `size_breakdown` list of per-size metrics for each group.
- Kept status computation (overstock/understock/no-sales/out-of-stock) and now attach it to each group row; preserved label mapping via `size_label_map` and added `sizes` string for display.

### Testing
- Ran the inventory test suite with `./manage.py test inventory` and confirmed all tests passed.
- Rendered the `product_filtered_list` view in development to verify template output and the nested per-size table display rendered without errors and displayed expected aggregated values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7dad21d8832c8fb105bf89a12b99)