### PR TITLE
Add reusable global button styles with primary variant

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -14,6 +14,88 @@ main {
     flex: 1 0 auto;
   }
 
+:root {
+  --button-height: 44px;
+  --button-padding-x: 22px;
+  --button-radius: 20px;
+  --button-border: #d7d7db;
+  --button-bg: #f3f3f4;
+  --button-text: #1a1a1a;
+  --button-primary-bg: #2f6df6;
+  --button-primary-bg-hover: #235ee4;
+  --button-primary-border: #2259d9;
+  --button-primary-text: #ffffff;
+}
+
+/* Reusable global button system */
+.btn,
+.btn-small,
+.btn-large {
+  align-items: center;
+  background: var(--button-bg) !important;
+  border: 1px solid var(--button-border) !important;
+  border-radius: var(--button-radius);
+  box-shadow: 0 1px 2px rgba(18, 18, 23, 0.08);
+  color: var(--button-text) !important;
+  display: inline-flex;
+  font-size: 1rem;
+  font-weight: 600;
+  gap: 8px;
+  height: var(--button-height);
+  justify-content: center;
+  line-height: 1;
+  padding: 0 var(--button-padding-x);
+  text-transform: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, transform 0.05s ease;
+}
+
+.btn:hover,
+.btn-small:hover,
+.btn-large:hover {
+  background: #ececef !important;
+  box-shadow: 0 2px 6px rgba(18, 18, 23, 0.12);
+}
+
+.btn:focus,
+.btn-small:focus,
+.btn-large:focus {
+  background: #ececef !important;
+}
+
+.btn:active,
+.btn-small:active,
+.btn-large:active {
+  transform: translateY(1px);
+}
+
+.btn.btn-primary,
+.btn-small.btn-primary,
+.btn-large.btn-primary {
+  background: var(--button-primary-bg) !important;
+  border-color: var(--button-primary-border) !important;
+  color: var(--button-primary-text) !important;
+}
+
+.btn.btn-primary:hover,
+.btn-small.btn-primary:hover,
+.btn-large.btn-primary:hover,
+.btn.btn-primary:focus,
+.btn-small.btn-primary:focus,
+.btn-large.btn-primary:focus {
+  background: var(--button-primary-bg-hover) !important;
+}
+
+.btn.disabled,
+.btn-small.disabled,
+.btn-large.disabled,
+.btn:disabled,
+.btn-small:disabled,
+.btn-large:disabled {
+  box-shadow: none;
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 /* Global card styling overrides */
 .card,
 .card-panel {

--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -601,7 +601,7 @@
 
   <div class="products-page-header">
     <h3 class="page-title">Products</h3>
-    <a class="btn add-product-trigger modal-trigger" href="#add-product-modal">Add Product</a>
+    <a class="btn btn-primary add-product-trigger modal-trigger" href="#add-product-modal">Add Product</a>
   </div>
 
   {% if request.GET.add_product_success %}

--- a/inventory/templates/inventory/product_list.html
+++ b/inventory/templates/inventory/product_list.html
@@ -9,7 +9,7 @@
 
   <div class="products-page-header">
     <h3 class="page-title">Products</h3>
-    <a class="btn add-product-trigger modal-trigger" href="#add-product-modal">Add Product</a>
+    <a class="btn btn-primary add-product-trigger modal-trigger" href="#add-product-modal">Add Product</a>
   </div>
 
   {% if request.GET.add_product_success %}

--- a/inventory/templates/inventory/sales_assign_referrers.html
+++ b/inventory/templates/inventory/sales_assign_referrers.html
@@ -297,7 +297,7 @@
                 </p>
               </div>
               <div class="modal-footer">
-                <button type="submit" class="btn waves-effect waves-light">Save</button>
+                <button type="submit" class="btn btn-primary waves-effect waves-light">Save</button>
                 <a href="#!" class="modal-close btn-flat">Cancel</a>
               </div>
             </form>

--- a/inventory/templates/inventory/sales_bucket_detail.html
+++ b/inventory/templates/inventory/sales_bucket_detail.html
@@ -212,7 +212,7 @@
               <div class="modal-footer">
                 <button
                   type="submit"
-                  class="btn waves-effect waves-light"
+                  class="btn btn-primary waves-effect waves-light"
                 >
                   Save
                 </button>

--- a/inventory/templates/inventory/sales_referrers.html
+++ b/inventory/templates/inventory/sales_referrers.html
@@ -86,7 +86,7 @@
           </div>
           <div class="card-panel filter-card filter-card--compact filter-card--actions">
             <div class="filter-toolbar__actions">
-              <button type="submit" class="btn-small waves-effect waves-light">
+              <button type="submit" class="btn-small btn-primary waves-effect waves-light">
                 Update
               </button>
             </div>

--- a/inventory/templates/inventory/snippets/add_product_modal.html
+++ b/inventory/templates/inventory/snippets/add_product_modal.html
@@ -128,8 +128,8 @@
 
       <div class="add-product-modal__actions">
         <button type="button" class="btn-flat" id="add-product-back" disabled>Back</button>
-        <button type="button" class="btn" id="add-product-next">Continue</button>
-        <button type="submit" class="btn green" id="add-product-save" hidden>Save</button>
+        <button type="button" class="btn btn-primary" id="add-product-next">Continue</button>
+        <button type="submit" class="btn btn-primary" id="add-product-save" hidden>Save</button>
       </div>
     </form>
   </div>

--- a/inventory/templates/inventory/snippets/product_card.html
+++ b/inventory/templates/inventory/snippets/product_card.html
@@ -36,7 +36,7 @@
                 <div style="margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px;">
                   <button
                     type="button"
-                    class="btn teal lighten-1"
+                    class="btn btn-primary"
                     data-open-order-modal="order-modal-{{ product.id }}"
                     data-order-mode="create"
                   >
@@ -45,7 +45,7 @@
                   {% if product.pending_order %}
                     <button
                       type="button"
-                      class="btn blue-grey lighten-1"
+                      class="btn"
                       data-open-order-modal="order-modal-{{ product.id }}"
                       data-order-mode="pending"
                     >
@@ -92,7 +92,7 @@
                   {% if not product.no_restock %}
                     <button
                       type="button"
-                      class="btn teal lighten-1"
+                      class="btn btn-primary"
                       data-open-order-modal="order-modal-{{ product.id }}"
                       data-order-mode="create"
                     >
@@ -102,7 +102,7 @@
                   {% if product.pending_order %}
                     <button
                       type="button"
-                      class="btn blue-grey lighten-1"
+                      class="btn"
                       data-open-order-modal="order-modal-{{ product.id }}"
                       data-order-mode="pending"
                     >
@@ -234,7 +234,7 @@
             </tbody>
           </table>
           <div style="margin-top: 16px; text-align: right;">
-            <button type="submit" class="btn teal lighten-1">Save order</button>
+            <button type="submit" class="btn btn-primary">Save order</button>
           </div>
         </div>
         </form>


### PR DESCRIPTION
### Motivation
- Create a simple, reusable button system so controls across the site share a consistent rounded grey default and an emphasized blue primary state.
- Expose a small set of CSS tokens so the button look can be tuned globally and reused for `.btn`, `.btn-small`, and `.btn-large`.

### Description
- Added CSS design tokens and a global button system to `inventory/static/styles.css`, including variables in `:root` and base rules for `.btn`, `.btn-small`, and `.btn-large`.
- Implemented a `.btn-primary` modifier with dedicated background, border, hover and focus states for important actions and a disabled style for all button sizes.
- Updated templates to use the new primary modifier for key CTAs: `inventory/templates/inventory/product_filtered_list.html`, `inventory/templates/inventory/product_list.html`, `inventory/templates/inventory/snippets/add_product_modal.html`, `inventory/templates/inventory/snippets/product_card.html`, `inventory/templates/inventory/sales_assign_referrers.html`, `inventory/templates/inventory/sales_bucket_detail.html`, and `inventory/templates/inventory/sales_referrers.html`.
- Preserved non-primary/secondary actions by leaving other `.btn` or `.btn-flat` usages intact so the neutral style remains the default.

### Testing
- Ran `python manage.py check` which could not complete in this environment because Django is not installed, so project checks were not executed successfully.
- No automated browser or visual regression tests were available in this runtime; style changes were limited to CSS and template class updates and should be verified in a local/dev server or staging environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef869a1864832ca7228138a87fb7ba)