### PR TITLE
Products stats: remove Notes box, remove 6‑month line, add product counts to Time on Market

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -797,10 +797,6 @@
             <span class="secondary-content teal-text text-darken-2">{{ discounted_products }} products / {{ discounted_items }} items</span>
           </li>
           <li class="collection-item" style="border-left: 3px solid #26a69a;">
-            <strong>On market over 6 months</strong>
-            <span class="secondary-content teal-text text-darken-2">{{ mature_products_over_six_months }} products</span>
-          </li>
-          <li class="collection-item" style="border-left: 3px solid #26a69a;">
             <strong>Already in order</strong>
             <span class="secondary-content teal-text text-darken-2">{{ items_in_order }} items</span>
           </li>
@@ -837,26 +833,8 @@
 
   <div class="row">
 
-    <!-- NOTES COLUMN -->
-    <div class="col s12 m4">
-      <div class="card-panel">
-        <ul class="collection" style="margin: 0;">
-          <li class="collection-item" style="border-left: 3px solid #26a69a;">
-            <strong>Products in this category</strong>
-            <span class="secondary-content teal-text text-darken-2">{{ total_products }}</span>
-          </li>
-          <li class="collection-item" style="border-left: 3px solid #26a69a;">
-            <strong>Partially out-of-stock</strong>
-            <span class="secondary-content teal-text text-darken-2">{{ partial_oos_products }}</span>
-          </li>
-
-        </ul>
-      </div>
-    </div>
-
-
     <!-- TIME ON MARKET -->
-    <div class="col s12 m4">
+    <div class="col s12 m6">
     {% if stock_age_breakdown %}
       <div class="card-panel">
         <h6 class="grey-text text-darken-1" style="margin-top: 0;">Time on market</h6>
@@ -866,7 +844,7 @@
               <div style="display: flex; justify-content: space-between; align-items: center; gap: 8px;">
                 <strong>{{ entry.label }}</strong>
                 {% if entry.percent %}
-                  <span class="teal-text text-darken-2">{{ entry.percent }}%</span>
+                  <span class="teal-text text-darken-2">{{ entry.percent }}% ({{ entry.product_count }} products)</span>
                 {% endif %}
               </div>
             </li>
@@ -876,7 +854,7 @@
     {% endif %}
     </div>
 
-    <div class="col s12 m4">
+    <div class="col s12 m6">
       <div class="card-panel">
         <h6 class="grey-text text-darken-1">Quarterly Sales (last 12 quarters)</h6>
         {% if has_quarterly_data %}

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1895,7 +1895,6 @@ def _render_filtered_products(
         getattr(product, "total_inventory", 0) for product in products
     )
     product_ids = [product.id for product in products]
-    total_products = len(products)
     discounted_products = sum(1 for product in products if product.discounted)
     discounted_items = sum(
         (getattr(variant, "latest_inventory", 0) or 0)
@@ -1903,19 +1902,6 @@ def _render_filtered_products(
         if product.discounted
         for variant in getattr(product, "variants_with_inventory", [])
     )
-    partial_oos_products = 0
-    for product in products:
-        variants = getattr(product, "variants_with_inventory", [])
-        if not variants:
-            continue
-        has_in_stock = any(
-            (getattr(variant, "latest_inventory", 0) or 0) > 0 for variant in variants
-        )
-        has_oos = any(
-            (getattr(variant, "latest_inventory", 0) or 0) <= 0 for variant in variants
-        )
-        if has_in_stock and has_oos:
-            partial_oos_products += 1
 
     sales_product_ids = set()
     order_product_ids = set()
@@ -2492,24 +2478,6 @@ def _render_filtered_products(
         replenishment_low = max(0, base_replenishment_low - stock_gap_adjustment)
         replenishment_high = max(0, base_replenishment_high - stock_gap_adjustment)
 
-    six_months_ago = today - relativedelta(months=6)
-    mature_product_ids = set()
-    if product_ids:
-        mature_from_arrivals = set(
-            OrderItem.objects.filter(
-                product_variant__product_id__in=product_ids,
-                date_arrived__isnull=False,
-                date_arrived__lte=six_months_ago,
-            ).values_list("product_variant__product_id", flat=True)
-        )
-        mature_from_sales = set(
-            Sale.objects.filter(
-                variant__product_id__in=product_ids,
-                date__lte=six_months_ago,
-            ).values_list("variant__product_id", flat=True)
-        )
-        mature_product_ids = mature_from_arrivals | mature_from_sales
-
     size_keys = (
         set(size_totals.keys())
         | set(size_sales_totals.keys())
@@ -2978,6 +2946,12 @@ def _render_filtered_products(
             "six_to_twelve": 0,
             "over_12": 0,
         }
+        bucket_product_ids: dict[str, set[int]] = {
+            "under_3": set(),
+            "three_to_six": set(),
+            "six_to_twelve": set(),
+            "over_12": set(),
+        }
         unknown_inventory = 0
 
         three_months_ago = today - relativedelta(months=3)
@@ -3004,6 +2978,7 @@ def _render_filtered_products(
                     bucket_key = "over_12"
 
                 bucket_totals[bucket_key] += inventory_count
+                bucket_product_ids[bucket_key].add(product.id)
 
         bucket_messages = {
             "under_3": "arrived within the last 3 months.",
@@ -3034,6 +3009,7 @@ def _render_filtered_products(
                 {
                     "label": label,
                     "percent": f"{percent_val:.1f}",
+                    "product_count": len(bucket_product_ids.get(key, set())),
                     "message": message,
                 }
             )
@@ -3072,8 +3048,6 @@ def _render_filtered_products(
             "filter_heading": heading,
             "filter_description": description,
             "filtered_inventory_total": filtered_inventory_total,
-            "total_products": total_products,
-            "partial_oos_products": partial_oos_products,
             "discounted_products": discounted_products,
             "new_products": new_products,
             "size_stock_rows": size_stock_rows,
@@ -3124,7 +3098,6 @@ def _render_filtered_products(
             "stock_delta_percent_abs": stock_delta_percent_abs,
             "is_understocked": is_understocked,
             "discounted_items": discounted_items,
-            "mature_products_over_six_months": len(mature_product_ids),
             "items_in_order": items_in_order,
             "pipeline_products": pipeline_products,
             "has_quarterly_data": bool(variant_ids),


### PR DESCRIPTION
### Motivation
- Simplify the Products statistics section by removing the redundant Notes box and a replenishment line that is no longer needed.
- Make the Time on market breakdown more informative by showing how many products contribute to each bucket in addition to percentages.
- Avoid keeping backend calculations that only served removed UI elements to reduce maintenance surface.

### Description
- Removed the Notes column ("Products in this category" and "Partially out-of-stock") from `inventory/templates/inventory/product_filtered_list.html` and rebalanced layout so `Time on market` and `Quarterly Sales` each use `m6` width.
- Removed the "On market over 6 months" row from the Replenishment card in the same template.
- Updated `Time on market` entries to render counts next to percentages (template now shows `{{ entry.percent }}% ({{ entry.product_count }} products)`).
- Added `bucket_product_ids` tracking in `inventory/views.py` and include `product_count` in each `stock_age_breakdown` entry, and removed unused context values/calculations (`total_products`, `partial_oos_products`, and `mature_products_over_six_months`).

### Testing
- Ran `python -m compileall inventory/views.py` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f075674260832cb42a109345a79b95)