### PR TITLE
Add 'Create reorder' quick action to product scorecard

### DIFF
--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -94,6 +94,18 @@
                     <span class="signal-muted">|</span>
                     av. discount {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
                   </p>
+                  {% if not product.no_restock %}
+                    <p class="signal-line" style="margin-top: 6px;">
+                      <button
+                        type="button"
+                        class="btn-flat"
+                        data-open-order-modal="order-modal-{{ product.id }}"
+                        data-order-mode="create"
+                      >
+                        Create reorder
+                      </button>
+                    </p>
+                  {% endif %}
                 {% elif product.is_on_order_no_sales %}
                   <hr/>
                   <p class="signal-line">


### PR DESCRIPTION
### Motivation
- Provide a small, discoverable quick action on normal products (not new/unlaunched and not on-order-without-sales) to launch the same overlay ordering form used for `Create order` so reorders are faster from the product listing.

### Description
- Inserted a `Create reorder` button in `inventory/templates/inventory/snippets/product_scorecard.html` that is shown when `not product.no_restock` and uses the existing `data-open-order-modal="order-modal-{{ product.id }}"` and `data-order-mode="create"` attributes so the existing modal/order flow is reused.

### Testing
- Committed the change (`git commit` succeeded) and inspected the diff; running `python manage.py check` failed in the container due to missing Django (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a599f288832ca5f38e1bb84ce834)