### PR TITLE
Add replenishment insights card to Products filtered view

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -775,7 +775,35 @@
       </div>
     </div>
 
-    <div class="col s12 m8">
+    <div class="col s12 m4">
+      <div class="card-panel">
+        <h4 class="teal-text text-darken-2" style="margin-top: 0; margin-bottom: 4px;">
+          {{ replenishment_low }}-{{ replenishment_high }}
+        </h4>
+        <p class="grey-text text-darken-1" style="margin: 0;">Estimated replenishment order (items)</p>
+
+        <div class="filter-divider"></div>
+        <ul class="collection" style="margin: 0;">
+          <li class="collection-item" style="border-left: 3px solid #26a69a;">
+            <strong>Stock position</strong>
+            <span class="secondary-content {% if is_understocked %}red-text text-darken-1{% else %}teal-text text-darken-2{% endif %}">
+              {% if is_understocked %}Understocked{% else %}Overstocked{% endif %}
+              {{ stock_delta_percent_abs|floatformat:1 }}%
+            </span>
+          </li>
+          <li class="collection-item" style="border-left: 3px solid #26a69a;">
+            <strong>Clearance in category</strong>
+            <span class="secondary-content teal-text text-darken-2">{{ discounted_products }} products / {{ discounted_items }} items</span>
+          </li>
+          <li class="collection-item" style="border-left: 3px solid #26a69a;">
+            <strong>On market over 6 months</strong>
+            <span class="secondary-content teal-text text-darken-2">{{ mature_products_over_six_months }} products</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="col s12 m12">
       <div class="profitability-summary">
         <p class="profitability-summary__row">
           <span>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1897,6 +1897,12 @@ def _render_filtered_products(
     product_ids = [product.id for product in products]
     total_products = len(products)
     discounted_products = sum(1 for product in products if product.discounted)
+    discounted_items = sum(
+        (getattr(variant, "latest_inventory", 0) or 0)
+        for product in products
+        if product.discounted
+        for variant in getattr(product, "variants_with_inventory", [])
+    )
     partial_oos_products = 0
     for product in products:
         variants = getattr(product, "variants_with_inventory", [])
@@ -2449,6 +2455,43 @@ def _render_filtered_products(
         {"label": period["label"], "total": period["total"]}
         for period in yearly_periods
     ]
+
+    stock_delta_quantity = filtered_inventory_total - last_year_sales_total
+    stock_delta_percent = (
+        (stock_delta_quantity / last_year_sales_total) * 100
+        if last_year_sales_total > 0
+        else Decimal("0")
+    )
+    stock_delta_percent_abs = abs(stock_delta_percent)
+    is_understocked = stock_delta_quantity < 0
+
+    base_replenishment_low = int(round(last_year_sales_total * Decimal("0.30")))
+    base_replenishment_high = int(round(last_year_sales_total * Decimal("0.45")))
+    stock_gap_adjustment = abs(stock_delta_quantity)
+    if is_understocked:
+        replenishment_low = base_replenishment_low + stock_gap_adjustment
+        replenishment_high = base_replenishment_high + stock_gap_adjustment
+    else:
+        replenishment_low = max(0, base_replenishment_low - stock_gap_adjustment)
+        replenishment_high = max(0, base_replenishment_high - stock_gap_adjustment)
+
+    six_months_ago = today - relativedelta(months=6)
+    mature_product_ids = set()
+    if product_ids:
+        mature_from_arrivals = set(
+            OrderItem.objects.filter(
+                product_variant__product_id__in=product_ids,
+                date_arrived__isnull=False,
+                date_arrived__lte=six_months_ago,
+            ).values_list("product_variant__product_id", flat=True)
+        )
+        mature_from_sales = set(
+            Sale.objects.filter(
+                variant__product_id__in=product_ids,
+                date__lte=six_months_ago,
+            ).values_list("variant__product_id", flat=True)
+        )
+        mature_product_ids = mature_from_arrivals | mature_from_sales
 
     size_keys = (
         set(size_totals.keys())
@@ -3058,6 +3101,13 @@ def _render_filtered_products(
             "stock_balance_groups": stock_balance_groups,
             "stock_age_breakdown": stock_age_breakdown,
             "profitability_summary": profitability_summary,
+            "replenishment_low": replenishment_low,
+            "replenishment_high": replenishment_high,
+            "stock_delta_percent": stock_delta_percent,
+            "stock_delta_percent_abs": stock_delta_percent_abs,
+            "is_understocked": is_understocked,
+            "discounted_items": discounted_items,
+            "mature_products_over_six_months": len(mature_product_ids),
             "has_quarterly_data": bool(variant_ids),
             "filter_controls": filter_controls,
             "showing_summary": " | ".join(selected_labels_flat)


### PR DESCRIPTION
### Motivation
- Provide a quick replenishment estimate alongside existing "Items sold last year" and "Items in stock" summaries to help planners maintain target stock levels (aim: ~6–12 months).
- Surface supporting signals (under/overstock percentage, clearance counts, and mature products) so buyers can make informed ordering decisions.

### Description
- Compute replenishment range and stock signals in `_render_filtered_products` using last-12-month sales as the baseline and adjusting by the current stock gap, and expose these values to the template via new context keys (`replenishment_low`, `replenishment_high`, `stock_delta_percent`, `stock_delta_percent_abs`, `is_understocked`, `discounted_items`, `mature_products_over_six_months`).
- Determine clearance item count by summing inventory units for products marked `discounted`, and determine "on market over 6 months" products by checking order arrival dates and sale dates relative to a six-month cutoff.
- Add a new third top summary card to `inventory/templates/inventory/product_filtered_list.html` that displays the replenishment range and the three supporting metrics beneath it, and adjust the layout so the profitability summary spans full width below the three cards.
- Files changed: `inventory/views.py` (calculation and context additions) and `inventory/templates/inventory/product_filtered_list.html` (UI/markup for the new card and layout tweak).

### Testing
- Ran `python manage.py check` in the container and it failed due to the environment missing Django (`ModuleNotFoundError: No module named 'django'`), so framework checks could not complete.
- Performed repository checks (`git status` / `git commit`) locally in the workspace and committed the changes (no runtime tests executed due to missing Django).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef906b0b18832cbddcff1e551fe009)