### PR TITLE
Add create-order overlay modal with smarter variant mix recommendations

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -597,6 +597,55 @@
       font-weight: 500;
       font-size: 12px;
     }
+
+    .product-order-modal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
+    }
+    .product-order-modal.is-open { display: block; }
+    .product-order-modal__backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+    }
+    .product-order-modal__content {
+      position: relative;
+      background: #fff;
+      width: min(980px, 95%);
+      margin: 3vh auto;
+      border-radius: 12px;
+      padding: 20px;
+      z-index: 1;
+      max-height: 94vh;
+      overflow-y: auto;
+    }
+    .product-order-modal__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 16px;
+    }
+    .product-order-modal__product-head {
+      display: grid;
+      grid-template-columns: 90px 1fr;
+      gap: 12px;
+      margin-bottom: 14px;
+      align-items: center;
+    }
+    .product-order-modal__photo {
+      width: 90px;
+      height: 90px;
+      object-fit: cover;
+      border-radius: 10px;
+    }
+    .product-order-modal__variant-options {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 8px;
+    }
   </style>
   {% if filter_controls %}
 
@@ -1896,6 +1945,71 @@
           const panel = closeButton.closest('.variant-panel');
           toggleVariantPanel(panel, false);
         });
+      });
+
+      const variantRecommendations = {
+        gi: { adult: ['A0', 'A1', 'A1L', 'A2', 'A2L', 'A3', 'A3L', 'A4', 'A5', 'F1', 'F2', 'F3', 'F4'], kids: ['M000', 'M00', 'M0', 'M1', 'M2', 'M3', 'M4'] },
+        ng: { adult: ['XS', 'S', 'M', 'L', 'XL', 'XXL'], kids: ['KXS', 'KS', 'KM', 'KL', 'KXL'] },
+        ap: { default: ['XS', 'S', 'M', 'L', 'XL'] },
+        ac: { default: [] },
+      };
+
+      const toggleOrderModal = (modal, open) => {
+        if (!modal) return;
+        modal.classList.toggle('is-open', open);
+        modal.setAttribute('aria-hidden', open ? 'false' : 'true');
+      };
+
+      const hydrateVariantCreator = (modal) => {
+        const optionsWrap = modal.querySelector('[data-variant-size-options]');
+        if (!optionsWrap) return;
+        const style = modal.dataset.productStyle || '';
+        const age = modal.dataset.productAge || '';
+        const styleMap = variantRecommendations[style] || {};
+        const sizes = styleMap[age] || styleMap.default || [];
+        optionsWrap.innerHTML = sizes.length
+          ? sizes.map((size) => `<label><input type="checkbox" class="filled-in" name="variant_sizes" value="${size}" checked><span>${size}</span></label>`).join('')
+          : '<span class="grey-text">No standard sizes for this category.</span>';
+      };
+
+      const updateOrderSplit = (modal) => {
+        const totalInput = modal.querySelector('[data-total-order-input]');
+        if (!totalInput) return;
+        const total = Math.max(parseInt(totalInput.value, 10) || 0, 0);
+        const rows = Array.from(modal.querySelectorAll('[data-order-qty-input]'));
+        if (!rows.length) return;
+        const raw = rows.map((input) => {
+          const share = parseFloat(input.dataset.sizeShare || '0');
+          const rawValue = total * share;
+          const floorValue = Math.floor(rawValue);
+          return { input, floorValue, fraction: rawValue - floorValue };
+        });
+        let remainder = total - raw.reduce((sum, row) => sum + row.floorValue, 0);
+        raw.sort((a, b) => b.fraction - a.fraction).forEach((row) => {
+          const add = remainder > 0 ? 1 : 0;
+          const value = row.floorValue + add;
+          row.input.value = value > 0 ? value : '';
+          remainder = Math.max(remainder - add, 0);
+        });
+      };
+
+      document.querySelectorAll('[data-open-order-modal]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const modal = document.getElementById(btn.getAttribute('data-open-order-modal'));
+          hydrateVariantCreator(modal);
+          toggleOrderModal(modal, true);
+        });
+      });
+
+      document.querySelectorAll('[data-close-order-modal]').forEach((btn) => {
+        btn.addEventListener('click', () => toggleOrderModal(btn.closest('.product-order-modal'), false));
+      });
+
+      document.querySelectorAll('.product-order-modal').forEach((modal) => {
+        const totalInput = modal.querySelector('[data-total-order-input]');
+        if (totalInput) {
+          totalInput.addEventListener('input', () => updateOrderSplit(modal));
+        }
       });
 
       if (!dataPoints || !dataPoints.length || !document.getElementById('quarterlySalesChart')) {

--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -103,7 +103,14 @@
                 {% else %}
                   <hr/>
                   <p class="signal-line">
-                    <a href="{% url 'order_list' %}?product={{ product.id }}">Create order for this product</a>
+                    <button
+                      type="button"
+                      class="btn-flat"
+                      data-open-order-modal="order-modal-{{ product.id }}"
+                      data-order-mode="create"
+                    >
+                      Create order
+                    </button>
                   </p>
                 {% endif %}
 
@@ -216,6 +223,102 @@
           {% endfor %}
         </tbody>
       </table>
+    </div>
+  </div>
+</div>
+
+<div
+  class="product-order-modal"
+  id="order-modal-{{ product.id }}"
+  aria-hidden="true"
+  data-product-style="{{ product.style|default:'' }}"
+  data-product-age="{{ product.age|default:'' }}"
+>
+  <div class="product-order-modal__backdrop" data-close-order-modal></div>
+  <div class="product-order-modal__content">
+    <div class="product-order-modal__header">
+      <h5>Create order · {{ product.product_name }}</h5>
+      <button type="button" class="btn-flat" data-close-order-modal>&times;</button>
+    </div>
+    <div class="product-order-modal__body">
+      <form method="post" action="{% url 'order_item_create' %}" class="product-order-form" data-order-form data-create-action="{% url 'order_item_create' %}" style="width: 100%;">
+        {% csrf_token %}
+        <input type="hidden" name="product_id" value="{{ product.id }}">
+        <div class="product-order-modal__table">
+          <div class="product-order-modal__product-head">
+            <div>
+              {% if product.product_photo %}
+                <img src="{{ product.product_photo.url }}" alt="{{ product.product_name }}" class="product-order-modal__photo">
+              {% else %}
+                <img src="{{ MEDIA_URL }}product_photos/product-placeholder.jpg" alt="{{ product.product_name }}" class="product-order-modal__photo">
+              {% endif %}
+            </div>
+            <div>
+              <p><strong>{{ product.product_name }}</strong> ({{ product.product_id }})</p>
+              <p class="grey-text text-darken-1">
+                {{ product.get_style_display|default:"—" }} · {{ product.get_type_display|default:"—" }} · {{ product.get_subtype_display|default:"—" }}
+              </p>
+            </div>
+          </div>
+
+          {% if product.variants_with_inventory %}
+            <div class="row" style="margin: 0 0 8px;">
+              <div class="input-field col s12 m6" style="margin-top: 0;">
+                <input type="date" name="date_expected" required>
+                <label>Expected arrival date</label>
+              </div>
+              <div class="input-field col s12 m6" style="margin-top: 0;">
+                <input type="number" min="0" step="0.01" name="item_cost_price" required>
+                <label>Item cost price (CNY)</label>
+              </div>
+            </div>
+            <div class="input-field" style="margin-top: 0;">
+              <input type="number" min="0" class="total-order-input" data-total-order-input placeholder="0">
+              <label>Total order quantity</label>
+            </div>
+            <table class="striped">
+              <thead>
+                <tr>
+                  <th>Variant</th>
+                  <th>Size</th>
+                  <th>Current stock</th>
+                  <th>Suggested qty</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for variant in product.variants_with_inventory %}
+                  <tr>
+                    <td>{{ variant.variant_code }}</td>
+                    <td>{{ variant.size|default:"—" }}</td>
+                    <td>{{ variant.latest_inventory|default:0 }}</td>
+                    <td>
+                      <input
+                        type="number"
+                        min="0"
+                        placeholder="0"
+                        name="variant_{{ variant.id }}"
+                        data-order-qty-input
+                        data-size-share="{{ variant.size_sales_share|default:0 }}"
+                      >
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% else %}
+            <p class="grey-text text-darken-2"><strong>No variants yet.</strong> Create variants before placing this order.</p>
+            <p class="grey-text">Suggested sizes based on category:</p>
+            <div class="product-order-modal__variant-options" data-variant-size-options></div>
+            <input type="hidden" name="create_variants" value="1">
+          {% endif %}
+
+          <div style="margin-top: 16px; text-align: right;">
+            <button type="submit" class="btn btn-primary">
+              {% if product.variants_with_inventory %}Save order{% else %}Create variants{% endif %}
+            </button>
+          </div>
+        </div>
+      </form>
     </div>
   </div>
 </div>

--- a/inventory/utils.py
+++ b/inventory/utils.py
@@ -639,6 +639,94 @@ def build_product_reorder_summary(
     }
 
 
+def calculate_category_size_mix(
+    product: Product,
+    *,
+    target_sizes: Optional[Sequence[str]] = None,
+    long_weeks: int = 52,
+    recent_weeks: int = 13,
+    today: Optional[date] = None,
+) -> dict[str, Any]:
+    """Estimate an order size mix for ``product`` using category sales velocity.
+
+    The estimator intentionally avoids using only cumulative sold units (which
+    can be biased by eventual sell-through). Instead it blends long-window and
+    recent sales speed and only counts weeks where variants were in stock.
+    """
+
+    today = today or date.today()
+    variant_qs = ProductVariant.objects.filter(
+        product__style=product.style,
+        product__type=product.type,
+        size__isnull=False,
+    ).exclude(size="")
+
+    variants = list(variant_qs.select_related("product").prefetch_related("sales", "snapshots"))
+    size_scores: Dict[str, float] = defaultdict(float)
+    total_active_weeks = 0
+
+    for candidate in variants:
+        long_detail = calculate_variant_sales_speed_details(
+            candidate, weeks=long_weeks, today=today, fallback_weeks=long_weeks
+        )
+        recent_detail = calculate_variant_sales_speed_details(
+            candidate, weeks=recent_weeks, today=today, fallback_weeks=recent_weeks
+        )
+
+        long_speed = float(long_detail.get("speed") or 0.0)
+        recent_speed = float(recent_detail.get("speed") or 0.0)
+        if long_speed <= 0 and recent_speed <= 0:
+            continue
+
+        # Base demand estimate: stable long-term + recency signal.
+        blended_speed = (long_speed * 0.65) + (recent_speed * 0.35)
+
+        # Momentum scaling to react to changing demand but keep bounded.
+        if long_speed > 0 and recent_speed > 0:
+            momentum_ratio = max(0.75, min(1.35, recent_speed / long_speed))
+        else:
+            momentum_ratio = 1.0
+
+        # Reliability weighting based on in-stock observation coverage.
+        active_weeks = max(
+            int(long_detail.get("active_weeks") or 0),
+            int(recent_detail.get("active_weeks") or 0),
+        )
+        reliability = max(min(active_weeks / max(long_weeks, 1), 1.0), 0.25)
+
+        stockout_boost = (
+            1.08
+            if long_detail.get("had_stockout") or recent_detail.get("had_stockout")
+            else 1.0
+        )
+        score = blended_speed * momentum_ratio * reliability * stockout_boost
+        size_scores[candidate.size] += score
+        total_active_weeks += active_weeks
+
+    requested_sizes = [size for size in (target_sizes or []) if size]
+    if requested_sizes:
+        size_scores = {size: size_scores.get(size, 0.0) for size in requested_sizes}
+
+    score_total = sum(size_scores.values())
+    if score_total <= 0 and requested_sizes:
+        equal_share = 1 / len(requested_sizes)
+        shares = {size: equal_share for size in requested_sizes}
+        method = "equal_fallback"
+    elif score_total <= 0:
+        shares = {}
+        method = "no_data"
+    else:
+        shares = {size: score / score_total for size, score in size_scores.items()}
+        method = "velocity_weighted"
+
+    return {
+        "shares": shares,
+        "method": method,
+        "sample_variants": len(variants),
+        "active_weeks": total_active_weeks,
+    }
+
+
 def calculate_variant_sales_speed_details(
     variant: ProductVariant,
     *,

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -100,6 +100,7 @@ from .utils import (
     CORE_SIZES,
     get_variant_speed_map,
     get_category_speed_stats,
+    calculate_category_size_mix,
 )
 
 
@@ -4127,10 +4128,19 @@ def order_list(request):
         filtered_sales_last_year = 0
         size_sales_share = {}
 
-    if size_sales_share:
-        for product in filtered_products:
-            for variant in getattr(product, "variants_with_inventory", []):
-                variant.size_sales_share = size_sales_share.get(variant.size, 0)
+    for product in filtered_products:
+        product_variants = list(getattr(product, "variants_with_inventory", []))
+        target_sizes = [v.size for v in product_variants if v.size]
+        mix = calculate_category_size_mix(
+            product,
+            target_sizes=target_sizes,
+            today=today,
+        )
+        share_map = mix.get("shares", {})
+        product.size_mix_method = mix.get("method")
+        product.size_mix_sample_variants = mix.get("sample_variants", 0)
+        for variant in product_variants:
+            variant.size_sales_share = share_map.get(variant.size, 0)
 
     pending_product_totals: dict[int, int] = defaultdict(int)
     pending_variant_totals: dict[int, int] = {}
@@ -4510,8 +4520,14 @@ def order_list(request):
                 )
                 .order_by("variant_code")
             )
+            mix = calculate_category_size_mix(
+                selected_product,
+                target_sizes=[v.size for v in variants if v.size],
+                today=today,
+            )
+            share_map = mix.get("shares", {})
             for variant in variants:
-                variant.size_sales_share = size_sales_share.get(variant.size, 0)
+                variant.size_sales_share = share_map.get(variant.size, 0)
             variant_stock_rows = [
                 {
                     "variant_code": variant.variant_code,
@@ -4747,6 +4763,31 @@ def order_list(request):
 def order_item_create(request):
     item_cost = request.POST.get("item_cost_price")
     date_expected = request.POST.get("date_expected")
+    create_variants = request.POST.get("create_variants") in {"1", "true", "on", "yes"}
+    product_id = request.POST.get("product_id")
+
+    if create_variants and product_id:
+        try:
+            product = Product.objects.get(id=int(product_id))
+        except (TypeError, ValueError, Product.DoesNotExist):
+            return HttpResponseBadRequest("Invalid product.")
+
+        requested_sizes = request.POST.getlist("variant_sizes")
+        for raw_size in requested_sizes:
+            size = (raw_size or "").strip()
+            if not size:
+                continue
+            if product.variants.filter(size=size).exists():
+                continue
+            base_code = f"{product.product_id}-{size}"
+            ProductVariant.objects.create(
+                product=product,
+                variant_code=_build_unique_variant_code(base_code),
+                size=size,
+                primary_color=None,
+            )
+        return redirect("order_list")
+
     if not item_cost or not date_expected:
         return HttpResponseBadRequest("Missing cost or expected date.")
 


### PR DESCRIPTION
## Summary
- replaced the "Create order for this product" link on new products with a button that opens an overlay modal
- added a create-order modal to the scorecard cards with product header details (photo + category/subcategory metadata)
- added variant rows in the modal (variant code, size, stock) and total-quantity driven auto-split into per-variant suggested quantities
- added a no-variants flow in the modal that offers suggested sizes by category/age and can create missing variants directly
- implemented a reusable `calculate_category_size_mix` utility that calculates order size shares from in-stock sales velocity (not just total sold), blending long-window and recent speeds with reliability + stockout adjustments
- wired order list size-share assignment to use the new reusable size-mix utility

## Why
- cumulative sales alone can recreate poor historical splits because eventually all sizes sell
- this approach uses sales speed during in-stock periods, so faster-moving sizes receive higher suggested shares while still remaining stable
- it also gives a practical workflow for products that do not yet have variants

## Notes
- no automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f081e4af64832cb23576c982168dc9)