### PR TITLE
Sync create-order modal variant edits to total and preserve previous page after save

### DIFF
--- a/inventory/static/order_split.js
+++ b/inventory/static/order_split.js
@@ -57,8 +57,20 @@
     });
   };
 
+  const syncTotalFromVariantInputs = (modal) => {
+    if (!modal) return;
+    const totalInput = modal.querySelector('[data-total-order-input]');
+    if (!totalInput) return;
+    const total = Array.from(modal.querySelectorAll('[data-order-qty-input]')).reduce((sum, input) => {
+      const value = parseInt(input.value, 10);
+      return sum + (Number.isFinite(value) && value > 0 ? value : 0);
+    }, 0);
+    totalInput.value = total > 0 ? String(total) : '';
+  };
+
   window.ProgressPlannerOrderSplit = {
     computeSplit,
     applyIdealSplitToModal,
+    syncTotalFromVariantInputs,
   };
 })(window);

--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -2014,6 +2014,13 @@
         if (totalInput) {
           totalInput.addEventListener('input', () => updateOrderSplit(modal));
         }
+
+        modal.querySelectorAll('[data-order-qty-input]').forEach((input) => {
+          input.addEventListener('input', () => {
+            if (!window.ProgressPlannerOrderSplit) return;
+            window.ProgressPlannerOrderSplit.syncTotalFromVariantInputs(modal);
+          });
+        });
       });
 
       if (!dataPoints || !dataPoints.length || !document.getElementById('quarterlySalesChart')) {

--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -246,6 +246,7 @@
       <form method="post" action="{% url 'order_item_create' %}" class="product-order-form" data-order-form data-create-action="{% url 'order_item_create' %}" style="width: 100%;">
         {% csrf_token %}
         <input type="hidden" name="product_id" value="{{ product.id }}">
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
         <div class="product-order-modal__table">
           <div class="product-order-modal__product-head">
             <div>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -4819,6 +4819,10 @@ def order_list(request):
 
 @require_POST
 def order_item_create(request):
+    next_url = (request.POST.get("next") or "").strip()
+    if not next_url.startswith("/"):
+        next_url = reverse("product_filtered")
+
     item_cost = request.POST.get("item_cost_price")
     date_expected = request.POST.get("date_expected")
     create_variants = request.POST.get("create_variants") in {"1", "true", "on", "yes"}
@@ -4844,7 +4848,7 @@ def order_item_create(request):
                 size=size,
                 primary_color=None,
             )
-        return redirect("order_list")
+        return redirect(next_url)
 
     if not item_cost or not date_expected:
         return HttpResponseBadRequest("Missing cost or expected date.")
@@ -4882,7 +4886,7 @@ def order_item_create(request):
     if not created:
         return HttpResponseBadRequest("No quantities provided.")
 
-    return redirect("order_list")
+    return redirect(next_url)
 
 
 @require_POST


### PR DESCRIPTION
### Motivation
- Users expect the modal `Total order quantity` to reflect manual edits to individual variant quantities so the displayed total stays correct.  
- Saving the create-order form currently forces a redirect to the heavier Orders page, causing perceived slowness and breaking the Products workflow.  
- Provide a simple mechanism to return users to the page they came from after saving (e.g. Products) to preserve context.

### Description
- Added `syncTotalFromVariantInputs` to `inventory/static/order_split.js` and exposed it on `window.ProgressPlannerOrderSplit` so variant input edits can update the total (`syncTotalFromVariantInputs`).
- Wired per-variant `input` listeners in `inventory/templates/inventory/product_filtered_list.html` to call `window.ProgressPlannerOrderSplit.syncTotalFromVariantInputs(modal)` when variant quantities change.  
- Inserted a hidden `next` form field in the create-order form (`inventory/templates/inventory/snippets/product_scorecard.html`) using `{{ request.get_full_path }}` so the form posts the current page as the return target.  
- Updated `order_item_create` in `inventory/views.py` to read `next` from `request.POST`, validate it starts with `/` and fall back to `reverse('product_filtered')` if not, and to `redirect(next_url)` after creating variants or order items instead of always redirecting to the Orders list.

### Testing
- Attempted `python manage.py check` which was run as an automated environment check and failed because Django is not installed in this environment, so full Django checks could not be completed (error: "Couldn't import Django").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4987c537c832c9fc4b23ff85c0c8b)