### PR TITLE
Hide empty-product scorecard signals and add create-order CTA

### DIFF
--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -52,39 +52,48 @@
 
                 <p class="signal-line signal-line--stock">
                   {{ product.total_inventory|default:0 }} in stock / {{ product.last_order_qty|default:0 }} ordered
-                  <span class="signal-muted">|</span>
-                  <button
-                    type="button"
-                    class="btn-flat signal-line signal-line--variants variant-summary-trigger"
-                    data-variant-panel-trigger
-                    data-product-id="{{ product.id }}"
-                  >
-                    Variants: {{ product.out_of_stock_variant_count|default:0 }} OOS · {{ product.low_stock_variant_count|default:0 }} Low
-                  </button>
-                  <span class="signal-muted">|</span>
-                  {% for core in product.core_size_signals %}
-                    <span class="signal-core {% if core.in_stock %}signal-core--ok{% else %}signal-core--miss{% endif %}">
-                      {% if core.in_stock %}✔{% else %}✖{% endif %} {{ core.size }}
-                    </span>
-                  {% endfor %}
+                  {% if product.total_inventory|default:0 != 0 or product.last_order_qty|default:0 != 0 or product.total_sales|default:0 != 0 %}
+                    <span class="signal-muted">|</span>
+                    <button
+                      type="button"
+                      class="btn-flat signal-line signal-line--variants variant-summary-trigger"
+                      data-variant-panel-trigger
+                      data-product-id="{{ product.id }}"
+                    >
+                      Variants: {{ product.out_of_stock_variant_count|default:0 }} OOS · {{ product.low_stock_variant_count|default:0 }} Low
+                    </button>
+                    <span class="signal-muted">|</span>
+                    {% for core in product.core_size_signals %}
+                      <span class="signal-core {% if core.in_stock %}signal-core--ok{% else %}signal-core--miss{% endif %}">
+                        {% if core.in_stock %}✔{% else %}✖{% endif %} {{ core.size }}
+                      </span>
+                    {% endfor %}
+                  {% endif %}
                 </p>
 
-                <hr/>
+                {% if product.total_inventory|default:0 != 0 or product.last_order_qty|default:0 != 0 or product.total_sales|default:0 != 0 %}
+                  <hr/>
 
-                <p class="signal-line">
-                    {% if product.time_on_market_months is not None %}
-                      {{ product.time_on_market_months|floatformat:0 }} months
-                    {% else %}
-                      -
-                    {% endif %}
-                    on market
-                  <span class="signal-muted">|</span>
-                  {{ product.total_sales|default:0 }} sold
-                  <span class="signal-muted">|</span>
-                  gross margin {{ product.profit_percentage|floatformat:0|default_if_none:"-" }}%
-                  <span class="signal-muted">|</span>
-                  av. discount {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
-                </p>
+                  <p class="signal-line">
+                      {% if product.time_on_market_months is not None %}
+                        {{ product.time_on_market_months|floatformat:0 }} months
+                      {% else %}
+                        -
+                      {% endif %}
+                      on market
+                    <span class="signal-muted">|</span>
+                    {{ product.total_sales|default:0 }} sold
+                    <span class="signal-muted">|</span>
+                    gross margin {{ product.profit_percentage|floatformat:0|default_if_none:"-" }}%
+                    <span class="signal-muted">|</span>
+                    av. discount {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
+                  </p>
+                {% else %}
+                  <hr/>
+                  <p class="signal-line">
+                    <a href="{% url 'order_list' %}?product={{ product.id }}">Create order for this product</a>
+                  </p>
+                {% endif %}
 
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- New products with no stock, no orders and no sales currently show empty signals and metrics that are not useful, so hide those and surface a quick action to create an order.

### Description
- Updated `inventory/templates/inventory/snippets/product_scorecard.html` to only render the `Variants: … OOS · … Low` button and core-size badges when at least one of `product.total_inventory`, `product.last_order_qty`, or `product.total_sales` is non-zero.
- Made the bottom metrics line (`on market | X sold | gross margin % | av. discount %`) conditional on the same activity check so it is hidden for activity-free products.
- Added a fallback CTA link `Create order for this product` that points to the order list scoped to the product via `?product=<id>` for products that have no activity.

### Testing
- Ran `python manage.py check` (automated Django system check) in this environment, which failed because Django is not installed here and the environment cannot run the project; no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f079219cf8832c99915f1df408f76f)