### PR TITLE
Count on-order from OrderItem.date_expected (include unassigned items) and update tests

### DIFF
--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -932,8 +932,8 @@ class SalesDataInventoryTests(TestCase):
             product_variant=self.variant,
             quantity=5,
             item_cost_price=1,
-            date_expected=date(2024, 3, 20),
-            date_arrived=date(2024, 4, 5),
+            date_expected=date(2099, 3, 20),
+            date_arrived=None,
         )
         order2 = Order.objects.create(order_date=date(2024, 3, 5))
         OrderItem.objects.create(
@@ -942,14 +942,58 @@ class SalesDataInventoryTests(TestCase):
             quantity=3,
             item_cost_price=1,
             date_expected=date(2024, 3, 15),
-            date_arrived=date(2024, 3, 20),
+            date_arrived=None,
         )
         url = reverse("sales_data")
         res = self.client.get(url, {"year": 2024, "month": 3})
         data = res.json()
-        self.assertEqual(data["on_order_count"], 5)
+        self.assertEqual(data["on_order_count"], 5)  # only future-expected item counts
         self.assertFalse(data["snapshot_warning"])
         self.assertEqual(data["snapshot_date"], "2024-04-01")
+
+    def test_on_order_calculation_includes_unassigned_order_items(self):
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date(2024, 4, 1),
+            inventory_count=8,
+        )
+        OrderItem.objects.create(
+            order=None,
+            product_variant=self.variant,
+            quantity=4,
+            item_cost_price=2,
+            date_expected=date(2099, 3, 18),
+            date_arrived=None,
+        )
+
+        url = reverse("sales_data")
+        res = self.client.get(url, {"year": 2024, "month": 3})
+        data = res.json()
+
+        self.assertEqual(data["on_order_count"], 4)
+        self.assertEqual(data["on_order_value"], 8.0)
+
+    def test_on_order_calculation_excludes_past_expected_items(self):
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date(2024, 4, 1),
+            inventory_count=8,
+        )
+        OrderItem.objects.create(
+            order=None,
+            product_variant=self.variant,
+            quantity=9,
+            item_cost_price=2,
+            date_expected=date(2024, 3, 18),
+            date_arrived=None,
+        )
+
+        url = reverse("sales_data")
+        res = self.client.get(url, {"year": 2024, "month": 3})
+        data = res.json()
+
+        self.assertEqual(data["on_order_count"], 0)
+
 
 
 class SalesViewTests(TestCase):

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -479,9 +479,10 @@ def _get_monthly_inventory_data(end_of_month: date) -> dict:
 
     Finds the InventorySnapshot closest to ``end_of_month`` (searching both
     before and after) and computes aggregate inventory metrics using that
-    snapshot date. Also calculates quantities that were still on order on the
-    specified date. Returns a dictionary containing the various totals along
-    with ``snapshot_warning`` and ``snapshot_date``.
+    snapshot date. Also calculates quantities currently considered "on order"
+    (expected delivery date in the future and no arrival date). Returns a
+    dictionary containing the various totals along with ``snapshot_warning``
+    and ``snapshot_date``.
     """
 
     # Locate the snapshot date nearest to the month end
@@ -573,9 +574,12 @@ def _get_monthly_inventory_data(end_of_month: date) -> dict:
         variants, _simplify_type
     )
 
-    # Orders still open at end_of_month
-    incoming = OrderItem.objects.filter(order__order_date__lte=end_of_month).filter(
-        Q(date_arrived__isnull=True) | Q(date_arrived__gt=end_of_month)
+    # "On order" means expected delivery in the future and no arrival date.
+    # Calculate directly from OrderItem records so unassigned items are included.
+    today = date.today()
+    incoming = OrderItem.objects.filter(
+        date_expected__gt=today,
+        date_arrived__isnull=True,
     )
     on_order_count = incoming.aggregate(total=Sum("quantity"))["total"] or 0
     on_order_value = (


### PR DESCRIPTION
### Motivation

- Ensure that "on order" totals include `OrderItem` rows that are not attached to an `Order` and only count items with a future expected delivery and no arrival date.
- Simplify and correct the on-order definition to rely on `date_expected` and `date_arrived` rather than the parent `Order` date.
- Clarify function docstring/comments around snapshot selection and on-order semantics.

### Description

- Change `_get_monthly_inventory_data` to compute `incoming` as `OrderItem.objects.filter(date_expected__gt=today, date_arrived__isnull=True)` so unassigned items are included and only future expected deliveries are counted.
- Update docstring and inline comments in `_get_monthly_inventory_data` to reflect the new on-order definition.
- Adjust existing test data to use a future `date_expected` and `date_arrived=None` for the on-order scenario.
- Add tests `test_on_order_calculation_includes_unassigned_order_items` and `test_on_order_calculation_excludes_past_expected_items` to verify inclusion of unassigned items and exclusion of past-expected items, and tweak an assertion comment in `test_on_order_calculation`.

### Testing

- Ran the Django test cases in `inventory.tests.SalesDataInventoryTests` including the newly added tests `test_on_order_calculation_includes_unassigned_order_items` and `test_on_order_calculation_excludes_past_expected_items`.
- All executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77b41c310832cb260a73f425df0ca)