### PR TITLE
Remove Series filter from Products and show Apply only when expanded

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -24,10 +24,8 @@
 
     .filter-section-header {
       display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      gap: 0px;
-      margin: 0px;
+      justify-content: flex-end;
+      margin-top: 8px;
     }
 
     .filter-title {
@@ -660,14 +658,6 @@
       {% if search_query %}
         <input type="hidden" name="product_search" value="{{ search_query }}">
       {% endif %}
-      <div class="filter-section-header">
-        <button type="submit" class="btn filter-apply-button" disabled>
-          Apply
-        </button>
-      </div>
-
-
-
       <div class="filter-bar">
         {% if category_filter %}
           <div
@@ -767,6 +757,11 @@
           {% endwith %}
         {% endfor %}
 
+      </div>
+      <div class="filter-section-header" hidden data-filter-apply-container>
+        <button type="submit" class="btn filter-apply-button" disabled>
+          Apply
+        </button>
       </div>
       <div class="filter-divider"></div>
     </form>
@@ -1064,6 +1059,7 @@
     (function() {
       const filterControllers = [];
       const applyButton = document.querySelector('.filter-apply-button');
+      const applyContainer = document.querySelector('[data-filter-apply-container]');
 
       const selectionsDiffer = (a, b) => {
         if (a.length !== b.length) return true;
@@ -1081,6 +1077,12 @@
 
         applyButton.disabled = !isDirty;
         applyButton.classList.toggle('is-dirty', isDirty);
+      };
+
+      const rebuildApplyVisibility = () => {
+        if (!applyContainer) return;
+        const hasExpandedFilter = filterControllers.some((controller) => controller.isExpanded());
+        applyContainer.hidden = !hasExpandedFilter;
       };
 
       const parseJsonScript = (id, fallback = []) => {
@@ -1547,6 +1549,7 @@
       });
 
       rebuildApplyState();
+      rebuildApplyVisibility();
 
       const setAllExpanded = (expanded) => {
         filterControllers.forEach((controller) => controller.setExpanded(expanded));
@@ -1559,6 +1562,7 @@
             const allExpanded = filterControllers.every((c) => c.isExpanded());
             const newState = !allExpanded;
             setAllExpanded(newState);
+            rebuildApplyVisibility();
           });
         });
       });

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1103,10 +1103,6 @@ def _build_product_list_context(request, preset_filters=None):
         group_filters = [gid.strip() for gid in request.GET.getlist("group_filter") if gid]
     group_filters = [str(g) for g in group_filters]
 
-    series_filters = preset_filters.get("series_filters")
-    if series_filters is None:
-        series_filters = [sid.strip() for sid in request.GET.getlist("series_filter") if sid]
-    series_filters = [str(s) for s in series_filters]
 
     zero_inventory = _get_filter("zero_inventory", "false")
     zero_inventory = zero_inventory if isinstance(zero_inventory, bool) else str(zero_inventory).lower() == "true"
@@ -1183,8 +1179,6 @@ def _build_product_list_context(request, preset_filters=None):
     if group_filters:
         products_qs = products_qs.filter(groups__id__in=group_filters).distinct()
 
-    if series_filters:
-        products_qs = products_qs.filter(series__id__in=series_filters).distinct()
 
     if clearance_only:
         products_qs = products_qs.filter(discounted=True)
@@ -1591,7 +1585,6 @@ def _build_product_list_context(request, preset_filters=None):
         "age_filter": age_filters[0] if age_filters else None,
         "age_filters": age_filters,
         "group_filters": group_filters,
-        "series_filters": series_filters,
         "option_filters": option_filters,
         "zero_inventory": zero_inventory,
         "clearance_only": clearance_only,
@@ -1601,7 +1594,6 @@ def _build_product_list_context(request, preset_filters=None):
         "style_choices": PRODUCT_STYLE_CHOICES,
         "age_choices": PRODUCT_AGE_CHOICES,
         "group_choices": Group.objects.all(),
-        "series_choices": Series.objects.all(),
         "sitewide_average_discount": sitewide_average_discount,
     }
 
@@ -1849,7 +1841,6 @@ def _render_filtered_products(
     style_selected = set(context.get("style_filters", []))
     age_selected = set(context.get("age_filters", []))
     group_selected = set(context.get("group_filters", []))
-    series_selected = set(context.get("series_filters", []))
     option_selected = set(context.get("option_filters", []))
 
     category_filter_control = {
@@ -1904,18 +1895,6 @@ def _render_filtered_products(
                     "checked": str(group.id) in group_selected,
                 }
                 for group in (context.get("group_choices") or Group.objects.all())
-            ],
-        ),
-        build_control(
-            "series",
-            "series_filter",
-            [
-                {
-                    "value": str(series.id),
-                    "label": series.name,
-                    "checked": str(series.id) in series_selected,
-                }
-                for series in (context.get("series_choices") or Series.objects.all())
             ],
         ),
         build_control(
@@ -3266,7 +3245,6 @@ def _build_filter_controls_context(
     style_selected = set(context.get("style_filters", []))
     age_selected = set(context.get("age_filters", []))
     group_selected = set(context.get("group_filters", []))
-    series_selected = set(context.get("series_filters", []))
 
     category_filter_control = {
         "styles": [
@@ -3322,18 +3300,6 @@ def _build_filter_controls_context(
                 for group in (context.get("group_choices") or Group.objects.all())
             ],
         ),
-        build_control(
-            "series",
-            "series_filter",
-            [
-                {
-                    "value": str(series.id),
-                    "label": series.name,
-                    "checked": str(series.id) in series_selected,
-                }
-                for series in (context.get("series_choices") or Series.objects.all())
-            ],
-        ),
     ]
 
     if category:
@@ -3378,7 +3344,6 @@ def product_filtered(request):
         ("style_filter", "style"),
         ("age_filter", "age"),
         ("group_filter", "group"),
-        ("series_filter", "series"),
         ("option_filter", "options"),
         ("show_retired", "options"),
         ("clearance_only", "options"),


### PR DESCRIPTION
### Motivation
- The Products page should not include a Series filter anymore and the UI should only show the Apply button when filter categories are expanded.

### Description
- Removed all server-side parsing and queryset application of `series_filter` and removed `series` control construction so Series no longer participates in product filtering (`inventory/views.py`).
- Removed `series_choices` and `series_filters` from the template/context so Series is not exposed to the Products filter bar (`inventory/views.py`).
- Moved the Apply button to the bottom-right of the filter area in the Products template and wrapped it in a container element that can be shown/hidden (`inventory/templates/inventory/product_filtered_list.html`).
- Added client-side logic `rebuildApplyVisibility` and wiring so the Apply container is hidden when all filters are collapsed and shown when any filter category is expanded (`inventory/templates/inventory/product_filtered_list.html`).

### Testing
- Attempted `python manage.py check` in this environment, which failed because Django is not installed here (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22f586e40832cb610b674b3762fec)