### PR TITLE
Use latest full month on dashboard and simplify async value updates

### DIFF
--- a/inventory/templates/inventory/home.html
+++ b/inventory/templates/inventory/home.html
@@ -67,7 +67,6 @@
       <div id="sales-info-card" class="card-panel">
         <p class="grey-text text-darken-2 box-title">Categories breakdown</p>
 
-        <h6 id="salesMonthLabel" class="center-align">{{ current_month_name }}</h6>
         <div class="row" style="margin: 0;">
           <div class="col s12 m6">
             <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
@@ -280,7 +279,6 @@ document.addEventListener("DOMContentLoaded", function () {
   let currentMonth = '{{ current_month_slug }}';
 
   function updateSalesSection(data) {
-    document.getElementById('salesMonthLabel').textContent = data.month_label;
     document.getElementById('monthChooserLabel').textContent = formatMonthRange(data.current_month_slug);
     document.getElementById('totalItemsSold').textContent = data.total_items_sold;
     document.getElementById('totalSales').textContent = '¥' + Math.round(data.total_sales).toLocaleString();
@@ -295,14 +293,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function updateInventorySection(data) {
     document.getElementById('inventoryCount').textContent = data.inventory_count + ' items';
-    document.getElementById('inventoryValue').textContent = 'cost value ¥' + Math.round(data.inventory_value).toLocaleString();
-    document.getElementById('onPaperValue').textContent = 'on paper value ¥' + Math.round(data.on_paper_value).toLocaleString();
-    document.getElementById('estimatedInventorySalesValue').textContent = 'estimated sales value ¥' + Math.round(data.estimated_inventory_sales_value).toLocaleString();
+    document.getElementById('inventoryValue').textContent = '¥' + Math.round(data.inventory_value).toLocaleString();
+    document.getElementById('onPaperValue').textContent = '¥' + Math.round(data.on_paper_value).toLocaleString();
+    document.getElementById('estimatedInventorySalesValue').textContent = '¥' + Math.round(data.estimated_inventory_sales_value).toLocaleString();
 
     document.getElementById('onOrderCount').textContent = data.on_order_count + ' items';
-    document.getElementById('onOrderValue').textContent = 'cost value ¥' + Math.round(data.on_order_value).toLocaleString();
-    document.getElementById('onOrderPaperValue').textContent = 'on paper value ¥' + Math.round(data.on_order_on_paper_value).toLocaleString();
-    document.getElementById('estimatedOnOrderSalesValue').textContent = 'estimated sales value ¥' + Math.round(data.estimated_on_order_sales_value).toLocaleString();
+    document.getElementById('onOrderValue').textContent = '¥' + Math.round(data.on_order_value).toLocaleString();
+    document.getElementById('onOrderPaperValue').textContent = '¥' + Math.round(data.on_order_on_paper_value).toLocaleString();
+    document.getElementById('estimatedOnOrderSalesValue').textContent = '¥' + Math.round(data.estimated_on_order_sales_value).toLocaleString();
 
     const warn = document.getElementById('snapshotWarning');
     const dateEl = document.getElementById('snapshotDate');

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -630,11 +630,12 @@ def home(request):
     # — Determining current month's date range —
     today = date.today()
     first_day_current = today.replace(day=1)
-    end_of_month = (first_day_current + relativedelta(months=1)) - timedelta(days=1)
+    first_day_latest_full_month = first_day_current - relativedelta(months=1)
+    end_of_month = (first_day_latest_full_month + relativedelta(months=1)) - timedelta(days=1)
 
-    # — Sales for current month —
+    # — Sales for latest full month —
     sales_this_month = Sale.objects.filter(
-        date__range=(first_day_current, end_of_month)
+        date__range=(first_day_latest_full_month, end_of_month)
     )
 
     # — Aggregate item counts by category —
@@ -677,8 +678,8 @@ def home(request):
         monthly_sales.append(float(rev))
         monthly_sales_last_year.append(float(rev_last))
 
-    current_month_name = first_day_current.strftime("%B %Y")
-    current_month_slug = first_day_current.strftime("%Y-%m")
+    current_month_name = first_day_latest_full_month.strftime("%B %Y")
+    current_month_slug = first_day_latest_full_month.strftime("%Y-%m")
 
     # — Summary card totals —
     total_sales = (


### PR DESCRIPTION
### Motivation
- Ensure the homepage loads the latest complete month of data on first render (e.g., show April when today is May 3) instead of a partially-complete current month.
- Remove the redundant date heading from the category donut so the pie chart does not show the month as a title/key.
- When switching months asynchronously, only update numeric values in the info boxes (currency numbers) and avoid re-inserting label text to match the updated layout.

### Description
- Changed the dashboard logic in `inventory/views.py` to compute `first_day_latest_full_month` and use that month for `sales_this_month`, `current_month_name`, and `current_month_slug` instead of the current month.
- Removed the month heading (`<h6 id="salesMonthLabel">`) from `inventory/templates/inventory/home.html` so the donut card no longer displays the date.
- Updated the client-side month-switch handlers in `inventory/templates/inventory/home.html` to stop setting `salesMonthLabel` and to render inventory/on-order values as plain currency numbers (e.g., `¥123,456`) rather than prefixed text like `cost value ¥...`.
- Kept the month chooser and `current_month_slug` driven navigation (via the existing `sales-data` endpoint) intact so interactive month changes continue to work.

### Testing
- Ran `python manage.py check`, which could not complete in this environment because Django is not installed and failed with `ModuleNotFoundError: No module named 'django'`.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77a286554832ca796d9d133f4bb15)