### PR TITLE
Add clearance toggle action to product scorecards

### DIFF
--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -132,6 +132,17 @@
                   </button>
                 </form>
 
+                <form method="post" action="{% url 'product_toggle_clearance' product.id %}" style="margin-top: 8px;">
+                  {% csrf_token %}
+                  {% if request.GET.urlencode %}
+                    <input type="hidden" name="redirect_querystring" value="{{ request.GET.urlencode }}">
+                  {% endif %}
+                  <input type="hidden" name="discounted" value="{% if product.discounted %}0{% else %}1{% endif %}">
+                  <button type="submit" class="btn-small {% if product.discounted %}green lighten-1{% else %}amber lighten-1{% endif %}">
+                    {% if product.discounted %}Undo clearance{% else %}Mark clearance{% endif %}
+                  </button>
+                </form>
+
                 {% if not product.decommissioned and product.total_inventory|default:0 > 0 %}
                   <form method="post" action="{% url 'product_decommission' product.id %}" style="margin-top: 6px;">
                     {% csrf_token %}

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -15,6 +15,11 @@ urlpatterns = [
         views.product_decommission,
         name='product_decommission',
     ),
+    path(
+        'products/<int:product_id>/toggle-clearance/',
+        views.product_toggle_clearance,
+        name='product_toggle_clearance',
+    ),
     path('products/type/<str:type_code>/', views.product_type_list, name='product_type_list'),
     path('products/style/<str:style_code>/', views.product_style_list, name='product_style_list'),
     path('products/group/<int:group_id>/', views.product_group_list, name='product_group_list'),

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -3202,6 +3202,26 @@ def product_toggle_no_restock(request, product_id: int):
     return redirect(redirect_url)
 
 
+@require_POST
+def product_toggle_clearance(request, product_id: int):
+    product = get_object_or_404(Product, pk=product_id)
+    explicit_state = request.POST.get("discounted")
+
+    if explicit_state is None:
+        product.discounted = not product.discounted
+    else:
+        product.discounted = explicit_state.lower() in {"1", "true", "yes", "on"}
+
+    product.save(update_fields=["discounted"])
+
+    redirect_querystring = request.POST.get("redirect_querystring", "").strip()
+    redirect_url = reverse("product_filtered")
+    if redirect_querystring:
+        redirect_url = f"{redirect_url}?{redirect_querystring}"
+
+    return redirect(redirect_url)
+
+
 def _redirect_to_product_filtered_with_query(redirect_querystring: str, **extra_params):
     redirect_url = reverse("product_filtered")
     query_items = []


### PR DESCRIPTION
### Motivation
- Provide a quick way on the Products listing to mark/unmark a product as clearance by toggling the underlying `Product.discounted` field, mirroring the other per-product actions (no-restock / decommission).

### Description
- Add a new POST route `products/<int:product_id>/toggle-clearance/` and name it `product_toggle_clearance` in `inventory/urls.py`.
- Implement `product_toggle_clearance` in `inventory/views.py` to toggle or explicitly set `Product.discounted` and then redirect back to the filtered products view while preserving `redirect_querystring` state.
- Add a clearance action control to the product scorecard UI in `inventory/templates/inventory/snippets/product_scorecard.html` that posts `discounted=1/0` and updates the button label and styling based on `product.discounted`.

### Testing
- Ran `python manage.py check` in this environment, which failed because Django is not installed here (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb1c71f00832c9fec07fec7c8ba69)