### PR TITLE
Add multi-step product creation modal; make restock_time and primary_color optional

### DIFF
--- a/inventory/migrations/0027_product_optional_fields_and_sizes.py
+++ b/inventory/migrations/0027_product_optional_fields_and_sizes.py
@@ -1,0 +1,69 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0026_referrer_discount_policy"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="product",
+            name="restock_time",
+            field=models.PositiveIntegerField(
+                blank=True,
+                help_text="Number of months required to restock this product.",
+                null=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="productvariant",
+            name="primary_color",
+            field=models.CharField(blank=True, max_length=7, null=True),
+        ),
+        migrations.AlterField(
+            model_name="productvariant",
+            name="size",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("XXS", "Extra-Extra-Small"),
+                    ("XS", "Extra-Small"),
+                    ("S", "Small"),
+                    ("M", "Medium"),
+                    ("L", "Large"),
+                    ("XL", "Extra Large"),
+                    ("XXL", "Extra-Extra Large"),
+                    ("A0", "A0"),
+                    ("A1", "A1"),
+                    ("A1L", "A1L"),
+                    ("A2", "A2"),
+                    ("A2L", "A2L"),
+                    ("A3", "A3"),
+                    ("A3L", "A3L"),
+                    ("A4", "A4"),
+                    ("A5", "A5"),
+                    ("F0", "F0"),
+                    ("F1", "F1"),
+                    ("F2", "F2"),
+                    ("F3", "F3"),
+                    ("F4", "F4"),
+                    ("M000", "M000"),
+                    ("M00", "M00"),
+                    ("M0", "M0"),
+                    ("M1", "M1"),
+                    ("M2", "M2"),
+                    ("M3", "M3"),
+                    ("M4", "M4"),
+                    ("KXS", "KXS"),
+                    ("KS", "KS"),
+                    ("KM", "KM"),
+                    ("KL", "KL"),
+                    ("KXL", "KXL"),
+                ],
+                max_length=4,
+                null=True,
+            ),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -192,7 +192,8 @@ class Product(models.Model):
         default=False, help_text="Check if this product is currently discounted."
     )
     restock_time = models.PositiveIntegerField(
-        default=0,
+        blank=True,
+        null=True,
         help_text="Number of months required to restock this product.",
     )
     no_restock = models.BooleanField(
@@ -261,6 +262,7 @@ class ProductVariant(models.Model):
         ("A3", "A3"),
         ("A3L", "A3L"),
         ("A4", "A4"),
+        ("A5", "A5"),
         ("F0", "F0"),
         ("F1", "F1"),
         ("F2", "F2"),
@@ -273,6 +275,11 @@ class ProductVariant(models.Model):
         ("M2", "M2"),
         ("M3", "M3"),
         ("M4", "M4"),
+        ("KXS", "KXS"),
+        ("KS", "KS"),
+        ("KM", "KM"),
+        ("KL", "KL"),
+        ("KXL", "KXL"),
     ]
 
     TYPE_CHOICES = PRODUCT_TYPE_CHOICES
@@ -284,7 +291,11 @@ class ProductVariant(models.Model):
         "Product", on_delete=models.CASCADE, related_name="variants"
     )
     variant_code = models.CharField(max_length=50, unique=True)  # Text/number code
-    primary_color = models.CharField(max_length=7)  # Hex code (e.g., #FFFFFF)
+    primary_color = models.CharField(
+        max_length=7,
+        blank=True,
+        null=True,
+    )  # Optional hex code (e.g., #FFFFFF)
     secondary_color = models.CharField(
         max_length=7, blank=True, null=True
     )  # Optional hex code

--- a/inventory/static/add-product-form.js
+++ b/inventory/static/add-product-form.js
@@ -1,0 +1,178 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const modalEl = document.getElementById('add-product-modal');
+  if (!modalEl) return;
+
+  M.Modal.init(modalEl);
+
+  const form = document.getElementById('add-product-form');
+  const steps = Array.from(form.querySelectorAll('.add-product-step'));
+  const stepLabel = form.querySelector('[data-step-label]');
+  const nextBtn = document.getElementById('add-product-next');
+  const backBtn = document.getElementById('add-product-back');
+  const saveBtn = document.getElementById('add-product-save');
+  const tempIdToggle = document.getElementById('use_temporary_id');
+  const productIdField = document.getElementById('product_id');
+  const styleField = document.getElementById('style');
+  const ageField = document.getElementById('age');
+  const addVariantsToggle = document.getElementById('add_variants_toggle');
+  const variantBuilder = document.getElementById('variant-builder');
+  const variantHint = document.getElementById('variant-hint');
+  const variantCheckboxes = document.getElementById('variant-checkboxes');
+  const variantInput = document.getElementById('custom_variant_input');
+  const addVariantBtn = document.getElementById('add_custom_variant_btn');
+  const variantsHiddenInput = document.getElementById('variant_sizes_input');
+  const summaryList = document.getElementById('add-product-summary');
+
+  let step = 1;
+
+  const selectElements = form.querySelectorAll('select');
+  M.FormSelect.init(selectElements);
+
+  const variantRecommendations = {
+    gi: {
+      adult: ['A0', 'A1', 'A1L', 'A2', 'A2L', 'A3', 'A3L', 'A4', 'A5', 'F1', 'F2', 'F3', 'F4'],
+      kids: ['M000', 'M00', 'M0', 'M1', 'M2', 'M3', 'M4'],
+    },
+    ng: {
+      adult: ['XS', 'S', 'M', 'L', 'XL', 'XXL'],
+      kids: ['KXS', 'KS', 'KM', 'KL', 'KXL'],
+    },
+    ap: {
+      default: ['XS', 'S', 'M', 'L', 'XL'],
+    },
+    ac: {
+      default: [],
+    },
+  };
+
+  const randomProductId = () => String(Math.floor(100000 + Math.random() * 900000));
+
+  const setStep = (nextStep) => {
+    step = Math.max(1, Math.min(3, nextStep));
+    steps.forEach((panel, index) => panel.classList.toggle('is-active', index === step - 1));
+    stepLabel.textContent = `Step ${step} of 3`;
+    backBtn.disabled = step === 1;
+    nextBtn.hidden = step === 3;
+    saveBtn.hidden = step !== 3;
+  };
+
+  const getSuggestedVariants = () => {
+    const style = styleField.value;
+    const age = ageField.value;
+    const styleMap = variantRecommendations[style] || {};
+    return styleMap[age] || styleMap.default || [];
+  };
+
+  const renderVariantChecklist = () => {
+    const suggestions = getSuggestedVariants();
+    variantCheckboxes.innerHTML = '';
+
+    if (styleField.value === 'ac') {
+      variantHint.textContent = 'Accessories have no standard size. You can leave variants empty or add custom labels.';
+    } else {
+      variantHint.textContent = suggestions.length
+        ? 'Suggested variants (uncheck any you do not want):'
+        : 'Choose category and age to get variant suggestions.';
+    }
+
+    suggestions.forEach((variant) => {
+      const label = document.createElement('label');
+      label.className = 'variant-checkbox';
+      label.innerHTML = `<input type="checkbox" class="filled-in" value="${variant}" checked><span>${variant}</span>`;
+      variantCheckboxes.appendChild(label);
+    });
+  };
+
+  const addCustomVariant = () => {
+    const value = (variantInput.value || '').trim();
+    if (!value) return;
+
+    const existing = Array.from(variantCheckboxes.querySelectorAll('input')).map((i) => i.value.toLowerCase());
+    if (existing.includes(value.toLowerCase())) {
+      variantInput.value = '';
+      return;
+    }
+
+    const label = document.createElement('label');
+    label.className = 'variant-checkbox';
+    label.innerHTML = `<input type="checkbox" class="filled-in" value="${value}" checked><span>${value}</span>`;
+    variantCheckboxes.appendChild(label);
+    variantInput.value = '';
+  };
+
+  const selectedVariants = () => Array.from(variantCheckboxes.querySelectorAll('input:checked')).map((item) => item.value);
+
+  const updateSummary = () => {
+    const fields = [
+      ['Name', form.product_name.value],
+      ['Product ID', form.product_id.value],
+      ['Category', styleField.options[styleField.selectedIndex]?.text || '—'],
+      ['Type', form.type.options[form.type.selectedIndex]?.text || '—'],
+      ['Subtype', form.subtype.options[form.subtype.selectedIndex]?.text || '—'],
+      ['Age', ageField.options[ageField.selectedIndex]?.text || '—'],
+      ['Restock time', form.restock_time.value ? `${form.restock_time.value} months` : 'Not set'],
+      ['Variants', addVariantsToggle.checked ? (selectedVariants().join(', ') || 'None selected') : 'Not added'],
+    ];
+
+    summaryList.innerHTML = fields
+      .map(([label, value]) => `<li class="collection-item"><strong>${label}:</strong> ${value || '—'}</li>`)
+      .join('');
+  };
+
+  tempIdToggle.addEventListener('change', function () {
+    if (tempIdToggle.checked) {
+      productIdField.value = randomProductId();
+      productIdField.readOnly = true;
+      M.updateTextFields();
+    } else {
+      productIdField.readOnly = false;
+      productIdField.value = '';
+      M.updateTextFields();
+    }
+  });
+
+  [styleField, ageField].forEach((field) => field.addEventListener('change', renderVariantChecklist));
+
+  addVariantsToggle.addEventListener('change', function () {
+    variantBuilder.hidden = !addVariantsToggle.checked;
+    if (addVariantsToggle.checked) renderVariantChecklist();
+  });
+
+  addVariantBtn.addEventListener('click', addCustomVariant);
+  variantInput.addEventListener('keydown', function (event) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      addCustomVariant();
+    }
+  });
+
+  backBtn.addEventListener('click', () => setStep(step - 1));
+
+  nextBtn.addEventListener('click', () => {
+    if (step === 1 && !form.product_name.value.trim()) {
+      M.toast({ html: 'Please add a product name.' });
+      return;
+    }
+
+    if (step === 1 && !tempIdToggle.checked && !form.product_id.value.trim()) {
+      M.toast({ html: 'Please add a product ID or choose temporary ID.' });
+      return;
+    }
+
+    if (step === 2) {
+      if (!styleField.value) {
+        M.toast({ html: 'Please choose a product category.' });
+        return;
+      }
+      updateSummary();
+    }
+
+    setStep(step + 1);
+  });
+
+  form.addEventListener('submit', function () {
+    variantsHiddenInput.value = addVariantsToggle.checked ? selectedVariants().join(',') : '';
+  });
+
+  setStep(1);
+});

--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -1956,3 +1956,53 @@ label.hide {
 @media (hover: hover) {
   .month-arrow:hover { color: #000; }
 }
+
+.products-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.add-product-modal {
+  max-width: 860px;
+}
+
+.add-product-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.add-product-step {
+  display: none;
+}
+
+.add-product-step.is-active {
+  display: block;
+}
+
+.add-product-modal__actions {
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.variant-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 18px;
+}
+
+.variant-checkbox {
+  min-width: 80px;
+}
+
+.add-product-custom-variant {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}

--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -599,7 +599,16 @@
   </style>
   {% if filter_controls %}
 
-  <h3 class="page-title">Products</h3>
+  <div class="products-page-header">
+    <h3 class="page-title">Products</h3>
+    <a class="btn add-product-trigger modal-trigger" href="#add-product-modal">Add Product</a>
+  </div>
+
+  {% if request.GET.add_product_success %}
+    <div class="card-panel green lighten-5 green-text text-darken-3">Product saved successfully.</div>
+  {% elif request.GET.add_product_error %}
+    <div class="card-panel red lighten-5 red-text text-darken-3">Could not save product. Please check the required fields and Product ID.</div>
+  {% endif %}
 
   <div class="filter-divider"></div>
 
@@ -1008,8 +1017,6 @@
 
   </div>
 
-  <div class="filter-divider"></div>
-
   <!-- END CATEGORY STATISTICS SECTION -->
 
   <!-- PRODUCT LIST SECTION -->
@@ -1019,11 +1026,13 @@
   <!-- END PRODUCT LIST SECTION -->
 
 </div>
+{% include 'inventory/snippets/add_product_modal.html' %}
 {% endblock %}
 
 {% block extrajs %}
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{% static 'no-restock-toggle.js' %}"></script>
+  <script src="{% static 'add-product-form.js' %}"></script>
   <script>
     (function() {
       const filterControllers = [];

--- a/inventory/templates/inventory/product_list.html
+++ b/inventory/templates/inventory/product_list.html
@@ -7,7 +7,16 @@
 {% block content %}
 <div class="section">
 
-  <h3 class="page-title">Products</h3>
+  <div class="products-page-header">
+    <h3 class="page-title">Products</h3>
+    <a class="btn add-product-trigger modal-trigger" href="#add-product-modal">Add Product</a>
+  </div>
+
+  {% if request.GET.add_product_success %}
+    <div class="card-panel green lighten-5 green-text text-darken-3">Product saved successfully.</div>
+  {% elif request.GET.add_product_error %}
+    <div class="card-panel red lighten-5 red-text text-darken-3">Could not save product. Please check the required fields and Product ID.</div>
+  {% endif %}
 
   <div id="controls" class="row grey lighten-3">
     <form id="productFilterForm" method="get">
@@ -90,10 +99,12 @@
 
   {% include 'inventory/snippets/product_card_default.html' %}
 </div>
+{% include 'inventory/snippets/add_product_modal.html' %}
 {% endblock %}
 
 {% block extrajs %}
 <script src="{% static 'no-restock-toggle.js' %}"></script>
+<script src="{% static 'add-product-form.js' %}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('select');

--- a/inventory/templates/inventory/snippets/add_product_modal.html
+++ b/inventory/templates/inventory/snippets/add_product_modal.html
@@ -1,0 +1,126 @@
+<div id="add-product-modal" class="modal add-product-modal">
+  <div class="modal-content">
+    <div class="add-product-modal__header">
+      <h4>Add Product</h4>
+      <span class="grey-text text-darken-1" data-step-label>Step 1 of 3</span>
+    </div>
+
+    <form id="add-product-form" method="post" action="{% url 'add_product' %}" enctype="multipart/form-data">
+      {% csrf_token %}
+      <input type="hidden" name="next" value="{{ request.get_full_path }}">
+      <input type="hidden" name="variant_sizes" id="variant_sizes_input">
+
+      <section data-step="1" class="add-product-step is-active">
+        <div class="input-field">
+          <input id="product_name" name="product_name" type="text" required>
+          <label for="product_name">Product name</label>
+        </div>
+
+        <div class="file-field input-field">
+          <div class="btn"><span>Image</span><input type="file" name="product_photo" accept="image/*"></div>
+          <div class="file-path-wrapper"><input class="file-path validate" type="text" placeholder="Upload product image"></div>
+        </div>
+
+        <p>
+          <label>
+            <input type="checkbox" class="filled-in" id="use_temporary_id" name="use_temporary_id" value="1">
+            <span>Use temporary Product ID (random)</span>
+          </label>
+        </p>
+
+        <div class="input-field">
+          <input id="product_id" name="product_id" type="text">
+          <label for="product_id">Product ID</label>
+        </div>
+      </section>
+
+      <section data-step="2" class="add-product-step">
+        <div class="row">
+          <div class="input-field col s12 m6">
+            <select id="style" name="style" required>
+              <option value="" selected disabled>Choose category</option>
+              {% for value, label in style_choices %}
+                <option value="{{ value }}">{{ label }}</option>
+              {% endfor %}
+            </select>
+            <label for="style">Category / Style</label>
+          </div>
+          <div class="input-field col s12 m6">
+            <select id="type" name="type">
+              <option value="" selected>Choose type</option>
+              {% for value, label in type_choices %}
+                <option value="{{ value }}">{{ label }}</option>
+              {% endfor %}
+            </select>
+            <label for="type">Type</label>
+          </div>
+          <div class="input-field col s12 m6">
+            <select id="subtype" name="subtype">
+              <option value="" selected>Choose subtype</option>
+              {% for value, label in subtype_choices %}
+                <option value="{{ value }}">{{ label }}</option>
+              {% endfor %}
+            </select>
+            <label for="subtype">Subtype</label>
+          </div>
+          <div class="input-field col s12 m6">
+            <select id="age" name="age">
+              <option value="" selected>Choose age</option>
+              {% for value, label in age_choices %}
+                <option value="{{ value }}">{{ label }}</option>
+              {% endfor %}
+            </select>
+            <label for="age">Age</label>
+          </div>
+          <div class="input-field col s12 m6">
+            <select id="groups" name="groups" multiple>
+              {% for group in group_choices %}
+                <option value="{{ group.id }}">{{ group.name }}</option>
+              {% endfor %}
+            </select>
+            <label for="groups">Groups</label>
+          </div>
+          <div class="input-field col s12 m6">
+            <select id="series" name="series" multiple>
+              {% for item in series_choices %}
+                <option value="{{ item.id }}">{{ item.name }}</option>
+              {% endfor %}
+            </select>
+            <label for="series">Series</label>
+          </div>
+          <div class="input-field col s12 m6">
+            <input id="restock_time" name="restock_time" type="number" min="0">
+            <label for="restock_time">Restock time (months, optional)</label>
+          </div>
+        </div>
+
+        <p>
+          <label>
+            <input type="checkbox" class="filled-in" id="add_variants_toggle">
+            <span>Add variants?</span>
+          </label>
+        </p>
+
+        <div id="variant-builder" class="add-product-variants" hidden>
+          <p class="grey-text text-darken-1" id="variant-hint"></p>
+          <div id="variant-checkboxes" class="variant-checkboxes"></div>
+          <div class="add-product-custom-variant">
+            <input type="text" id="custom_variant_input" placeholder="Add custom variant">
+            <button type="button" class="btn-flat" id="add_custom_variant_btn">+</button>
+          </div>
+        </div>
+      </section>
+
+      <section data-step="3" class="add-product-step">
+        <h6>Confirm product details</h6>
+        <ul class="collection" id="add-product-summary"></ul>
+      </section>
+
+      <div class="add-product-modal__actions">
+        <button type="button" class="btn-flat" id="add-product-back" disabled>Back</button>
+        <button type="button" class="btn" id="add-product-next">Continue</button>
+        <button type="submit" class="btn green" id="add-product-save" hidden>Save</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     path('', views.home, name='home'),
     path('products/', views.product_list, name='product_list'),
+    path('products/create/', views.add_product, name='add_product'),
     path('products/filtered/', views.product_filtered, name='product_filtered'),
     path(
         'products/<int:product_id>/toggle-no-restock/',

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -9,6 +9,7 @@ import statistics
 import math
 from urllib.parse import urlencode, parse_qsl
 import logging
+import random
 from io import BytesIO
 import os
 from pathlib import Path
@@ -1608,6 +1609,87 @@ def _build_product_list_context(request, preset_filters=None):
 
     return context
 
+
+
+
+def _generate_temporary_product_id() -> str:
+    while True:
+        generated = str(random.randint(100000, 999999))
+        if not Product.objects.filter(product_id=generated).exists():
+            return generated
+
+
+def _build_unique_variant_code(base_code: str) -> str:
+    candidate = base_code
+    counter = 2
+
+    while ProductVariant.objects.filter(variant_code=candidate).exists():
+        candidate = f"{base_code}-{counter}"
+        counter += 1
+
+    return candidate
+
+
+@require_POST
+def add_product(request):
+    next_url = request.POST.get("next") or reverse("product_filtered")
+
+    product_name = (request.POST.get("product_name") or "").strip()
+    submitted_product_id = (request.POST.get("product_id") or "").strip()
+    use_temporary_id = request.POST.get("use_temporary_id") in {"1", "true", "on", "yes"}
+
+    product_id = _generate_temporary_product_id() if use_temporary_id else submitted_product_id
+
+    if not product_name:
+        return redirect(f"{next_url}{'&' if '?' in next_url else '?'}add_product_error=missing_name")
+
+    if not product_id:
+        return redirect(f"{next_url}{'&' if '?' in next_url else '?'}add_product_error=missing_product_id")
+
+    if Product.objects.filter(product_id=product_id).exists():
+        return redirect(f"{next_url}{'&' if '?' in next_url else '?'}add_product_error=duplicate_product_id")
+
+    style = (request.POST.get("style") or "").strip() or None
+    type_code = (request.POST.get("type") or "").strip() or None
+    subtype = (request.POST.get("subtype") or "").strip() or None
+    age = (request.POST.get("age") or "").strip() or None
+
+    restock_raw = (request.POST.get("restock_time") or "").strip()
+    restock_time = int(restock_raw) if restock_raw.isdigit() else None
+
+    variant_sizes_raw = (request.POST.get("variant_sizes") or "").strip()
+    variant_sizes = [size.strip() for size in variant_sizes_raw.split(",") if size.strip()]
+
+    with transaction.atomic():
+        product = Product.objects.create(
+            product_id=product_id,
+            product_name=product_name,
+            product_photo=request.FILES.get("product_photo"),
+            style=style,
+            type=type_code,
+            subtype=subtype,
+            age=age,
+            restock_time=restock_time,
+        )
+
+        group_ids = request.POST.getlist("groups")
+        if group_ids:
+            product.groups.set(Group.objects.filter(id__in=group_ids))
+
+        series_ids = request.POST.getlist("series")
+        if series_ids:
+            product.series.set(Series.objects.filter(id__in=series_ids))
+
+        for index, size in enumerate(variant_sizes, start=1):
+            base_code = f"{product_id}-{size}" if size else f"{product_id}-VAR{index}"
+            ProductVariant.objects.create(
+                product=product,
+                variant_code=_build_unique_variant_code(base_code),
+                size=size if size.lower() != "no size" else None,
+                primary_color=None,
+            )
+
+    return redirect(f"{next_url}{'&' if '?' in next_url else '?'}add_product_success=1")
 
 def product_list(request):
     context = _build_product_list_context(request)


### PR DESCRIPTION
### Motivation
- Provide a usable UI to create products from the Products page via a focused multi-step modal workflow. 
- Let users optionally assign a temporary random `product_id` and optionally add suggested or custom variants during creation. 
- Make `restock_time` and `primary_color` optional to match more flexible product/variant data. 

### Description
- Added a 3-step floating modal form and assets: template `inventory/templates/inventory/snippets/add_product_modal.html`, frontend logic `inventory/static/add-product-form.js`, and styles in `inventory/static/styles.css` to show an `Add Product` CTA in the products header and drive the multi-step flow. 
- Implemented client-side variant recommendations (by `style` + `age`), checkbox selection, custom variant addition, temporary random Product ID generation, and a confirmation summary before submit. 
- Added server-side endpoint `add_product` and helpers (`_generate_temporary_product_id`, `_build_unique_variant_code`) in `inventory/views.py`, and routed it at `path('products/create/', views.add_product, name='add_product')` to create the `Product` and optional `ProductVariant` records transactionally. 
- Updated the models in `inventory/models.py` to make `Product.restock_time` optional (`blank=True, null=True`), make `ProductVariant.primary_color` optional (`blank=True, null=True`), and extended `ProductVariant.SIZE_CHOICES` with the requested sizes; added migration `inventory/migrations/0027_product_optional_fields_and_sizes.py`. 

### Testing
- Ran `python -m py_compile inventory/views.py inventory/models.py` which completed successfully. 
- Ran `python -m py_compile inventory/migrations/0027_product_optional_fields_and_sizes.py` which completed successfully. 
- Attempted `python manage.py makemigrations inventory` but it could not be executed in this environment because Django is not installed, so migration generation checks could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef58f4e444832c84de41cb52c720e5)