### PR TITLE
Update size stock snapshot thresholds, OOS counting, and tile layout

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -396,11 +396,26 @@
     }
 
     .size-tile__months {
+      font-weight: 600;
+      margin: 8px 0 8px;
+      font-size: 13px;
+      line-height: 1.3;
+      white-space: nowrap;
+      color: #4b5563;
+    }
+
+    .size-tile__headline {
       font-weight: 700;
       margin: 0 0 8px;
       font-size: 14px;
-      line-height: 1;
+      line-height: 1.2;
       white-space: nowrap;
+      color: #1f2937;
+    }
+
+    .size-tile__months-divider {
+      color: #9ca3af;
+      margin: 0 6px;
     }
 
     .size-tile__bar {
@@ -443,6 +458,18 @@
     .size-tile__meta-divider {
       color: #bdbdbd;
       margin: 0 6px;
+    }
+
+    .size-tile__meta-item--oos {
+      font-weight: 600;
+    }
+
+    .size-tile__meta-item--oos-some {
+      color: #ef6c00;
+    }
+
+    .size-tile__meta-item--oos-high {
+      color: #c62828;
     }
 
     .size-snapshot__footnote {
@@ -873,7 +900,7 @@
                 <h6 style="margin: 0 0 8px;">{{ row.label }}</h6>
                 <div>In stock: {{ row.inventory }}</div>
                 <div>Net sales (12 mo): {{ row.sales }}</div>
-                <div>OOS variants: {{ row.oos_variants }}</div>
+                <div>OOS variants: {{ row.oos_variants }} / {{ row.variant_count }}</div>
                 <span class="size-pill {% if 'Understocked' in row.status %}size-pill--under{% elif 'Overstocked' in row.status %}size-pill--over{% endif %}">
                   {{ row.status }}
                 </span>
@@ -881,25 +908,26 @@
               <div class="size-group__sizes">
                 {% for size_row in row.size_breakdown %}
                   <div class="size-tile">
-                    <p class="size-tile__months">
-                      {% if size_row.has_months_of_stock %}
-                        {{ size_row.months_of_stock|floatformat:1 }} mo
-                      {% else %}
-                        —
-                      {% endif %}
-                    </p>
+                    <p class="size-tile__headline">{{ size_row.inventory }} in stock | {{ size_row.sales }} sales</p>
                     <div class="size-tile__bar">
                       <div
                         class="size-tile__bar-fill"
                         style="width: {{ size_row.bar_percent|floatformat:0 }}%; background: {{ size_row.bar_color }};"
                       ></div>
                     </div>
+                    <p class="size-tile__months">
+                      {% if size_row.has_months_of_stock %}
+                        {{ size_row.months_of_stock|floatformat:1 }} mo stock
+                      {% else %}
+                        —
+                      {% endif %}
+                      <span class="size-tile__months-divider">·</span>
+                      {{ size_row.sales_speed_monthly|floatformat:1 }} / mo sales
+                    </p>
                     <div class="size-tile__meta">
-                      <span class="size-tile__meta-item">{{ size_row.inventory }} in stock</span>
-                      <span class="size-tile__meta-divider">|</span>
-                      <span class="size-tile__meta-item">{{ size_row.sales }} sales</span>
-                      <span class="size-tile__meta-divider">|</span>
-                      <span class="size-tile__meta-item">{{ size_row.oos_variants }} OOS</span>
+                      <span class="size-tile__meta-item size-tile__meta-item--oos {% if size_row.oos_level == 'some' %}size-tile__meta-item--oos-some{% elif size_row.oos_level == 'high' %}size-tile__meta-item--oos-high{% endif %}">
+                        {{ size_row.oos_variants }} OOS / {{ size_row.variant_count }} variants
+                      </span>
                     </div>
                   </div>
                 {% endfor %}

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1832,6 +1832,7 @@ def _render_filtered_products(
 
     size_totals: dict[str, int] = {}
     size_oos_counts: dict[str, int] = {}
+    size_variant_counts: dict[str, int] = {}
     size_label_map = dict(ProductVariant.SIZE_CHOICES)
     age_totals: dict[str, int] = {}
     style_totals: dict[str, int] = {}
@@ -1855,6 +1856,7 @@ def _render_filtered_products(
         for variant in getattr(product, "variants_with_inventory", []):
             if not variant.size:
                 continue
+            size_variant_counts[variant.size] = size_variant_counts.get(variant.size, 0) + 1
             inventory_count = getattr(variant, "latest_inventory", 0) or 0
             if inventory_count <= 0:
                 size_oos_counts[variant.size] = size_oos_counts.get(variant.size, 0) + 1
@@ -2248,7 +2250,15 @@ def _render_filtered_products(
         set(size_totals.keys())
         | set(size_sales_totals.keys())
         | set(size_oos_counts.keys())
+        | set(size_variant_counts.keys())
     )
+
+    def _interpolate_rgb(start: tuple[int, int, int], end: tuple[int, int, int], t: float) -> str:
+        t = max(0.0, min(1.0, t))
+        r = int(round(start[0] + ((end[0] - start[0]) * t)))
+        g = int(round(start[1] + ((end[1] - start[1]) * t)))
+        b = int(round(start[2] + ((end[2] - start[2]) * t)))
+        return f"rgb({r}, {g}, {b})"
 
     size_groups = [
         {
@@ -2297,28 +2307,38 @@ def _render_filtered_products(
         inventory_qty = sum(size_totals.get(code, 0) for code in present_sizes)
         sales_qty = sum(size_sales_totals.get(code, 0) for code in present_sizes)
         oos_variants = sum(size_oos_counts.get(code, 0) for code in present_sizes)
+        total_variants = sum(size_variant_counts.get(code, 0) for code in present_sizes)
         size_breakdown = []
         for size_code in present_sizes:
             size_inventory_qty = size_totals.get(size_code, 0)
             size_sales_qty = size_sales_totals.get(size_code, 0)
             size_oos_variants = size_oos_counts.get(size_code, 0)
+            size_total_variants = size_variant_counts.get(size_code, 0)
             months_of_stock = (
                 (size_inventory_qty / size_sales_qty) if size_sales_qty > 0 else None
             )
-            if months_of_stock is None:
+            if size_sales_qty <= 0:
                 bar_percent = 100 if size_inventory_qty > 0 else 0
-                bar_color = "#00897b" if size_inventory_qty > 0 else "#b0bec5"
+                bar_color = "#2e7d32" if size_inventory_qty > 0 else "#b0bec5"
             else:
-                capped_months = min(months_of_stock, 6)
-                bar_percent = (capped_months / 6) * 100
-                if months_of_stock < 1:
+                stock_vs_sales_ratio = size_inventory_qty / size_sales_qty
+                bar_percent = min(stock_vs_sales_ratio, 1) * 100
+                if stock_vs_sales_ratio >= 1:
+                    bar_color = "#2e7d32"
+                elif stock_vs_sales_ratio < 0.25:
                     bar_color = "#e53935"
-                elif months_of_stock < 3:
-                    bar_color = "#ffb300"
-                elif months_of_stock < 6:
-                    bar_color = "#8bc34a"
                 else:
-                    bar_color = "#00897b"
+                    bar_color = _interpolate_rgb((251, 140, 0), (46, 125, 50), (stock_vs_sales_ratio - 0.25) / 0.75)
+
+            oos_ratio = (
+                (size_oos_variants / size_total_variants) if size_total_variants > 0 else 0
+            )
+            if size_oos_variants <= 0:
+                oos_level = "none"
+            elif oos_ratio > 0.5:
+                oos_level = "high"
+            else:
+                oos_level = "some"
 
             size_breakdown.append(
                 {
@@ -2329,8 +2349,12 @@ def _render_filtered_products(
                     "oos_variants": size_oos_variants,
                     "has_months_of_stock": months_of_stock is not None,
                     "months_of_stock": months_of_stock,
+                    "sales_speed_monthly": (size_sales_qty / 12) if size_sales_qty > 0 else 0,
                     "bar_percent": bar_percent,
                     "bar_color": bar_color,
+                    "oos_ratio": oos_ratio,
+                    "oos_level": oos_level,
+                    "variant_count": size_total_variants,
                 }
             )
 
@@ -2353,6 +2377,7 @@ def _render_filtered_products(
                 "inventory": inventory_qty,
                 "sales": sales_qty,
                 "oos_variants": oos_variants,
+                "variant_count": total_variants,
                 "status": status_note,
             }
         )


### PR DESCRIPTION
### Motivation
- Make the "Stock position by size" tiles reflect stock vs last‑12‑month sales with color thresholds (green/gradient/orange/red) rather than the previous months‑of‑stock buckets.
- Move the displayed metrics so the stock vs sales value is the tile title and the sales speed is shown under the progress bar.
- Fix incorrect OOS counts by counting total variants per size from the same filtered dataset and highlight OOS severity (orange when any OOS, red when >50% OOS).

### Description
- Added `size_variant_counts` to collect total variants per size and used it to compute `oos_ratio` and `oos_level` in the size snapshot aggregation in `inventory/views.py`.
- Reworked bar logic in `inventory/views.py` to compute `stock_vs_sales_ratio` and `bar_percent`, using these thresholds: green when ratio >= 1, red when ratio < 0.25, and a gradient from orange→green for intermediate values, implemented via `_interpolate_rgb`.
- Added `sales_speed_monthly`, `oos_ratio`, `oos_level`, and `variant_count` to each `size_breakdown` entry returned to the template.
- Updated `inventory/templates/inventory/product_filtered_list.html` to show `stock vs sales` in the tile headline, move monthly sales speed beneath the bar, display `OOS / total variants` with CSS classes for `some` (orange) and `high` (red), and add minor CSS for the new layout and OOS colors.

### Testing
- Attempted `python manage.py check` in the environment, but it failed with `ModuleNotFoundError: No module named 'django'` so Django system checks could not be executed here.
- No automated unit tests were run in this environment due to missing Django; changes were limited to server view logic and template/CSS updates and committed for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca606e590832cbebc8bed9b826d2d)