### PR TITLE
Add clearance-only option to products filter

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -681,6 +681,9 @@
                 {% else %}
                   <span class="chip__placeholder">Retired hidden</span>
                 {% endif %}
+                {% if clearance_only %}
+                  <span class="chip chip--selected">Clearance only</span>
+                {% endif %}
               </div>
             </div>
             <button type="button" class="btn-flat filter-card__toggle" aria-expanded="false" aria-controls="filter-options-static">
@@ -699,6 +702,18 @@
                 href="{% url 'product_filtered' %}?{% if request.GET.urlencode %}{{ request.GET.urlencode }}&{% endif %}show_retired=true"
               >
                 Show retired products
+              </a>
+            {% endif %}
+            {% if clearance_only %}
+              <p class="grey-text text-darken-1" style="margin: 8px 0 0;">
+                Showing only clearance products (discounted items).
+              </p>
+            {% else %}
+              <a
+                class="filter-option"
+                href="{% url 'product_filtered' %}?{% if request.GET.urlencode %}{{ request.GET.urlencode }}&{% endif %}clearance_only=true"
+              >
+                Show clearance products
               </a>
             {% endif %}
           </div>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1093,6 +1093,12 @@ def _build_product_list_context(request, preset_filters=None):
 
     zero_inventory = _get_filter("zero_inventory", "false")
     zero_inventory = zero_inventory if isinstance(zero_inventory, bool) else str(zero_inventory).lower() == "true"
+    clearance_only = _get_filter("clearance_only", "false")
+    clearance_only = (
+        clearance_only
+        if isinstance(clearance_only, bool)
+        else str(clearance_only).lower() == "true"
+    )
     search_query = request.GET.get("product_search", "").strip()
 
     # ─── Date ranges ────────────────────────────────────────────────────────────
@@ -1160,6 +1166,9 @@ def _build_product_list_context(request, preset_filters=None):
 
     if series_filters:
         products_qs = products_qs.filter(series__id__in=series_filters).distinct()
+
+    if clearance_only:
+        products_qs = products_qs.filter(discounted=True)
 
     if search_query:
         products_qs = products_qs.filter(
@@ -1565,6 +1574,7 @@ def _build_product_list_context(request, preset_filters=None):
         "group_filters": group_filters,
         "series_filters": series_filters,
         "zero_inventory": zero_inventory,
+        "clearance_only": clearance_only,
         "search_query": search_query,
         "type_choices": available_type_choices,
         "subtype_choices": available_subtype_choices,


### PR DESCRIPTION
### Motivation
- Provide an "Options" filter to show only clearance products (products marked with `discounted=True`) on the products page.

### Description
- Parse a `clearance_only` query flag in `_build_product_list_context` and normalize it to a boolean using the existing `_get_filter` helper.
- Apply the filter to the queryset with `products_qs = products_qs.filter(discounted=True)` when enabled.
- Pass `clearance_only` into the template context and update the Options card in `inventory/templates/inventory/product_filtered_list.html` to display a "Clearance only" chip, a `Show clearance products` action when inactive, and explanatory text when active.
- Changes touch `inventory/views.py` and `inventory/templates/inventory/product_filtered_list.html`.

### Testing
- Ran `python manage.py check`, which failed in this environment due to missing Django (`ModuleNotFoundError: No module named 'django'`).
- No further automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed258e2384832c96dd71af85a3bb86)