### PR TITLE
Count on-order stock directly from OrderItem records

### DIFF
--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -951,6 +951,29 @@ class SalesDataInventoryTests(TestCase):
         self.assertFalse(data["snapshot_warning"])
         self.assertEqual(data["snapshot_date"], "2024-04-01")
 
+    def test_on_order_calculation_includes_unassigned_order_items(self):
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date(2024, 4, 1),
+            inventory_count=8,
+        )
+        OrderItem.objects.create(
+            order=None,
+            product_variant=self.variant,
+            quantity=4,
+            item_cost_price=2,
+            date_expected=date(2024, 3, 18),
+            date_arrived=None,
+        )
+
+        url = reverse("sales_data")
+        res = self.client.get(url, {"year": 2024, "month": 3})
+        data = res.json()
+
+        self.assertEqual(data["on_order_count"], 4)
+        self.assertEqual(data["on_order_value"], 8.0)
+
+
 
 class SalesViewTests(TestCase):
     def setUp(self):

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -573,10 +573,12 @@ def _get_monthly_inventory_data(end_of_month: date) -> dict:
         variants, _simplify_type
     )
 
-    # Orders still open at end_of_month
-    incoming = OrderItem.objects.filter(order__order_date__lte=end_of_month).filter(
-        Q(date_arrived__isnull=True) | Q(date_arrived__gt=end_of_month)
-    )
+    # Order items still open at end_of_month.
+    # We intentionally calculate this from OrderItem records directly so
+    # unassigned order items (order=None) are included.
+    incoming = OrderItem.objects.filter(
+        date_expected__lte=end_of_month
+    ).filter(Q(date_arrived__isnull=True) | Q(date_arrived__gt=end_of_month))
     on_order_count = incoming.aggregate(total=Sum("quantity"))["total"] or 0
     on_order_value = (
         incoming.aggregate(


### PR DESCRIPTION
### Motivation
- Some incoming stock is represented by `OrderItem` rows that are not associated with an `Order`, so calculating "on order" by joining on `Order.order_date` misses those items.  
- The homepage and inventory chart need to show accurate on-order counts/values including unassigned order items.  
- Make `OrderItem` the single source of truth for undelivered/on-order quantities at month-end.

### Description
- Change month-end on-order query in `_get_monthly_inventory_data` to build `incoming` from `OrderItem` directly using `date_expected__lte=end_of_month` and `Q(date_arrived__isnull=True) | Q(date_arrived__gt=end_of_month)` so unassigned `OrderItem(order=None)` are included (file: `inventory/views.py`).  
- Retain existing aggregated computations (`on_order_count`, `on_order_value`, `on_order_on_paper_value`, and `estimated_on_order_sales_value`) but feed them from the new `incoming` queryset (file: `inventory/views.py`).  
- Add a regression test `test_on_order_calculation_includes_unassigned_order_items` to `inventory/tests.py` which creates an unassigned `OrderItem` and asserts it contributes to `on_order_count` and `on_order_value` (file: `inventory/tests.py`).

### Testing
- Added a focused unit test covering unassigned `OrderItem` inclusion and value calculation which is present in `inventory/tests.py`.  
- Attempted to run `python -m pytest inventory/tests.py -k "on_order_calculation"`, but test collection failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'dateutil'`), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77b41c310832cb260a73f425df0ca)