### PR TITLE
Restyle primary navigation to match mockup

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -11,6 +11,75 @@ body {
     "GRAD" 0;
 }
 
+.app-shell {
+  background: #35363a;
+}
+
+.app-nav {
+  background: #f7f7f5;
+  border-bottom: 1px solid #d9d6d0;
+  box-shadow: none;
+  margin: 44px auto 0;
+  width: min(1320px, calc(100% - 64px));
+}
+
+.app-nav .nav-wrapper.app-nav__inner {
+  align-items: center;
+  display: flex;
+  min-height: 88px;
+  padding: 0 24px;
+}
+
+.app-nav .brand-logo.app-nav__brand {
+  color: #2d2d2f;
+  font-size: 2.1rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  position: static;
+  transform: none;
+}
+
+.app-nav .app-nav__links {
+  align-items: stretch;
+  display: flex;
+  gap: 28px;
+  margin-left: 72px;
+}
+
+.app-nav .app-nav__links li {
+  float: none;
+  line-height: 1;
+}
+
+.app-nav .app-nav__links li a {
+  border-bottom: 2px solid transparent;
+  color: #8a8578;
+  font-size: 1.2rem;
+  font-weight: 400;
+  line-height: 1;
+  padding: 34px 14px 32px;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.app-nav .app-nav__links li.active a,
+.app-nav .app-nav__links li a:hover {
+  background: transparent;
+  border-bottom-color: #4a4a4a;
+  color: #2f2f31;
+}
+
+.app-nav .app-nav__links li a:focus {
+  background: transparent;
+}
+
+main .container {
+  background: #f7f7f5;
+  margin-top: 0;
+  padding-top: 24px;
+  width: min(1320px, calc(100% - 64px));
+}
+
 
 
 main {
@@ -816,12 +885,6 @@ main {
 :where(.card, .card-panel).yellow.accent-2 { --card-border-color: #ffea00; }
 :where(.card, .card-panel).yellow.accent-3 { --card-border-color: #ffd600; }
 :where(.card, .card-panel).yellow.accent-4 { --card-border-color: #ffd600; }
-
-a.brand-logo img {
-  width: 150px;
-  margin: 20px 0;
-}
-
 
 div.metadata {
   padding: 10px;

--- a/inventory/templates/inventory/base.html
+++ b/inventory/templates/inventory/base.html
@@ -23,21 +23,20 @@
 
 </head>
 
-<body class="grey lighten-5">
+<body class="grey lighten-5 app-shell">
 
 <header>
-  <!-- Top Navbar -->
-  <nav class="grey lighten-5">
-    <div class="nav-wrapper container">
-      <a href="{% url 'home' %}" class="brand-logo"><img src="/media/logo.png"></a>
-      <ul class="right hide-on-med-and-down">
-        <li class="{% if request.resolver_match.url_name == 'home' %}active{% endif %}"><a href="{% url 'home' %}">Home</a></li>
+  <nav class="app-nav">
+    <div class="nav-wrapper container app-nav__inner">
+      <a href="{% url 'home' %}" class="brand-logo app-nav__brand">ProgressPlanner</a>
+      <ul class="right hide-on-med-and-down app-nav__links">
+        <li class="{% if request.resolver_match.url_name == 'home' %}active{% endif %}"><a href="{% url 'home' %}">Dashboard</a></li>
         <li class="{% if request.resolver_match.url_name == 'product_filtered' or request.resolver_match.url_name == 'product_list' or request.resolver_match.url_name == 'product_type_list' or request.resolver_match.url_name == 'product_style_list' or request.resolver_match.url_name == 'product_group_list' or request.resolver_match.url_name == 'product_series_list' %}active{% endif %}"><a href="{% url 'product_filtered' %}">Products</a></li>
-        <li class="{% if request.resolver_match.url_name == 'product_canvas' %}active{% endif %}"><a href="{% url 'product_canvas' %}">Product Canvas</a></li>
         <li class="{% if request.resolver_match.url_name == 'inventory_snapshots' %}active{% endif %}"><a href="{% url 'inventory_snapshots' %}">Inventory</a></li>
         <li class="{% if request.resolver_match.url_name == 'order_list' %}active{% endif %}"><a href="{% url 'order_list' %}">Orders</a></li>
         <li class="{% if request.resolver_match.url_name == 'sales' %}active{% endif %}"><a href="{% url 'sales' %}">Sales</a></li>
-        <li class=""><a href="{% url 'admin:index' %}" class="active">Admin</a></li>
+        <li class="{% if request.resolver_match.url_name == 'product_canvas' %}active{% endif %}"><a href="{% url 'product_canvas' %}">Canvas</a></li>
+        <li><a href="{% url 'admin:index' %}">Admin</a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
### Motivation
- Update the shared header to match a minimalist mock: a centered tab-style top navigation with a muted inactive state and an underlined active tab. 
- Make the page read as a single surface by aligning the main content container with the new nav panel and switching to a text wordmark for the brand.

### Description
- Reworked the header markup in `inventory/templates/inventory/base.html` to use a new `app-nav` structure, added `app-shell` on the `body`, and replaced the logo image with the `ProgressPlanner` wordmark. 
- Reordered and relabeled top-level links to a dashboard-style set (`Dashboard`, `Products`, `Inventory`, `Orders`, `Sales`, `Canvas`, `Admin`) while preserving existing route `url` calls and active-state logic. 
- Added new styles to `inventory/static/styles.css` for `.app-shell`, `.app-nav`, `.app-nav__inner`, `.app-nav__brand`, and `.app-nav__links` to implement the light surface, subtle bottom divider, muted inactive labels, active underline, and horizontal spacing. 
- Adjusted nav link typography (`font-size` to `1.2rem`) and removed the old `a.brand-logo img` sizing rule, and aligned `main .container` width/background with the nav panel.

### Testing
- Ran `python manage.py check` to validate the project, which failed in this environment because `django` is not installed (test could not complete).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0fd1754cc832c912d9c747e891189)