### PR TITLE
Preserve variant order when computing splits, show suggested splits in templates, refine size-mix calculation and add test

### DIFF
--- a/inventory/static/order_split.js
+++ b/inventory/static/order_split.js
@@ -18,10 +18,11 @@
     }
 
     const normalized = normalizeShares(shares);
-    const rows = normalized.map((share) => {
+    const rows = normalized.map((share, index) => {
       const rawValue = total * share;
       const floorValue = Math.floor(rawValue);
       return {
+        index,
         value: floorValue,
         fraction: rawValue - floorValue,
       };
@@ -37,6 +38,7 @@
       index += 1;
     }
 
+    rows.sort((a, b) => a.index - b.index);
     return rows.map((row) => row.value);
   };
 

--- a/inventory/templates/inventory/snippets/product_card.html
+++ b/inventory/templates/inventory/snippets/product_card.html
@@ -194,6 +194,7 @@
                 <th>SKU</th>
                 <th>Stock</th>
                 <th>Sales speed (6 mo)</th>
+                <th>Suggested split</th>
                 <th>Order Qty</th>
               </tr>
             </thead>
@@ -208,6 +209,13 @@
                       {{ variant.sales_speed_6_months|floatformat:1 }} / month
                     {% else %}
                       —
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if variant.size_sales_share %}
+                      {% widthratio variant.size_sales_share 1 100 %}%
+                    {% else %}
+                      0%
                     {% endif %}
                   </td>
                   <td>
@@ -228,7 +236,7 @@
                 </tr>
               {% empty %}
                 <tr>
-                  <td colspan="5" class="grey-text">No variants available.</td>
+                  <td colspan="6" class="grey-text">No variants available.</td>
                 </tr>
               {% endfor %}
             </tbody>

--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -282,6 +282,8 @@
                   <th>Variant</th>
                   <th>Size</th>
                   <th>Current stock</th>
+                  <th>Sales speed (6 mo)</th>
+                  <th>Suggested split</th>
                   <th>Suggested qty</th>
                 </tr>
               </thead>
@@ -291,6 +293,20 @@
                     <td>{{ variant.variant_code }}</td>
                     <td>{{ variant.size|default:"—" }}</td>
                     <td>{{ variant.latest_inventory|default:0 }}</td>
+                    <td>
+                      {% if variant.sales_speed_6_months is not None %}
+                        {{ variant.sales_speed_6_months|floatformat:1 }} / month
+                      {% else %}
+                        —
+                      {% endif %}
+                    </td>
+                    <td>
+                      {% if variant.size_sales_share %}
+                        {% widthratio variant.size_sales_share 1 100 %}%
+                      {% else %}
+                        0%
+                      {% endif %}
+                    </td>
                     <td>
                       <input
                         type="number"

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -35,6 +35,7 @@ from .models import (
 from django.urls import reverse
 from .admin import SaleAdmin, SaleDateEqualsFilter
 from .utils import (
+    build_ideal_order_split,
     get_low_stock_products,
     get_restock_alerts,
     calculate_variant_sales_speed,
@@ -566,6 +567,106 @@ class CategorySizeMixTests(TestCase):
         stats = get_product_cohort_speed_stats(target, weeks=4, today=today)
         self.assertIn("S", stats["size_avgs"])
         self.assertNotIn("L", stats["size_avgs"])
+
+    def test_category_size_mix_uses_all_matching_variants_for_ratio(self):
+        today = date.today()
+        target = Product.objects.create(
+            product_id="P-MIX-RATIO-T",
+            product_name="Ratio Target",
+            type="ng",
+            subtype="ss",
+            age="adult",
+        )
+        target_variants = {
+            "S": ProductVariant.objects.create(
+                product=target, variant_code="R-T-S", primary_color="#000000", size="S"
+            ),
+            "M": ProductVariant.objects.create(
+                product=target, variant_code="R-T-M", primary_color="#000000", size="M"
+            ),
+            "L": ProductVariant.objects.create(
+                product=target, variant_code="R-T-L", primary_color="#000000", size="L"
+            ),
+        }
+
+        cohort_product = Product.objects.create(
+            product_id="P-MIX-RATIO-C",
+            product_name="Ratio Cohort",
+            type="ng",
+            subtype="ss",
+            age="adult",
+        )
+        cohort_variants = {
+            "S": ProductVariant.objects.create(
+                product=cohort_product,
+                variant_code="R-C-S",
+                primary_color="#000000",
+                size="S",
+            ),
+            "M": ProductVariant.objects.create(
+                product=cohort_product,
+                variant_code="R-C-M",
+                primary_color="#000000",
+                size="M",
+            ),
+            "L": ProductVariant.objects.create(
+                product=cohort_product,
+                variant_code="R-C-L",
+                primary_color="#000000",
+                size="L",
+            ),
+        }
+
+        all_matching_variants = list(target_variants.values()) + list(
+            cohort_variants.values()
+        )
+        for variant in all_matching_variants:
+            InventorySnapshot.objects.create(
+                product_variant=variant,
+                date=today - timedelta(weeks=8),
+                inventory_count=500,
+            )
+            InventorySnapshot.objects.create(
+                product_variant=variant,
+                date=today,
+                inventory_count=400,
+            )
+
+        for i in range(8):
+            Sale.objects.create(
+                order_number=f"R-S-{i}",
+                date=today - timedelta(weeks=i),
+                variant=cohort_variants["S"],
+                sold_quantity=2,
+                sold_value=20,
+            )
+            Sale.objects.create(
+                order_number=f"R-M-{i}",
+                date=today - timedelta(weeks=i),
+                variant=cohort_variants["M"],
+                sold_quantity=8,
+                sold_value=80,
+            )
+            Sale.objects.create(
+                order_number=f"R-L-{i}",
+                date=today - timedelta(weeks=i),
+                variant=cohort_variants["L"],
+                sold_quantity=4,
+                sold_value=40,
+            )
+
+        mix = calculate_category_size_mix(
+            target,
+            target_sizes=["S", "M", "L"],
+            long_weeks=8,
+            recent_weeks=4,
+            today=today,
+        )
+        split = build_ideal_order_split(100, mix["shares"])
+
+        self.assertEqual(split.get("S"), 14)
+        self.assertEqual(split.get("M"), 57)
+        self.assertEqual(split.get("L"), 29)
 
 
 class ProductAdminFormTests(TestCase):

--- a/inventory/utils.py
+++ b/inventory/utils.py
@@ -658,48 +658,35 @@ def calculate_category_size_mix(
     today = today or date.today()
     variant_qs = get_product_cohort_variant_queryset(product)
 
-    variants = list(variant_qs.select_related("product").prefetch_related("sales", "snapshots"))
+    variants = list(
+        variant_qs.select_related("product").prefetch_related("sales", "snapshots")
+    )
     size_scores: Dict[str, float] = defaultdict(float)
     total_active_weeks = 0
-    requested_sizes = [size for size in (target_sizes or []) if size]
+    requested_sizes = []
+    seen_sizes = set()
+    for raw_size in target_sizes or []:
+        normalized = (raw_size or "").strip()
+        if not normalized or normalized in seen_sizes:
+            continue
+        seen_sizes.add(normalized)
+        requested_sizes.append(normalized)
 
     for candidate in variants:
-        long_detail = calculate_variant_sales_speed_details(
-            candidate, weeks=long_weeks, today=today, fallback_weeks=long_weeks
-        )
-        recent_detail = calculate_variant_sales_speed_details(
-            candidate, weeks=recent_weeks, today=today, fallback_weeks=recent_weeks
-        )
-
-        long_speed = float(long_detail.get("speed") or 0.0)
-        recent_speed = float(recent_detail.get("speed") or 0.0)
-        if long_speed <= 0 and recent_speed <= 0:
+        size_key = (candidate.size or "").strip()
+        if not size_key:
             continue
-
-        # Base demand estimate: stable long-term + recency signal.
-        blended_speed = (long_speed * 0.65) + (recent_speed * 0.35)
-
-        # Momentum scaling to react to changing demand but keep bounded.
-        if long_speed > 0 and recent_speed > 0:
-            momentum_ratio = max(0.75, min(1.35, recent_speed / long_speed))
-        else:
-            momentum_ratio = 1.0
-
-        # Reliability weighting based on in-stock observation coverage.
-        active_weeks = max(
-            int(long_detail.get("active_weeks") or 0),
-            int(recent_detail.get("active_weeks") or 0),
+        detail = calculate_variant_sales_speed_details(
+            candidate,
+            weeks=long_weeks,
+            today=today,
+            fallback_weeks=max(long_weeks, recent_weeks),
         )
-        reliability = max(min(active_weeks / max(long_weeks, 1), 1.0), 0.25)
-
-        stockout_boost = (
-            1.08
-            if long_detail.get("had_stockout") or recent_detail.get("had_stockout")
-            else 1.0
-        )
-        score = blended_speed * momentum_ratio * reliability * stockout_boost
-        size_scores[candidate.size] += score
-        total_active_weeks += active_weeks
+        speed = float(detail.get("speed") or 0.0)
+        if speed <= 0:
+            continue
+        size_scores[size_key] += speed
+        total_active_weeks += int(detail.get("active_weeks") or 0)
 
     if requested_sizes:
         size_scores = {size: size_scores.get(size, 0.0) for size in requested_sizes}


### PR DESCRIPTION
### Motivation
- Ensure the ideal order split algorithm returns quantities in the original variant order after distributing rounding remainder. 
- Surface sales speed and the computed "Suggested split" in product order UIs so users can see recommendations. 
- Make category size-mix calculations more robust by normalizing requested sizes and using a simpler, consistent sales-speed detail for scoring.

### Description
- Updated `computeSplit` in `inventory/static/order_split.js` to track each entry's original `index`, distribute remainder by fractional priority, and then restore the original ordering before returning final quantities. 
- Kept `applyIdealSplitToModal` API intact and exported `computeSplit` for reuse. 
- Added a "Suggested split" column and displayed sales speed in `product_card.html` and `product_scorecard.html`, and adjusted table colspan where needed. 
- Refactored `calculate_category_size_mix` in `inventory/utils.py` to normalize and deduplicate `target_sizes`, skip variants missing size, use a single call to `calculate_variant_sales_speed_details` (with a safe `fallback_weeks`), and aggregate speed-based scores and active weeks for size shares. 
- Added import of `build_ideal_order_split` to `inventory/tests.py` and introduced a new test `test_category_size_mix_uses_all_matching_variants_for_ratio` that builds cohorts, sales, and snapshots, computes the mix and verifies the integer split distribution for a sample total (100). 

### Testing
- Ran the Django inventory test suite including the new `CategorySizeMixTests.test_category_size_mix_uses_all_matching_variants_for_ratio` test via `./manage.py test inventory`, and the tests passed. 
- Verified the new template changes render extra columns and the JS `computeSplit` maintains original order while distributing rounding remainder in manual UI checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08fcd1c50832c95ad2442adad73ab)