### PR TITLE
Sync order modal totals, normalize size stats, preserve return URL, and harden JS init

### DIFF
--- a/inventory/static/add-product-form.js
+++ b/inventory/static/add-product-form.js
@@ -26,6 +26,10 @@ document.addEventListener('DOMContentLoaded', function () {
   const photoDropzone = document.getElementById('product-photo-dropzone');
   const photoFilename = document.getElementById('product-photo-filename');
 
+  if (!form || !stepLabel || !nextBtn || !backBtn || !saveBtn) {
+    return;
+  }
+
   let step = 1;
 
   const selectElements = form.querySelectorAll('select');
@@ -68,7 +72,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const setStep = (nextStep) => {
     step = Math.max(1, Math.min(3, nextStep));
     steps.forEach((panel, index) => panel.classList.toggle('is-active', index === step - 1));
-    stepLabel.textContent = `Step ${step} of 3`;
+    if (stepLabel) stepLabel.textContent = `Step ${step} of 3`;
     backBtn.disabled = step === 1;
     nextBtn.hidden = step === 3;
     saveBtn.hidden = step !== 3;

--- a/inventory/static/order_split.js
+++ b/inventory/static/order_split.js
@@ -57,8 +57,20 @@
     });
   };
 
+  const syncTotalFromVariantInputs = (modal) => {
+    if (!modal) return;
+    const totalInput = modal.querySelector('[data-total-order-input]');
+    if (!totalInput) return;
+    const total = Array.from(modal.querySelectorAll('[data-order-qty-input]')).reduce((sum, input) => {
+      const value = parseInt(input.value, 10);
+      return sum + (Number.isFinite(value) && value > 0 ? value : 0);
+    }, 0);
+    totalInput.value = total > 0 ? String(total) : '';
+  };
+
   window.ProgressPlannerOrderSplit = {
     computeSplit,
     applyIdealSplitToModal,
+    syncTotalFromVariantInputs,
   };
 })(window);

--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -2014,6 +2014,13 @@
         if (totalInput) {
           totalInput.addEventListener('input', () => updateOrderSplit(modal));
         }
+
+        modal.querySelectorAll('[data-order-qty-input]').forEach((input) => {
+          input.addEventListener('input', () => {
+            if (!window.ProgressPlannerOrderSplit) return;
+            window.ProgressPlannerOrderSplit.syncTotalFromVariantInputs(modal);
+          });
+        });
       });
 
       if (!dataPoints || !dataPoints.length || !document.getElementById('quarterlySalesChart')) {

--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -246,6 +246,7 @@
       <form method="post" action="{% url 'order_item_create' %}" class="product-order-form" data-order-form data-create-action="{% url 'order_item_create' %}" style="width: 100%;">
         {% csrf_token %}
         <input type="hidden" name="product_id" value="{{ product.id }}">
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
         <div class="product-order-modal__table">
           <div class="product-order-modal__product-head">
             <div>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1768,6 +1768,18 @@ def product_order_mix_stats(request, product_id: int):
     )
     size_share_map = mix.get("shares", {})
 
+    def _norm_size(value):
+        return (value or "").strip().upper()
+
+    normalized_speed_map = {
+        _norm_size(size): float(speed or 0.0)
+        for size, speed in cohort_size_speed_map.items()
+    }
+    normalized_share_map = {
+        _norm_size(size): float(share or 0.0)
+        for size, share in size_share_map.items()
+    }
+
     payload = {
         "product_id": product.id,
         "method": mix.get("method"),
@@ -1780,8 +1792,8 @@ def product_order_mix_stats(request, product_id: int):
             {
                 "variant_id": variant.id,
                 "size": variant.size,
-                "sales_speed": float(cohort_size_speed_map.get(variant.size, 0.0) or 0.0),
-                "size_share": float(size_share_map.get(variant.size, 0.0) or 0.0),
+                "sales_speed": normalized_speed_map.get(_norm_size(variant.size), 0.0),
+                "size_share": normalized_share_map.get(_norm_size(variant.size), 0.0),
             }
             for variant in variants
         ],
@@ -4819,6 +4831,10 @@ def order_list(request):
 
 @require_POST
 def order_item_create(request):
+    next_url = (request.POST.get("next") or "").strip()
+    if not next_url.startswith("/"):
+        next_url = reverse("product_filtered")
+
     item_cost = request.POST.get("item_cost_price")
     date_expected = request.POST.get("date_expected")
     create_variants = request.POST.get("create_variants") in {"1", "true", "on", "yes"}
@@ -4844,7 +4860,7 @@ def order_item_create(request):
                 size=size,
                 primary_color=None,
             )
-        return redirect("order_list")
+        return redirect(next_url)
 
     if not item_cost or not date_expected:
         return HttpResponseBadRequest("Missing cost or expected date.")
@@ -4882,7 +4898,7 @@ def order_item_create(request):
     if not created:
         return HttpResponseBadRequest("No quantities provided.")
 
-    return redirect("order_list")
+    return redirect(next_url)
 
 
 @require_POST


### PR DESCRIPTION
### Motivation

- Ensure the Create Order modal behaves reliably when users edit per-variant quantities and when JavaScript elements are missing. 
- Match variant sizes consistently between cohort stats and product variants so recommendation lookups succeed regardless of whitespace/casing. 
- Preserve the originating list view after creating variants or order items so users are returned to the same page.

### Description

- Added a guard in `inventory/static/add-product-form.js` to bail out early when required DOM elements are missing and avoid errors when updating step labels. 
- Introduced `syncTotalFromVariantInputs` in `inventory/static/order_split.js` and exported it on `window.ProgressPlannerOrderSplit` to compute and populate the total order input from per-variant quantity fields. 
- Wired up per-variant `input` listeners in `inventory/templates/inventory/product_filtered_list.html` to call `syncTotalFromVariantInputs` so the total updates as users type. 
- Normalized size keys in `product_order_mix_stats` in `inventory/views.py` by stripping/uppercasing size strings before computing `sales_speed` and `size_share` so size lookups are case/whitespace insensitive. 
- Added a hidden `next` input to the order modal form in `inventory/templates/inventory/snippets/product_scorecard.html` containing `request.get_full_path` and updated `order_item_create` in `inventory/views.py` to redirect back to that `next` path (with safety check) after creating variants or order items instead of always redirecting to `order_list`.

### Testing

- Ran the Django inventory test suite with `./manage.py test inventory` and all tests completed successfully. 
- Executed a quick integration smoke check of the Create Order modal flows including variant quantity edits and form submits, and the total sync and redirects behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4987c537c832c9fc4b23ff85c0c8b)