### PR TITLE
Unify sales-speed calculation and ideal order split logic

### DIFF
--- a/inventory/static/order_split.js
+++ b/inventory/static/order_split.js
@@ -1,0 +1,62 @@
+(function (window) {
+  const normalizeShares = (shares) => {
+    const cleaned = shares.map((value) => {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+    });
+    const totalShare = cleaned.reduce((sum, share) => sum + share, 0);
+    if (totalShare > 0) {
+      return cleaned.map((share) => share / totalShare);
+    }
+    return cleaned.map(() => (cleaned.length ? 1 / cleaned.length : 0));
+  };
+
+  const computeSplit = (totalQuantity, shares) => {
+    const total = Math.max(parseInt(totalQuantity, 10) || 0, 0);
+    if (!Array.isArray(shares) || !shares.length) {
+      return [];
+    }
+
+    const normalized = normalizeShares(shares);
+    const rows = normalized.map((share) => {
+      const rawValue = total * share;
+      const floorValue = Math.floor(rawValue);
+      return {
+        value: floorValue,
+        fraction: rawValue - floorValue,
+      };
+    });
+
+    let remainder = total - rows.reduce((sum, row) => sum + row.value, 0);
+    rows.sort((a, b) => b.fraction - a.fraction);
+
+    let index = 0;
+    while (remainder > 0 && rows.length) {
+      rows[index % rows.length].value += 1;
+      remainder -= 1;
+      index += 1;
+    }
+
+    return rows.map((row) => row.value);
+  };
+
+  const applyIdealSplitToModal = (modal) => {
+    if (!modal) return;
+    const totalInput = modal.querySelector('[data-total-order-input]');
+    if (!totalInput) return;
+    const inputs = Array.from(modal.querySelectorAll('[data-order-qty-input]'));
+    if (!inputs.length) return;
+
+    const shares = inputs.map((input) => input.dataset.sizeShare || '0');
+    const split = computeSplit(totalInput.value, shares);
+    inputs.forEach((input, index) => {
+      const value = split[index] || 0;
+      input.value = value > 0 ? value : '';
+    });
+  };
+
+  window.ProgressPlannerOrderSplit = {
+    computeSplit,
+    applyIdealSplitToModal,
+  };
+})(window);

--- a/inventory/templates/inventory/order_list.html
+++ b/inventory/templates/inventory/order_list.html
@@ -1,4 +1,5 @@
 {% extends 'inventory/base.html' %}
+{% load static %}
 
 {% block title %}Orders{% endblock %}
 
@@ -644,6 +645,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/luxon@3.4.3/build/global/luxon.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1.3.1/dist/chartjs-adapter-luxon.umd.min.js"></script>
+<script src="{% static 'order_split.js' %}"></script>
 <script>
   (function() {
     const filterControllers = [];
@@ -1418,45 +1420,9 @@
     });
 
     const updateOrderSplit = (modal) => {
-      const totalInput = modal.querySelector('[data-total-order-input]');
-      if (!totalInput) return;
-      const total = Math.max(parseInt(totalInput.value, 10) || 0, 0);
-      const rows = Array.from(modal.querySelectorAll('[data-order-qty-input]'));
-      if (!rows.length) return;
-
-      const shares = rows.map((input) => {
-        const parsed = parseFloat(input.dataset.sizeShare || '0');
-        return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-      });
-      const totalShare = shares.reduce((sum, share) => sum + share, 0);
-      const normalized = totalShare > 0
-        ? shares.map((share) => share / totalShare)
-        : shares.map(() => 1 / rows.length);
-
-      const splitRows = rows.map((input, index) => {
-        const rawValue = total * normalized[index];
-        const floorValue = Math.floor(rawValue);
-        return {
-          input,
-          floorValue,
-          fraction: rawValue - floorValue,
-        };
-      });
-
-      let remainder = total - splitRows.reduce((sum, row) => sum + row.floorValue, 0);
-      splitRows.sort((a, b) => b.fraction - a.fraction);
-
-      let index = 0;
-      while (remainder > 0 && splitRows.length) {
-        splitRows[index % splitRows.length].floorValue += 1;
-        remainder -= 1;
-        index += 1;
+      if (window.ProgressPlannerOrderSplit) {
+        window.ProgressPlannerOrderSplit.applyIdealSplitToModal(modal);
       }
-
-      splitRows.forEach((row) => {
-        row.input.value = row.floorValue > 0 ? row.floorValue : '';
-      });
-
       updateOrderProjectionChart(modal);
     };
 

--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -1045,7 +1045,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{% static 'no-restock-toggle.js' %}"></script>
   <script src="{% static 'add-product-form.js' %}"></script>
-  <script>
+<script src="{% static 'order_split.js' %}"></script>
+<script>
     (function() {
       const filterControllers = [];
       const applyButton = document.querySelector('.filter-apply-button');
@@ -1973,39 +1974,8 @@
       };
 
       const updateOrderSplit = (modal) => {
-        const totalInput = modal.querySelector('[data-total-order-input]');
-        if (!totalInput) return;
-        const total = Math.max(parseInt(totalInput.value, 10) || 0, 0);
-        const rows = Array.from(modal.querySelectorAll('[data-order-qty-input]'));
-        if (!rows.length) return;
-        const shares = rows.map((input) => {
-          const parsed = parseFloat(input.dataset.sizeShare || '0');
-          return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-        });
-        const totalShare = shares.reduce((sum, share) => sum + share, 0);
-        const normalized = totalShare > 0
-          ? shares.map((share) => share / totalShare)
-          : shares.map(() => 1 / rows.length);
-
-        const splitRows = rows.map((input, index) => {
-          const rawValue = total * normalized[index];
-          const floorValue = Math.floor(rawValue);
-          return { input, floorValue, fraction: rawValue - floorValue };
-        });
-
-        let remainder = total - splitRows.reduce((sum, row) => sum + row.floorValue, 0);
-        splitRows.sort((a, b) => b.fraction - a.fraction);
-
-        let index = 0;
-        while (remainder > 0 && splitRows.length) {
-          splitRows[index % splitRows.length].floorValue += 1;
-          remainder -= 1;
-          index += 1;
-        }
-
-        splitRows.forEach((row) => {
-          row.input.value = row.floorValue > 0 ? row.floorValue : '';
-        });
+        if (!window.ProgressPlannerOrderSplit) return;
+        window.ProgressPlannerOrderSplit.applyIdealSplitToModal(modal);
       };
 
       document.querySelectorAll('[data-open-order-modal]').forEach((btn) => {

--- a/inventory/utils.py
+++ b/inventory/utils.py
@@ -4,7 +4,7 @@ import json
 
 from collections import defaultdict
 from datetime import date, datetime, timedelta
-from typing import List, Optional, Sequence, Dict, Any, Iterable, Union
+from typing import List, Optional, Sequence, Dict, Any, Iterable, Union, Mapping
 from decimal import Decimal, ROUND_HALF_UP
 
 from dateutil.relativedelta import relativedelta
@@ -996,6 +996,83 @@ def calculate_sales_speed(
     return calculate_sales_speed_for_variants(
         resolved_variants, weeks=weeks, today=today, weight=weight
     )
+
+
+def calculate_sales_speed_by_size(
+    target: Optional[Union[ProductVariant, Product, Iterable[ProductVariant]]] = None,
+    *,
+    variants: Optional[Iterable[ProductVariant]] = None,
+    variant_filters: Optional[dict[str, Any]] = None,
+    weeks: int = 26,
+    today: Optional[date] = None,
+) -> dict[str, float]:
+    """Return a size-keyed monthly sales speed map.
+
+    This is the unified entry-point for places that need per-size sales speed
+    data. Variants sharing the same size are summed together.
+    """
+
+    resolved_variants = _resolve_variants_for_sales_speed(
+        target, variants=variants, variant_filters=variant_filters
+    )
+    speed_map: dict[str, float] = defaultdict(float)
+    for variant in resolved_variants:
+        size_key = (variant.size or "").strip() or variant.variant_code
+        speed_map[size_key] += calculate_sales_speed(
+            variant,
+            weeks=weeks,
+            today=today,
+        )
+    return dict(speed_map)
+
+
+def build_ideal_order_split(
+    total_quantity: int,
+    shares_by_key: Mapping[str, float],
+) -> dict[str, int]:
+    """Allocate ``total_quantity`` into an idealized split using shares.
+
+    Uses largest-remainder rounding so all units are allocated while remaining
+    close to the requested proportions.
+    """
+
+    total = max(int(total_quantity or 0), 0)
+    keys = list(shares_by_key.keys())
+    if not keys:
+        return {}
+
+    cleaned_shares = {
+        key: max(float(shares_by_key.get(key, 0) or 0), 0.0) for key in keys
+    }
+    total_share = sum(cleaned_shares.values())
+    if total_share <= 0:
+        normalized = {key: 1 / len(keys) for key in keys}
+    else:
+        normalized = {key: share / total_share for key, share in cleaned_shares.items()}
+
+    rows = []
+    allocated = 0
+    for key in keys:
+        raw_value = total * normalized[key]
+        floor_value = math.floor(raw_value)
+        allocated += floor_value
+        rows.append(
+            {
+                "key": key,
+                "value": floor_value,
+                "fraction": raw_value - floor_value,
+            }
+        )
+
+    remainder = total - allocated
+    rows.sort(key=lambda row: row["fraction"], reverse=True)
+    index = 0
+    while remainder > 0 and rows:
+        rows[index % len(rows)]["value"] += 1
+        remainder -= 1
+        index += 1
+
+    return {row["key"]: int(row["value"]) for row in rows}
 
 
 def calculate_sell_through_projection(

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -95,8 +95,9 @@ from .utils import (
     compute_product_health,
     get_low_stock_products,
     calculate_sales_speed,
-    calculate_variant_sales_speed,
+    calculate_sales_speed_by_size,
     calculate_months_to_stockout,
+    build_ideal_order_split,
     CORE_SIZES,
     get_variant_speed_map,
     get_category_speed_stats,
@@ -4215,7 +4216,12 @@ def order_list(request):
             product.variants.all()
         )
         stock_by_size: dict[str, int] = defaultdict(int)
-        speed_by_size: dict[str, Decimal] = {}
+        speed_by_size = {
+            size: Decimal(str(speed or 0))
+            for size, speed in calculate_sales_speed_by_size(
+                variants=variants, weeks=26, today=today
+            ).items()
+        }
         out_of_stock_sizes: set[str] = set()
         out_of_stock_variants: set[str] = set()
         total_stock = 0
@@ -4230,9 +4236,6 @@ def order_list(request):
                 out_of_stock_variants.add(variant.variant_code)
             else:
                 has_in_stock = True
-            speed_by_size[size_key] = speed_by_size.get(size_key, Decimal("0")) + Decimal(
-                str(calculate_variant_sales_speed(variant, weeks=26, today=today) or 0)
-            )
 
         on_order_total = pending_product_totals.get(product.id, 0)
         months_remaining = None
@@ -4310,14 +4313,19 @@ def order_list(request):
                 speed for speed in speed_by_size.values() if speed and speed > 0
             )
             if total_speed > 0:
-                for size, speed in sorted(speed_by_size.items()):
-                    if not speed or speed <= 0:
+                share_map = {
+                    size: float(speed / total_speed)
+                    for size, speed in speed_by_size.items()
+                    if speed and speed > 0
+                }
+                ratio_split = build_ideal_order_split(100, share_map)
+                for size, pct in sorted(ratio_split.items()):
+                    if pct <= 0:
                         continue
-                    ratio = float(speed / total_speed)
                     size_ratios.append(
                         {
                             "size": size,
-                            "ratio": round(ratio * 100, 1),
+                            "ratio": round(float(pct), 1),
                         }
                     )
             else:


### PR DESCRIPTION
## Summary
- introduced `calculate_sales_speed_by_size(...)` in `inventory/utils.py` as a single shared way to compute grouped size-level monthly sales speed from a product/variant set
- introduced `build_ideal_order_split(...)` in `inventory/utils.py` to produce deterministic largest-remainder allocations for suggested order quantities
- refactored `order_list` view to use unified sales-speed aggregation helper instead of in-view per-variant speed calculations
- refactored reorder ratio generation to use the new ideal split helper so ratio outputs are generated through one canonical algorithm
- extracted duplicate front-end order split code into `inventory/static/order_split.js` and wired both `order_list.html` and `product_filtered_list.html` to it

## Why
This removes duplicated sales-speed/split logic spread across view and templates, making behavior consistent and easier to maintain.

## Notes
- No test execution was performed in this run (static refactor only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f088eb67c4832cac2d12d9f4c8480e)