### PR TITLE
Unify filter bar styles between Product and Order pages

### DIFF
--- a/inventory/static/styles.css
+++ b/inventory/static/styles.css
@@ -952,7 +952,8 @@ div.metadata {
   box-shadow: none;
   max-width: 100%;
   min-width: 220px;
-  padding: 20px;
+  padding: 12px 16px 10px;
+  flex: 1 1 310px;
 }
 
 .filter-divider {
@@ -967,14 +968,40 @@ div.metadata {
   border-radius: 12px;
   box-shadow: none;
   color: #455a64;
-  cursor: pointer;
+  cursor: default;
   font-size: 12px;
   height: 36px;
   line-height: 1;
-  opacity: 1;
+  opacity: 0.5;
   padding: 0 14px;
   text-transform: none;
+  transition: opacity 0.2s ease, color 0.2s ease;
 }
+.filter-apply-button.is-dirty { opacity: 1; cursor: pointer; }
+.filter-card__header { display:flex; justify-content:space-between; align-items:flex-start; gap:12px; }
+.filter-card__content { flex: 1; min-width: 0; }
+.filter-card__subtitle { margin: 0 0 6px; }
+.filter-card__description { margin: 0 0 8px; }
+.filter-card__empty-state { margin: 0; }
+.filter-card__toggle-symbol { display:inline-block; font-size:22px; line-height:0; width:24px; text-align:right; position:relative; top:-6px; right:-16px; }
+.filter-card__options { border-top:1px solid #eceff1; margin-top:12px; padding-top:12px; }
+.option-list { display:block; margin:0 0 12px; }
+.filter-option { display:block; width:100%; text-align:left; padding:6px 0; border:none; background:transparent; color:#039be5; font-weight:700; cursor:pointer; text-decoration:underline; transition:color 0.2s ease; }
+.filter-option:hover { color:#0277bd; }
+.filter-card--tiered .tiered-section { margin-bottom: 12px; }
+.filter-card--tiered .tiered-section[hidden] { display: none; }
+.filter-card--tiered .tiered-section__title { margin:0 0 6px; font-weight:600; color:#455a64; }
+.filter-card--tiered .filter-option { display:inline-flex; width:auto; margin-right:10px; }
+.chip-set { display:flex; flex-wrap:wrap; gap:8px; margin:0; min-height:32px; }
+.chip-set .chip__placeholder { background:#eceff1; color:#607d8b; padding:6px 10px; border-radius:5px; font-size:13px; display:inline-flex; align-items:center; }
+.chip--selected { display:inline-flex; align-items:center; gap:6px; background:#e0f2f1; border:1px solid #b2dfdb; border-radius:0; }
+.chip__remove { border:none; background:transparent; cursor:pointer; padding:0 4px; color:#00695c; font-size:16px; line-height:1; }
+
+.product-filter-surface { padding: 10px 15px; }
+.product-filter-form { margin: 0; width: 100%; }
+.product-filter-grid { width: 100%; }
+.product-filter-controls .input-field { margin-top: 0; }
+.product-filter-groups { display:flex; flex-direction:column; gap:12px; }
 
 .filter-card--compact {
   flex: 1 1 220px;

--- a/inventory/templates/inventory/order_list.html
+++ b/inventory/templates/inventory/order_list.html
@@ -10,181 +10,7 @@
   <h3 class="page-title">Order Planner</h3>
 
   <style>
-    .filter-bar {
-      display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-      margin-bottom: 16px;
-    }
-
-    .filter-card {
-      padding: 12px 16px 10px;
-      border: 1px solid #e0e0e0;
-      border-radius: 10px;
-      box-shadow: none;
-      flex: 0 0 15%;
-      max-width: 20%;
-      min-width: 310px;
-    }
-
-    .filter-section-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      gap: 0px;
-      margin: 0px;
-    }
-
-    .filter-title {
-      margin: 15px 0 6px;
-    }
-
-    .filter-showing {
-      margin: 0;
-      color: #546e7a;
-      font-weight: 600;
-    }
-
-    @media (max-width: 992px) {
-      .filter-card {
-        flex: 1 1 100%;
-        max-width: 100%;
-      }
-    }
-
-    .filter-card__header {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      gap: 12px;
-    }
-
-    .chip-set {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-      margin: 0;
-      min-height: 32px;
-    }
-
-    .chip-set .chip__placeholder {
-      background: #eceff1;
-      color: #607d8b;
-      padding: 6px 10px;
-      border-radius: 5px;
-      font-size: 13px;
-      display: inline-flex;
-      align-items: center;
-    }
-
-    .chip--selected {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      background: #e0f2f1;
-      border: 1px solid #b2dfdb;
-      border-radius: 0;
-    }
-
-    .chip__remove {
-      border: none;
-      background: transparent;
-      cursor: pointer;
-      padding: 0 4px;
-      color: #00695c;
-      font-size: 16px;
-      line-height: 1;
-    }
-
-    .filter-card__toggle-symbol {
-      display: inline-block;
-      font-size: 22px;
-      line-height: 0;
-      width: 24px;
-      text-align: right;
-      position:relative;
-      top:-6px;
-      right:-16px;
-    }
-
-
-    .filter-card__options {
-      border-top: 1px solid #eceff1;
-      margin-top: 12px;
-      padding-top: 12px;
-    }
-
-    .option-list {
-      display: block;
-      margin: 0 0 12px;
-    }
-
-    .filter-option {
-      display: block;
-      width: 100%;
-      text-align: left;
-      padding: 6px 0;
-      border: none;
-      background: transparent;
-      color: #039be5;
-      font-weight: 700;
-      cursor: pointer;
-      text-decoration: underline;
-      transition: color 0.2s ease;
-    }
-
-    .filter-option:hover {
-      color: #0277bd;
-    }
-
-    .filter-divider {
-      border-bottom: 1px solid #e0e0e0;
-      margin: 12px 0 20px;
-      padding-bottom: 8px;
-    }
-
-    .filter-apply-button {
-      background: #f5f5f5;
-      color: #455a64;
-      border: 1px solid #dcdcdc;
-      border-radius: 12px;
-      box-shadow: none;
-      font-size: 12px;
-      line-height: 1;
-      text-transform: none;
-      height: 36px;
-      padding: 0 14px;
-      opacity: 0.5;
-      transition: opacity 0.2s ease, color 0.2s ease;
-      cursor: default;
-    }
-
-    .filter-apply-button.is-dirty {
-      opacity: 1;
-      cursor: pointer;
-    }
-
-    .filter-card--tiered .tiered-section {
-      margin-bottom: 12px;
-    }
-
-    .filter-card--tiered .tiered-section[hidden] {
-      display: none;
-    }
-
-    .filter-card--tiered .tiered-section__title {
-      margin: 0 0 6px;
-      font-weight: 600;
-      color: #455a64;
-    }
-
-    .filter-card--tiered .filter-option {
-      display: inline-flex;
-      width: auto;
-      margin-right: 10px;
-    }
-
-    .flag-details {
+.flag-details {
       margin: 6px 0 0;
     }
 
@@ -288,8 +114,8 @@
             data-subtype-field="subtype_filter"
           >
             <div class="filter-card__header">
-              <div style="flex: 1; min-width: 0;">
-                <p class="grey-text text-darken-1" style="margin: 0 0 6px;">Product Category</p>
+              <div class="filter-card__content">
+                <p class="grey-text text-darken-1 filter-card__subtitle">Product Category</p>
                 <div class="chip-set" data-selected-chips>
                   <span class="chip__placeholder" data-placeholder>None selected</span>
                 </div>
@@ -328,8 +154,8 @@
               data-category-label="{{ control.category_title }}"
             >
               <div class="filter-card__header">
-                <div style="flex: 1; min-width: 0;">
-                  <p class="grey-text text-darken-1" style="margin: 0 0 6px;" data-filter-heading>
+                <div class="filter-card__content">
+                  <p class="grey-text text-darken-1 filter-card__subtitle" data-filter-heading>
                     {{ control.header_text }}
                   </p>
                   <div class="chip-set" data-selected-chips>
@@ -353,7 +179,7 @@
               </div>
 
               <div id="{{ option_id }}" class="filter-card__options" hidden>
-                <p class="grey-text text-darken-1" style="margin: 0 0 8px;">Add or remove {{ control.category_title }} options</p>
+                <p class="grey-text text-darken-1 filter-card__description">Add or remove {{ control.category_title }} options</p>
                 <div class="option-list" data-available-options>
                   {% for option in control.options %}
                     {% if not option.checked %}
@@ -367,7 +193,7 @@
                       </button>
                     {% endif %}
                   {% empty %}
-                    <p class="grey-text text-darken-1" style="margin: 0;">No options available.</p>
+                    <p class="grey-text text-darken-1 filter-card__empty-state">No options available.</p>
                   {% endfor %}
                 </div>
               </div>

--- a/inventory/templates/inventory/product_list.html
+++ b/inventory/templates/inventory/product_list.html
@@ -18,10 +18,10 @@
     <div class="card-panel red lighten-5 red-text text-darken-3">Could not save product. Please check the required fields and Product ID.</div>
   {% endif %}
 
-  <div id="controls" class="row grey lighten-3">
-    <form id="productFilterForm" method="get">
+  <div id="controls" class="row grey lighten-3 product-filter-surface">
+    <form id="productFilterForm" method="get" class="product-filter-form">
 
-      <div class="col s2">
+      <div class="col s12 m3 product-filter-controls">
 
         <div class="input-field">
           <select name="type_filter" onchange="this.form.submit()">
@@ -55,7 +55,7 @@
 
 
       </div>
-      <div class="col s9">
+      <div class="col s12 m9 product-filter-groups">
 
 
         <div class="checkbox-set">


### PR DESCRIPTION
### Motivation
- Consolidate duplicated filter-bar styling so both Product and Order pages share a single, maintainable set of rules in the global stylesheet instead of repeating template-local CSS.
- Eliminate inline style attributes for filter controls to ensure visuals are CSS-driven and easier to update consistently.
- Improve layout efficiency by introducing small reusable utility classes and aligning markup structure between pages.

### Description
- Moved Order page filter CSS out of the template and into `inventory/static/styles.css`, reusing the existing shared filter rules and adding a few utility selectors for subtitle/description/empty-state and header layout.
- Added/normalized CSS tweaks in `inventory/static/styles.css` (adjusted `.filter-card` padding and `flex` behaviour, unified `.filter-apply-button` opacity/transition and dirty state, and added `.filter-card__*` utility classes and product filter surface/form/grid helpers).
- Replaced inline `style=` attributes in `inventory/templates/inventory/order_list.html` for filter headings/descriptions/empty states with class-based markup (`filter-card__content`, `filter-card__subtitle`, `filter-card__description`, `filter-card__empty-state`) so styles are applied from the stylesheet.
- Updated `inventory/templates/inventory/product_list.html` markup to use `product-filter-surface`, `product-filter-form`, `product-filter-controls`, and `product-filter-groups` to align with the shared filter styling and remove duplication.

### Testing
- Attempted to run `python manage.py check`, which could not complete in this environment because Django is not installed (the command failed with a `ModuleNotFoundError`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50535a248832c814f4639b72ae0dc)