### PR TITLE
Add Create/View reorder buttons to product scorecard

### DIFF
--- a/inventory/templates/inventory/snippets/product_scorecard.html
+++ b/inventory/templates/inventory/snippets/product_scorecard.html
@@ -94,6 +94,40 @@
                     <span class="signal-muted">|</span>
                     av. discount {{ product.average_discount_percentage|floatformat:0|default_if_none:"-" }}%
                   </p>
+                  {% if not product.no_restock %}
+                    <p class="signal-line" style="margin-top: 6px;">
+                      <button
+                        type="button"
+                        class="btn-flat"
+                        data-open-order-modal="order-modal-{{ product.id }}"
+                        data-order-mode="create"
+                      >
+                        Create reorder
+                      </button>
+                      {% if product.pending_order %}
+                        <span class="signal-muted">|</span>
+                        <button
+                          type="button"
+                          class="btn-flat"
+                          data-open-order-modal="order-modal-{{ product.id }}"
+                          data-order-mode="pending"
+                        >
+                          View order
+                        </button>
+                      {% endif %}
+                    </p>
+                  {% elif product.pending_order %}
+                    <p class="signal-line" style="margin-top: 6px;">
+                      <button
+                        type="button"
+                        class="btn-flat"
+                        data-open-order-modal="order-modal-{{ product.id }}"
+                        data-order-mode="pending"
+                      >
+                        View order
+                      </button>
+                    </p>
+                  {% endif %}
                 {% elif product.is_on_order_no_sales %}
                   <hr/>
                   <p class="signal-line">


### PR DESCRIPTION
### Motivation
- Provide quick reorder actions from the product scorecard when a product is eligible for restock or already has a pending order.
- Surface a "View order" action even for products that are flagged as non-restockable if they already have a pending order.

### Description
- Added conditional UI in `inventory/templates/inventory/snippets/product_scorecard.html` to show a "Create reorder" button and a "View order" button when `product.no_restock` is false and `product.pending_order` exists, using `data-open-order-modal` and `data-order-mode` attributes.
- Added a branch to still show a "View order" button when `product.no_restock` is true but `product.pending_order` is present.
- Preserved existing branches for `product.is_on_order_no_sales` (estimated arrival) and the default "Create order" button for other cases, and added small spacing via `style="margin-top: 6px;"` for the new button row.

### Testing
- Ran the automated backend test suite with `pytest` and all tests passed.
- Executed template rendering/unit tests for the inventory scorecard snippet and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a599f288832ca5f38e1bb84ce834)