### PR TITLE
Use media/logo2.png as navbar brand image

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -33,13 +33,17 @@ nav, nav .nav-wrapper i, nav a.sidenav-trigger, nav a.sidenav-trigger i {
 }
 
 .app-nav .brand-logo.app-nav__brand {
-  color: #2d2d2f;
-  font-size: 2.1rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  align-items: center;
+  display: inline-flex;
   line-height: 1;
   position: static;
   transform: none;
+}
+
+.app-nav .app-nav__brand-image {
+  display: block;
+  height: 44px;
+  width: auto;
 }
 
 .app-nav .app-nav__links {

--- a/inventory/templates/inventory/base.html
+++ b/inventory/templates/inventory/base.html
@@ -28,7 +28,9 @@
 <header>
   <nav class="app-nav">
     <div class="nav-wrapper container app-nav__inner">
-      <a href="{% url 'home' %}" class="brand-logo app-nav__brand">ProgressPlanner</a>
+      <a href="{% url 'home' %}" class="brand-logo app-nav__brand" aria-label="ProgressPlanner Home">
+        <img src="/media/logo2.png" alt="ProgressPlanner" class="app-nav__brand-image">
+      </a>
       <ul class="right hide-on-med-and-down app-nav__links">
         <li class="{% if request.resolver_match.url_name == 'home' %}active{% endif %}"><a href="{% url 'home' %}">Dashboard</a></li>
         <li class="{% if request.resolver_match.url_name == 'product_filtered' or request.resolver_match.url_name == 'product_list' or request.resolver_match.url_name == 'product_type_list' or request.resolver_match.url_name == 'product_style_list' or request.resolver_match.url_name == 'product_group_list' or request.resolver_match.url_name == 'product_series_list' %}active{% endif %}"><a href="{% url 'product_filtered' %}">Products</a></li>


### PR DESCRIPTION
### Motivation
- Replace the text-based site brand in the top-left navigation with the provided logo image so the site shows the visual brand instead of the text `ProgressPlanner`.
- Ensure the brand link remains a link to the home page and remains accessible when the visible text is removed.

### Description
- Updated `inventory/templates/inventory/base.html` to replace the text brand with an image element pointing to `/media/logo2.png` and added an `aria-label` on the anchor to preserve accessibility.
- Updated `inventory/static/styles.css` to use `inline-flex` alignment for the brand container and added `.app-nav__brand-image` rules to constrain the logo height and preserve aspect ratio.
- Kept the existing home link behavior and adjusted layout so the navigation links align correctly next to the image.

### Testing
- Ran `python manage.py check`, which failed in this environment because `django` is not installed and therefore could not validate the project; no other automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11afac25c832caeae2b056b563933)