### PR TITLE
Remove redundant stock position box on products page

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -838,14 +838,6 @@
     <!-- NOTES COLUMN -->
     <div class="col s12 m4">
 
-      <!-- TOTAL STOCK POSITION -->
-      {% if stock_balance_note %}
-      <div class="card-panel">
-        <h6 class="grey-text text-darken-1" style="margin-top: 0;">Stock position</h6>
-          <p class="teal-text text-darken-2" style="margin-bottom: 0;">{{ stock_balance_note }}</p>
-      </div>
-      {% endif %}
-
       <div class="card-panel">
         <ul class="collection" style="margin: 0;">
           <li class="collection-item" style="border-left: 3px solid #26a69a;">


### PR DESCRIPTION
### Motivation
- The products page contained a standalone “Stock position” summary card that duplicated information already shown elsewhere on the page, so it should be removed to reduce clutter.

### Description
- Deleted the standalone Stock position card from the notes column in `inventory/templates/inventory/product_filtered_list.html`, leaving the other inventory summary and the "By category" / "By group" breakdowns intact.

### Testing
- Ran `python manage.py check` which failed in this environment due to missing Django (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f070cb74ec832c8f604891f2fcc12a)