### PR TITLE
Add replenishment & stock summary panel to filtered products view

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -775,7 +775,43 @@
       </div>
     </div>
 
-    <div class="col s12 m8">
+    <div class="col s12 m4">
+      <div class="card-panel">
+        <h4 class="teal-text text-darken-2" style="margin-top: 0; margin-bottom: 4px;">
+          {{ replenishment_low }}-{{ replenishment_high }}
+        </h4>
+        <p class="grey-text text-darken-1" style="margin: 0;">Estimated replenishment order (items)</p>
+
+        <div class="filter-divider"></div>
+        <ul class="collection" style="margin: 0;">
+          <li class="collection-item" style="border-left: 3px solid #26a69a;">
+            <strong>Stock position</strong>
+            <span class="secondary-content {% if is_understocked %}red-text text-darken-1{% else %}teal-text text-darken-2{% endif %}">
+              {% if is_understocked %}Understocked{% else %}Overstocked{% endif %}
+              {{ stock_delta_percent_abs|floatformat:1 }}%
+            </span>
+          </li>
+          <li class="collection-item" style="border-left: 3px solid #26a69a;">
+            <strong>Clearance in category</strong>
+            <span class="secondary-content teal-text text-darken-2">{{ discounted_products }} products / {{ discounted_items }} items</span>
+          </li>
+          <li class="collection-item" style="border-left: 3px solid #26a69a;">
+            <strong>On market over 6 months</strong>
+            <span class="secondary-content teal-text text-darken-2">{{ mature_products_over_six_months }} products</span>
+          </li>
+          <li class="collection-item" style="border-left: 3px solid #26a69a;">
+            <strong>Already in order</strong>
+            <span class="secondary-content teal-text text-darken-2">{{ items_in_order }} items</span>
+          </li>
+          <li class="collection-item" style="border-left: 3px solid #26a69a;">
+            <strong>In the pipeline</strong>
+            <span class="secondary-content teal-text text-darken-2">{{ pipeline_products }} products</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="col s12 m12">
       <div class="profitability-summary">
         <p class="profitability-summary__row">
           <span>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1897,6 +1897,12 @@ def _render_filtered_products(
     product_ids = [product.id for product in products]
     total_products = len(products)
     discounted_products = sum(1 for product in products if product.discounted)
+    discounted_items = sum(
+        (getattr(variant, "latest_inventory", 0) or 0)
+        for product in products
+        if product.discounted
+        for variant in getattr(product, "variants_with_inventory", [])
+    )
     partial_oos_products = 0
     for product in products:
         variants = getattr(product, "variants_with_inventory", [])
@@ -1930,6 +1936,23 @@ def _render_filtered_products(
         if product.id not in sales_product_ids
         and product.id not in order_product_ids
     )
+    pipeline_products = sum(
+        1
+        for product in products
+        if product.id not in sales_product_ids
+        and product.id not in order_product_ids
+        and not product.discounted
+        and not product.decommissioned
+    )
+    items_in_order = 0
+    if variant_ids:
+        items_in_order = (
+            OrderItem.objects.filter(
+                product_variant_id__in=variant_ids,
+                date_arrived__isnull=True,
+            ).aggregate(total_qty=Sum("quantity")).get("total_qty")
+            or 0
+        )
 
     group_choices = list(context.get("group_choices") or Group.objects.all())
     group_label_map = {group.id: group.name or "Unspecified" for group in group_choices}
@@ -2449,6 +2472,43 @@ def _render_filtered_products(
         {"label": period["label"], "total": period["total"]}
         for period in yearly_periods
     ]
+
+    stock_delta_quantity = filtered_inventory_total - last_year_sales_total
+    stock_delta_percent = (
+        (stock_delta_quantity / last_year_sales_total) * 100
+        if last_year_sales_total > 0
+        else Decimal("0")
+    )
+    stock_delta_percent_abs = abs(stock_delta_percent)
+    is_understocked = stock_delta_quantity < 0
+
+    base_replenishment_low = int(round(last_year_sales_total * Decimal("0.30")))
+    base_replenishment_high = int(round(last_year_sales_total * Decimal("0.45")))
+    stock_gap_adjustment = abs(stock_delta_quantity)
+    if is_understocked:
+        replenishment_low = base_replenishment_low + stock_gap_adjustment
+        replenishment_high = base_replenishment_high + stock_gap_adjustment
+    else:
+        replenishment_low = max(0, base_replenishment_low - stock_gap_adjustment)
+        replenishment_high = max(0, base_replenishment_high - stock_gap_adjustment)
+
+    six_months_ago = today - relativedelta(months=6)
+    mature_product_ids = set()
+    if product_ids:
+        mature_from_arrivals = set(
+            OrderItem.objects.filter(
+                product_variant__product_id__in=product_ids,
+                date_arrived__isnull=False,
+                date_arrived__lte=six_months_ago,
+            ).values_list("product_variant__product_id", flat=True)
+        )
+        mature_from_sales = set(
+            Sale.objects.filter(
+                variant__product_id__in=product_ids,
+                date__lte=six_months_ago,
+            ).values_list("variant__product_id", flat=True)
+        )
+        mature_product_ids = mature_from_arrivals | mature_from_sales
 
     size_keys = (
         set(size_totals.keys())
@@ -3058,6 +3118,15 @@ def _render_filtered_products(
             "stock_balance_groups": stock_balance_groups,
             "stock_age_breakdown": stock_age_breakdown,
             "profitability_summary": profitability_summary,
+            "replenishment_low": replenishment_low,
+            "replenishment_high": replenishment_high,
+            "stock_delta_percent": stock_delta_percent,
+            "stock_delta_percent_abs": stock_delta_percent_abs,
+            "is_understocked": is_understocked,
+            "discounted_items": discounted_items,
+            "mature_products_over_six_months": len(mature_product_ids),
+            "items_in_order": items_in_order,
+            "pipeline_products": pipeline_products,
             "has_quarterly_data": bool(variant_ids),
             "filter_controls": filter_controls,
             "showing_summary": " | ".join(selected_labels_flat)


### PR DESCRIPTION
### Motivation
- Surface replenishment guidance and several stock-health metrics alongside the filtered product list to help merchants prioritize orders and clearance actions.

### Description
- Added a new stock/replenishment card in `inventory/templates/inventory/product_filtered_list.html` that displays an estimated replenishment range and a collection of metrics (stock position, clearance counts, mature products, items already in order, and pipeline products).  
- Computed new context values in `inventory/views.py`, including `discounted_items`, `pipeline_products`, `items_in_order`, `mature_products_over_six_months`, `stock_delta_percent`/`stock_delta_percent_abs`, `is_understocked`, and `replenishment_low`/`replenishment_high`, using aggregations on `OrderItem` and `Sale` as well as simple arithmetic based on `last_year_sales_total`.  
- Adjusted layout column widths in the template to accommodate the new panel and wired the new context variables into the template for display.

### Testing
- Ran the Django unit test suite with `pytest` and the project tests, and all tests passed.  
- Verified template rendering for the filtered products page by running the development server and checking the new panel loads without template errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef906b0b18832cbddcff1e551fe009)