### PR TITLE
Show pending-order ETA and adjust product scorecard for unlaunched/on-order products

### DIFF
--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -34,57 +34,78 @@
               <div class="signal-card__metrics">
 
 
-                <div class="signal-progress-wrap">
-                  <div class="signal-progress">
-                    <span
-                      class="signal-progress__fill"
-                      style="width: {% if product.stock_remaining_pct is not None %}{{ product.stock_remaining_pct|floatformat:0 }}{% else %}0{% endif %}%; --stock-pct: {% if product.stock_remaining_pct is not None %}{{ product.stock_remaining_pct|floatformat:0 }}{% else %}0{% endif %};"
-                    ></span>
+                {% if not product.is_new_unlaunched and not product.is_on_order_no_sales %}
+                  <div class="signal-progress-wrap">
+                    <div class="signal-progress">
+                      <span
+                        class="signal-progress__fill"
+                        style="width: {% if product.stock_remaining_pct is not None %}{{ product.stock_remaining_pct|floatformat:0 }}{% else %}0{% endif %}%; --stock-pct: {% if product.stock_remaining_pct is not None %}{{ product.stock_remaining_pct|floatformat:0 }}{% else %}0{% endif %};"
+                      ></span>
+                    </div>
+                    <span class="signal-muted">
+                      {% if product.stock_remaining_pct is not None %}
+                        {{ product.stock_remaining_pct|floatformat:0 }}%
+                      {% else %}
+                        -
+                      {% endif %}
+                    </span>
                   </div>
-                  <span class="signal-muted">
-                    {% if product.stock_remaining_pct is not None %}
-                      {{ product.stock_remaining_pct|floatformat:0 }}%
-                    {% else %}
-                      -
-                    {% endif %}
-                  </span>
-                </div>
+                {% endif %}
 
                 <p class="signal-line signal-line--stock">
                   {{ product.total_inventory|default:0 }} in stock / {{ product.last_order_qty|default:0 }} ordered
-                  <span class="signal-muted">|</span>
-                  <button
-                    type="button"
-                    class="btn-flat signal-line signal-line--variants variant-summary-trigger"
-                    data-variant-panel-trigger
-                    data-product-id="{{ product.id }}"
-                  >
-                    Variants: {{ product.out_of_stock_variant_count|default:0 }} OOS · {{ product.low_stock_variant_count|default:0 }} Low
-                  </button>
-                  <span class="signal-muted">|</span>
-                  {% for core in product.core_size_signals %}
-                    <span class="signal-core {% if core.in_stock %}signal-core--ok{% else %}signal-core--miss{% endif %}">
-                      {% if core.in_stock %}✔{% else %}✖{% endif %} {{ core.size }}
-                    </span>
-                  {% endfor %}
+                  {% if not product.is_new_unlaunched and not product.is_on_order_no_sales %}
+                    <span class="signal-muted">|</span>
+                    <button
+                      type="button"
+                      class="btn-flat signal-line signal-line--variants variant-summary-trigger"
+                      data-variant-panel-trigger
+                      data-product-id="{{ product.id }}"
+                    >
+                      Variants: {{ product.out_of_stock_variant_count|default:0 }} OOS · {{ product.low_stock_variant_count|default:0 }} Low
+                    </button>
+                    <span class="signal-muted">|</span>
+                    {% for core in product.core_size_signals %}
+                      <span class="signal-core {% if core.in_stock %}signal-core--ok{% else %}signal-core--miss{% endif %}">
+                        {% if core.in_stock %}✔{% else %}✖{% endif %} {{ core.size }}
+                      </span>
+                    {% endfor %}
+                  {% endif %}
                 </p>
 
-                <hr/>
+                {% if not product.is_new_unlaunched and not product.is_on_order_no_sales %}
+                  <hr/>
 
-                <p class="signal-line">
-                    {% if product.time_on_market_months is not None %}
-                      {{ product.time_on_market_months|floatformat:0 }} months
+                  <p class="signal-line">
+                      {% if product.time_on_market_months is not None %}
+                        {{ product.time_on_market_months|floatformat:0 }} months
+                      {% else %}
+                        -
+                      {% endif %}
+                      on market
+                    <span class="signal-muted">|</span>
+                    {{ product.total_sales|default:0 }} sold
+                    <span class="signal-muted">|</span>
+                    gross margin {{ product.profit_percentage|floatformat:0|default_if_none:"-" }}%
+                    <span class="signal-muted">|</span>
+                    av. discount {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
+                  </p>
+                {% elif product.is_on_order_no_sales %}
+                  <hr/>
+                  <p class="signal-line">
+                    Estimated arrival:
+                    {% if product.pending_order_expected_date %}
+                      {{ product.pending_order_expected_date|date:"M j, Y" }}
                     {% else %}
-                      -
+                      —
                     {% endif %}
-                    on market
-                  <span class="signal-muted">|</span>
-                  {{ product.total_sales|default:0 }} sold
-                  <span class="signal-muted">|</span>
-                  gross margin {{ product.profit_percentage|floatformat:0|default_if_none:"-" }}%
-                  <span class="signal-muted">|</span>
-                  av. discount {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
-                </p>
+                  </p>
+                {% else %}
+                  <hr/>
+                  <p class="signal-line">
+                    <a href="{% url 'order_list' %}?product={{ product.id }}">Create order for this product</a>
+                  </p>
+                {% endif %}
 
               </div>
             </div>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1205,6 +1205,7 @@ def _build_product_list_context(request, preset_filters=None):
     )
 
     pending_variant_totals: dict[int, int] = {}
+    pending_expected_date_by_product: dict[int, date] = {}
     if products:
         pending_rows = (
             OrderItem.objects.filter(
@@ -1216,6 +1217,19 @@ def _build_product_list_context(request, preset_filters=None):
         )
         pending_variant_totals = {
             row["product_variant_id"]: row["total"] or 0 for row in pending_rows
+        }
+        pending_expected_rows = (
+            OrderItem.objects.filter(
+                product_variant__product__in=products,
+                date_arrived__isnull=True,
+            )
+            .values("product_variant__product_id")
+            .annotate(expected_date=Max("date_expected"))
+        )
+        pending_expected_date_by_product = {
+            row["product_variant__product_id"]: row["expected_date"]
+            for row in pending_expected_rows
+            if row.get("expected_date")
         }
 
     # ─── Compute per‐product stats ───────────────────────────────────────────────
@@ -1295,6 +1309,19 @@ def _build_product_list_context(request, preset_filters=None):
         product.last_order_qty = metrics["last_order_qty"]
         product.sold_since_last_order = metrics["sold_since_last_order"]
         product.variant_months_to_sell_out = metrics["variant_months_to_sell_out"]
+        product.pending_order_expected_date = pending_expected_date_by_product.get(
+            product.id
+        )
+        product.is_new_unlaunched = (
+            product.total_inventory == 0
+            and product.last_order_qty == 0
+            and product.total_sales == 0
+        )
+        product.is_on_order_no_sales = (
+            product.total_inventory == 0
+            and product.total_sales == 0
+            and product.last_order_label == "On Order"
+        )
         product.profit = product.total_sales_value - product.last_order_cost
         product.gift_units = metrics.get("gift_units", 0)
         product.gift_rate = (


### PR DESCRIPTION
### Motivation

- Surface pending order estimated arrival dates for products that have incoming stock but no sales, and simplify the scorecard UI for products that are new/unlaunched or on-order-without-sales.
- Avoid showing misleading stock progress, variant summaries, and sales/statistics for products that have no inventory and no sales yet.

### Description

- Added aggregation in `_build_product_list_context` to compute `pending_expected_date_by_product` from `OrderItem` using `Max(date_expected)` and attach it to each product as `product.pending_order_expected_date`.
- Introduced `product.is_new_unlaunched` and `product.is_on_order_no_sales` flags based on inventory, last order, and sales totals to drive conditional rendering logic in the template.
- Updated `inventory/templates/inventory/snippets/product_scorecard.html` to wrap the stock progress bar, variants summary, and detailed sales/statistics inside a conditional that hides them for new/unlaunched or on-order-no-sales products.
- Added alternate displays: show an "Estimated arrival" line with the expected date (or an em dash) for `is_on_order_no_sales`, and show a `Create order for this product` link for `is_new_unlaunched` products.

### Testing

- Ran the project test suite with `pytest -q` and `python manage.py test inventory`, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f079219cf8832c99915f1df408f76f)