### PR TITLE
Handle new/on-order products in product scorecard (ETA and Create order link)

### DIFF
--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -52,39 +52,58 @@
 
                 <p class="signal-line signal-line--stock">
                   {{ product.total_inventory|default:0 }} in stock / {{ product.last_order_qty|default:0 }} ordered
-                  <span class="signal-muted">|</span>
-                  <button
-                    type="button"
-                    class="btn-flat signal-line signal-line--variants variant-summary-trigger"
-                    data-variant-panel-trigger
-                    data-product-id="{{ product.id }}"
-                  >
-                    Variants: {{ product.out_of_stock_variant_count|default:0 }} OOS · {{ product.low_stock_variant_count|default:0 }} Low
-                  </button>
-                  <span class="signal-muted">|</span>
-                  {% for core in product.core_size_signals %}
-                    <span class="signal-core {% if core.in_stock %}signal-core--ok{% else %}signal-core--miss{% endif %}">
-                      {% if core.in_stock %}✔{% else %}✖{% endif %} {{ core.size }}
-                    </span>
-                  {% endfor %}
+                  {% if not product.is_new_unlaunched and not product.is_on_order_no_sales %}
+                    <span class="signal-muted">|</span>
+                    <button
+                      type="button"
+                      class="btn-flat signal-line signal-line--variants variant-summary-trigger"
+                      data-variant-panel-trigger
+                      data-product-id="{{ product.id }}"
+                    >
+                      Variants: {{ product.out_of_stock_variant_count|default:0 }} OOS · {{ product.low_stock_variant_count|default:0 }} Low
+                    </button>
+                    <span class="signal-muted">|</span>
+                    {% for core in product.core_size_signals %}
+                      <span class="signal-core {% if core.in_stock %}signal-core--ok{% else %}signal-core--miss{% endif %}">
+                        {% if core.in_stock %}✔{% else %}✖{% endif %} {{ core.size }}
+                      </span>
+                    {% endfor %}
+                  {% endif %}
                 </p>
 
-                <hr/>
+                {% if not product.is_new_unlaunched and not product.is_on_order_no_sales %}
+                  <hr/>
 
-                <p class="signal-line">
-                    {% if product.time_on_market_months is not None %}
-                      {{ product.time_on_market_months|floatformat:0 }} months
+                  <p class="signal-line">
+                      {% if product.time_on_market_months is not None %}
+                        {{ product.time_on_market_months|floatformat:0 }} months
+                      {% else %}
+                        -
+                      {% endif %}
+                      on market
+                    <span class="signal-muted">|</span>
+                    {{ product.total_sales|default:0 }} sold
+                    <span class="signal-muted">|</span>
+                    gross margin {{ product.profit_percentage|floatformat:0|default_if_none:"-" }}%
+                    <span class="signal-muted">|</span>
+                    av. discount {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
+                  </p>
+                {% elif product.is_on_order_no_sales %}
+                  <hr/>
+                  <p class="signal-line">
+                    Estimated arrival:
+                    {% if product.pending_order_expected_date %}
+                      {{ product.pending_order_expected_date|date:"M j, Y" }}
                     {% else %}
-                      -
+                      —
                     {% endif %}
-                    on market
-                  <span class="signal-muted">|</span>
-                  {{ product.total_sales|default:0 }} sold
-                  <span class="signal-muted">|</span>
-                  gross margin {{ product.profit_percentage|floatformat:0|default_if_none:"-" }}%
-                  <span class="signal-muted">|</span>
-                  av. discount {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
-                </p>
+                  </p>
+                {% else %}
+                  <hr/>
+                  <p class="signal-line">
+                    <a href="{% url 'order_list' %}?product={{ product.id }}">Create order for this product</a>
+                  </p>
+                {% endif %}
 
               </div>
             </div>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1205,6 +1205,7 @@ def _build_product_list_context(request, preset_filters=None):
     )
 
     pending_variant_totals: dict[int, int] = {}
+    pending_expected_date_by_product: dict[int, date] = {}
     if products:
         pending_rows = (
             OrderItem.objects.filter(
@@ -1216,6 +1217,19 @@ def _build_product_list_context(request, preset_filters=None):
         )
         pending_variant_totals = {
             row["product_variant_id"]: row["total"] or 0 for row in pending_rows
+        }
+        pending_expected_rows = (
+            OrderItem.objects.filter(
+                product_variant__product__in=products,
+                date_arrived__isnull=True,
+            )
+            .values("product_variant__product_id")
+            .annotate(expected_date=Max("date_expected"))
+        )
+        pending_expected_date_by_product = {
+            row["product_variant__product_id"]: row["expected_date"]
+            for row in pending_expected_rows
+            if row.get("expected_date")
         }
 
     # ─── Compute per‐product stats ───────────────────────────────────────────────
@@ -1295,6 +1309,19 @@ def _build_product_list_context(request, preset_filters=None):
         product.last_order_qty = metrics["last_order_qty"]
         product.sold_since_last_order = metrics["sold_since_last_order"]
         product.variant_months_to_sell_out = metrics["variant_months_to_sell_out"]
+        product.pending_order_expected_date = pending_expected_date_by_product.get(
+            product.id
+        )
+        product.is_new_unlaunched = (
+            product.total_inventory == 0
+            and product.last_order_qty == 0
+            and product.total_sales == 0
+        )
+        product.is_on_order_no_sales = (
+            product.total_inventory == 0
+            and product.total_sales == 0
+            and product.last_order_label == "On Order"
+        )
         product.profit = product.total_sales_value - product.last_order_cost
         product.gift_units = metrics.get("gift_units", 0)
         product.gift_rate = (


### PR DESCRIPTION
### Motivation
- Prevent showing variant summaries, core-size indicators, and sales metrics for products that have never been launched or that are currently on order with no sales. 
- Surface an estimated arrival date for products that are on order but not yet sold. 
- Provide a quick call-to-action to create an order for new/unlaunched products.

### Description
- Add aggregation of pending order expected dates in `inventory/views.py` and expose `product.pending_order_expected_date`. 
- Add product state flags `product.is_new_unlaunched` and `product.is_on_order_no_sales` in the product context to drive conditional UI. 
- Update `inventory/templates/inventory/snippets/product_scorecard.html` to hide variant/core-size elements and baseline sales metrics for the two special product states, to show an ETA when the product is on order with no sales, and to show a "Create order for this product" link for new/unlaunched products. 
- Preserve the original display for normal products (months on market, sold, gross margin, average discount, and variant/core indicators).

### Testing
- Ran the inventory app test suite with `./manage.py test inventory` and the tests completed successfully. 
- Ran `flake8` linting on the modified files and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f079219cf8832c99915f1df408f76f)