### PR TITLE
Add Sales & Stock breakdown tree view to inventory snapshots

### DIFF
--- a/inventory/templates/inventory/inventory_snapshots.html
+++ b/inventory/templates/inventory/inventory_snapshots.html
@@ -167,6 +167,71 @@
       opacity: 1;
       cursor: pointer;
     }
+
+    .sales-breakdown-card {
+      border-radius: 12px;
+      overflow: hidden;
+    }
+
+    .sales-breakdown-title {
+      margin: 0 0 16px;
+      font-size: 1.45rem;
+      font-weight: 600;
+    }
+
+    .sales-breakdown-table {
+      border: 1px solid #e3e8ee;
+      border-radius: 12px;
+      overflow: hidden;
+      margin-bottom: 0;
+    }
+
+    .sales-breakdown-table thead th {
+      background: #f7f9fc;
+      font-weight: 600;
+      color: #2f3a4a;
+      border-bottom: 1px solid #e3e8ee;
+    }
+
+    .sales-breakdown-table td {
+      border-bottom: 1px solid #edf1f6;
+    }
+
+    .sales-tree-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding-left: calc(var(--indent-level, 0) * 26px);
+    }
+
+    .toggle-btn {
+      min-width: 24px;
+      height: 24px;
+      line-height: 24px;
+      padding: 0;
+      border: 1px solid #90a4ae;
+      border-radius: 999px;
+      color: #1976d2;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .toggle-icon {
+      font-size: 16px;
+      font-weight: 700;
+    }
+
+    .toggle-spacer {
+      display: inline-block;
+      width: 24px;
+      height: 24px;
+    }
+
+    .category-label {
+      font-weight: 500;
+      color: #253247;
+    }
   </style>
 
   <div class="filter-divider"></div>
@@ -224,6 +289,73 @@
     </div>
     <div class="filter-divider"></div>
   </form>
+
+  <div class="row">
+    <div class="col s12">
+      <div class="card z-depth-1 sales-breakdown-card">
+        <div class="card-content">
+          <h5 class="sales-breakdown-title">Sales and Stock Breakdown</h5>
+          <div class="table-responsive">
+            <table class="striped sales-breakdown-table">
+              <thead>
+                <tr>
+                  <th>Category</th>
+                  <th class="right-align">Sales value</th>
+                  <th class="right-align">Items sold</th>
+                  <th class="right-align">% of parent</th>
+                  <th class="right-align">In stock now</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in sales_hierarchy_rows %}
+                  <tr
+                    class="sales-tree-row"
+                    data-row-id="{{ row.id }}"
+                    {% if row.parent_id %}data-parent-id="{{ row.parent_id }}"{% endif %}
+                    {% if row.level > 1 %}hidden{% endif %}
+                  >
+                    <td>
+                      <div class="sales-tree-label" style="--indent-level: {{ row.level }};">
+                        {% if row.has_children %}
+                          <button
+                            type="button"
+                            class="toggle-btn btn-flat"
+                            data-toggle-id="{{ row.id }}"
+                            aria-expanded="{% if row.level == 0 %}true{% else %}false{% endif %}"
+                          >
+                            <span class="toggle-icon">{% if row.level == 0 %}−{% else %}+{% endif %}</span>
+                          </button>
+                        {% else %}
+                          <span class="toggle-spacer"></span>
+                        {% endif %}
+                        <span class="category-label">{{ row.label }}</span>
+                      </div>
+                    </td>
+                    <td class="right-align">£{{ row.sold_value|floatformat:2 }}</td>
+                    <td class="right-align">{{ row.sold_qty }}</td>
+                    <td class="right-align">
+                      {% if row.percent is not None %}
+                        {{ row.percent|floatformat:1 }}%
+                      {% else %}
+                        —
+                      {% endif %}
+                    </td>
+                    <td class="right-align">{{ row.stock_qty }}</td>
+                  </tr>
+                {% empty %}
+                  <tr>
+                    <td colspan="5" class="center-align grey-text text-darken-1">
+                      No inventory sales data available.
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}
 
@@ -521,6 +653,52 @@
           const allExpanded = filterControllers.every((c) => c.isExpanded());
           const newState = !allExpanded;
           setAllExpanded(newState);
+        });
+      });
+    });
+  })();
+</script>
+
+<script>
+  (function() {
+    const rows = Array.from(document.querySelectorAll('.sales-tree-row'));
+
+    function getChildren(rowId) {
+      return rows.filter((row) => row.dataset.parentId === rowId);
+    }
+
+    function setToggleState(toggleButton, expanded) {
+      toggleButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      const icon = toggleButton.querySelector('.toggle-icon');
+      if (icon) {
+        icon.textContent = expanded ? '−' : '+';
+      }
+    }
+
+    function collapseDescendants(rowId) {
+      getChildren(rowId).forEach((child) => {
+        child.hidden = true;
+        const childToggle = child.querySelector('.toggle-btn[data-toggle-id]');
+        if (childToggle) {
+          setToggleState(childToggle, false);
+        }
+        collapseDescendants(child.dataset.rowId);
+      });
+    }
+
+    document.querySelectorAll('.toggle-btn[data-toggle-id]').forEach((button) => {
+      button.addEventListener('click', function() {
+        const rowId = this.dataset.toggleId;
+        const currentlyExpanded = this.getAttribute('aria-expanded') === 'true';
+        const nextExpanded = !currentlyExpanded;
+
+        setToggleState(this, nextExpanded);
+
+        getChildren(rowId).forEach((child) => {
+          child.hidden = !nextExpanded;
+          if (!nextExpanded) {
+            collapseDescendants(child.dataset.rowId);
+          }
         });
       });
     });

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -6118,6 +6118,230 @@ def inventory_snapshots(request):
         sale_qs = sale_qs.filter(variant__product__type__in=selected_types)
         order_qs = order_qs.filter(product_variant__product__type__in=selected_types)
 
+    def _normalize_group_name(name: str) -> str:
+        return "".join(ch.lower() for ch in (name or "") if ch.isalnum())
+
+    def _resolve_tier(group_names: list[str]) -> Optional[str]:
+        normalized = {_normalize_group_name(name) for name in group_names}
+        if any("core" in name for name in normalized):
+            return "core"
+        if any("midrange" in name for name in normalized):
+            return "midrange"
+        if any("premium" in name for name in normalized):
+            return "premium"
+        return None
+
+    tier_labels = OrderedDict(
+        [
+            ("core", "Core"),
+            ("midrange", "Midrange"),
+            ("premium", "Premium"),
+        ]
+    )
+    style_labels = OrderedDict(PRODUCT_STYLE_CHOICES)
+    age_labels = OrderedDict(PRODUCT_AGE_CHOICES)
+
+    products_qs = Product.objects.prefetch_related("groups")
+    if selected_types:
+        products_qs = products_qs.filter(type__in=selected_types)
+    products = list(products_qs.only("id", "age", "style"))
+    product_meta = {}
+    for product in products:
+        if product.id in product_meta:
+            continue
+        product_meta[product.id] = {
+            "age": product.age or "",
+            "style": product.style or "",
+            "tier": _resolve_tier([group.name for group in product.groups.all()]),
+        }
+
+    product_ids = list(product_meta.keys())
+
+    sales_rows = (
+        sale_qs.values("variant__product_id")
+        .annotate(
+            sold_qty=Coalesce(Sum("sold_quantity"), Value(0)),
+            return_qty=Coalesce(Sum("return_quantity"), Value(0)),
+            sold_value=Coalesce(
+                Sum("sold_value"),
+                Value(Decimal("0.00")),
+                output_field=DecimalField(max_digits=12, decimal_places=2),
+            ),
+            return_value=Coalesce(
+                Sum("return_value"),
+                Value(Decimal("0.00")),
+                output_field=DecimalField(max_digits=12, decimal_places=2),
+            ),
+        )
+        .order_by()
+    )
+    sales_by_product = {
+        row["variant__product_id"]: {
+            "sold_qty": int(row["sold_qty"] or 0) - int(row["return_qty"] or 0),
+            "sold_value": (row["sold_value"] or Decimal("0"))
+            - (row["return_value"] or Decimal("0")),
+        }
+        for row in sales_rows
+    }
+
+    latest_snapshot = (
+        InventorySnapshot.objects.filter(
+            product_variant=OuterRef("pk"),
+            date__lte=today,
+        )
+        .order_by("-date")
+        .values("inventory_count")[:1]
+    )
+    stock_rows = (
+        ProductVariant.objects.filter(product_id__in=product_ids)
+        .annotate(
+            latest_inventory=Coalesce(
+                Subquery(latest_snapshot),
+                Value(0),
+                output_field=IntegerField(),
+            )
+        )
+        .values("product_id")
+        .annotate(stock_qty=Coalesce(Sum("latest_inventory"), Value(0)))
+        .order_by()
+    )
+    stock_by_product = {
+        row["product_id"]: int(row["stock_qty"] or 0)
+        for row in stock_rows
+    }
+
+    def _empty_metrics():
+        return {"sold_value": Decimal("0"), "sold_qty": 0, "stock_qty": 0}
+
+    tree = {
+        "all": _empty_metrics(),
+        "ages": {
+            age_code: {
+                **_empty_metrics(),
+                "styles": {
+                    style_code: {
+                        **_empty_metrics(),
+                        "tiers": {
+                            tier_code: _empty_metrics() for tier_code in tier_labels.keys()
+                        },
+                    }
+                    for style_code in style_labels.keys()
+                },
+            }
+            for age_code in age_labels.keys()
+        },
+    }
+
+    for product_id, meta in product_meta.items():
+        age_code = meta["age"]
+        style_code = meta["style"]
+        if age_code not in tree["ages"] or style_code not in style_labels:
+            continue
+
+        sales_metrics = sales_by_product.get(product_id, {})
+        sold_qty = max(int(sales_metrics.get("sold_qty", 0) or 0), 0)
+        sold_value = max(
+            sales_metrics.get("sold_value", Decimal("0")) or Decimal("0"),
+            Decimal("0"),
+        )
+        stock_qty = int(stock_by_product.get(product_id, 0) or 0)
+        tier_code = meta["tier"]
+
+        for node in (
+            tree["all"],
+            tree["ages"][age_code],
+            tree["ages"][age_code]["styles"][style_code],
+        ):
+            node["sold_qty"] += sold_qty
+            node["sold_value"] += sold_value
+            node["stock_qty"] += stock_qty
+
+        if tier_code in tier_labels:
+            tier_node = tree["ages"][age_code]["styles"][style_code]["tiers"][tier_code]
+            tier_node["sold_qty"] += sold_qty
+            tier_node["sold_value"] += sold_value
+            tier_node["stock_qty"] += stock_qty
+
+    def _as_percent(part, whole):
+        if not whole:
+            return 0
+        return round((part / whole) * 100, 1)
+
+    all_sold_qty = tree["all"]["sold_qty"]
+    hierarchy_rows = []
+
+    def _append_row(
+        *,
+        row_id,
+        parent_id,
+        level,
+        label,
+        metrics,
+        percent=None,
+        has_children=False,
+    ):
+        hierarchy_rows.append(
+            {
+                "id": row_id,
+                "parent_id": parent_id,
+                "level": level,
+                "label": label,
+                "sold_value": metrics["sold_value"],
+                "sold_qty": metrics["sold_qty"],
+                "stock_qty": metrics["stock_qty"],
+                "percent": percent,
+                "has_children": has_children,
+            }
+        )
+
+    _append_row(
+        row_id="all",
+        parent_id=None,
+        level=0,
+        label="All sales",
+        metrics=tree["all"],
+        percent=None,
+        has_children=True,
+    )
+
+    for age_code, age_label in age_labels.items():
+        age_row_id = f"age-{age_code}"
+        age_node = tree["ages"][age_code]
+        _append_row(
+            row_id=age_row_id,
+            parent_id="all",
+            level=1,
+            label=age_label,
+            metrics=age_node,
+            percent=_as_percent(age_node["sold_qty"], all_sold_qty),
+            has_children=True,
+        )
+
+        for style_code, style_label in style_labels.items():
+            style_row_id = f"{age_row_id}-style-{style_code}"
+            style_node = age_node["styles"][style_code]
+            _append_row(
+                row_id=style_row_id,
+                parent_id=age_row_id,
+                level=2,
+                label=style_label,
+                metrics=style_node,
+                percent=_as_percent(style_node["sold_qty"], age_node["sold_qty"]),
+                has_children=True,
+            )
+
+            for tier_code, tier_label in tier_labels.items():
+                tier_node = style_node["tiers"][tier_code]
+                _append_row(
+                    row_id=f"{style_row_id}-tier-{tier_code}",
+                    parent_id=style_row_id,
+                    level=3,
+                    label=tier_label,
+                    metrics=tier_node,
+                    percent=_as_percent(tier_node["sold_qty"], style_node["sold_qty"]),
+                    has_children=False,
+                )
+
     # ——— 1) Build actual_data from snapshots ————————————————————————
     snaps = (
         snap_qs.values("date").annotate(total=Sum("inventory_count")).order_by("date")
@@ -6193,6 +6417,7 @@ def inventory_snapshots(request):
             "actual_data": json.dumps(actual_data),
             "forecast_data": json.dumps(forecast_data),
             "sales_last_12_months": sales_last_12_months,
+            "sales_hierarchy_rows": hierarchy_rows,
         },
     )
 


### PR DESCRIPTION
### Motivation
- Provide a hierarchical breakdown of sales and current stock on the inventory snapshots page so users can inspect totals by age/style/tier slices. 
- Surface per-category metrics (sales value, items sold, % of parent, in-stock) in a compact, collapsible tree view to aid analysis. 
- Compute and present aggregated sales and stock metrics server-side to avoid expensive client-side computation and keep template rendering simple. 

### Description
- Added a new sales breakdown card in `inventory/templates/inventory/inventory_snapshots.html` including styles, a responsive table, and a collapsible tree UI with toggle buttons and percent display. 
- Implemented client-side expansion/collapse behavior in a new inline script that toggles rows using `data-row-id`/`data-parent-id` and manages `aria-expanded` and toggle icons. 
- Extended `inventory/views.py` to aggregate sales and stock per product, resolve product `tier` via product groups, and build a nested `tree` keyed by `age`, `style`, and `tier` with summed `sold_value`, `sold_qty`, and `stock_qty`. 
- Produced `hierarchy_rows` (flat list with `id`, `parent_id`, `level`, `label`, metrics, `percent`, and `has_children`) and passed it to the template as `sales_hierarchy_rows` for rendering. 

### Testing
- Ran the project's automated test suite with `pytest` and the Django app tests via `./manage.py test inventory`, and the suite completed successfully. 
- Verified that template renders without errors by exercising the `inventory_snapshots` view in development server and confirming `sales_hierarchy_rows` is present in the context. 
- Confirmed basic client-side toggle interactions by manually testing expand/collapse behavior in the browser (no JS errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfbdef620832c8ac9d7e3261f3217)