### PR TITLE
Define "on order" as future-expected items and include unassigned OrderItems; update logic and tests

### DIFF
--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -932,8 +932,8 @@ class SalesDataInventoryTests(TestCase):
             product_variant=self.variant,
             quantity=5,
             item_cost_price=1,
-            date_expected=date(2024, 3, 20),
-            date_arrived=date(2024, 4, 5),
+            date_expected=date(2099, 3, 20),
+            date_arrived=None,
         )
         order2 = Order.objects.create(order_date=date(2024, 3, 5))
         OrderItem.objects.create(
@@ -942,14 +942,58 @@ class SalesDataInventoryTests(TestCase):
             quantity=3,
             item_cost_price=1,
             date_expected=date(2024, 3, 15),
-            date_arrived=date(2024, 3, 20),
+            date_arrived=None,
         )
         url = reverse("sales_data")
         res = self.client.get(url, {"year": 2024, "month": 3})
         data = res.json()
-        self.assertEqual(data["on_order_count"], 5)
+        self.assertEqual(data["on_order_count"], 5)  # only future-expected item counts
         self.assertFalse(data["snapshot_warning"])
         self.assertEqual(data["snapshot_date"], "2024-04-01")
+
+    def test_on_order_calculation_includes_unassigned_order_items(self):
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date(2024, 4, 1),
+            inventory_count=8,
+        )
+        OrderItem.objects.create(
+            order=None,
+            product_variant=self.variant,
+            quantity=4,
+            item_cost_price=2,
+            date_expected=date(2099, 3, 18),
+            date_arrived=None,
+        )
+
+        url = reverse("sales_data")
+        res = self.client.get(url, {"year": 2024, "month": 3})
+        data = res.json()
+
+        self.assertEqual(data["on_order_count"], 4)
+        self.assertEqual(data["on_order_value"], 8.0)
+
+    def test_on_order_calculation_excludes_past_expected_items(self):
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date(2024, 4, 1),
+            inventory_count=8,
+        )
+        OrderItem.objects.create(
+            order=None,
+            product_variant=self.variant,
+            quantity=9,
+            item_cost_price=2,
+            date_expected=date(2024, 3, 18),
+            date_arrived=None,
+        )
+
+        url = reverse("sales_data")
+        res = self.client.get(url, {"year": 2024, "month": 3})
+        data = res.json()
+
+        self.assertEqual(data["on_order_count"], 0)
+
 
 
 class SalesViewTests(TestCase):

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -474,14 +474,27 @@ def _get_sales_insights_month(today: date) -> Tuple[date, date, bool]:
     return previous_start, previous_end, False
 
 
+
+
+def _on_order_items_queryset(today: Optional[date] = None):
+    """Return OrderItems considered currently on order.
+
+    On-order items are expected in the future and have no recorded arrival date.
+    """
+    today = today or date.today()
+    return OrderItem.objects.filter(
+        date_expected__gt=today,
+        date_arrived__isnull=True,
+    )
 def _get_monthly_inventory_data(end_of_month: date) -> dict:
     """Return inventory and on-order stats as of the given month end.
 
     Finds the InventorySnapshot closest to ``end_of_month`` (searching both
     before and after) and computes aggregate inventory metrics using that
-    snapshot date. Also calculates quantities that were still on order on the
-    specified date. Returns a dictionary containing the various totals along
-    with ``snapshot_warning`` and ``snapshot_date``.
+    snapshot date. Also calculates quantities currently considered "on order"
+    (expected delivery date in the future and no arrival date). Returns a
+    dictionary containing the various totals along with ``snapshot_warning``
+    and ``snapshot_date``.
     """
 
     # Locate the snapshot date nearest to the month end
@@ -573,10 +586,9 @@ def _get_monthly_inventory_data(end_of_month: date) -> dict:
         variants, _simplify_type
     )
 
-    # Orders still open at end_of_month
-    incoming = OrderItem.objects.filter(order__order_date__lte=end_of_month).filter(
-        Q(date_arrived__isnull=True) | Q(date_arrived__gt=end_of_month)
-    )
+    # "On order" means expected delivery in the future and no arrival date.
+    # Calculate directly from OrderItem records so unassigned items are included.
+    incoming = _on_order_items_queryset()
     on_order_count = incoming.aggregate(total=Sum("quantity"))["total"] or 0
     on_order_value = (
         incoming.aggregate(
@@ -5906,7 +5918,7 @@ def inventory_snapshots(request):
     # base querysets
     snap_qs = InventorySnapshot.objects.filter(date__lte=today)
     sale_qs = Sale.objects.filter(date__lte=today)
-    order_qs = OrderItem.objects.filter(date_arrived__isnull=True)
+    order_qs = _on_order_items_queryset()
 
     if selected_types:
         snap_qs = snap_qs.filter(product_variant__product__type__in=selected_types)
@@ -6188,7 +6200,7 @@ def inventory_snapshots(request):
         events[mo] += -avg_monthly
 
     # 3c) Restock bumps on their exact date_expected
-    for oi in order_qs.filter(date_expected__gt=last_snapshot_date):
+    for oi in order_qs:
         events[oi.date_expected] += oi.quantity
 
     # ——— 4) Turn events into a sorted forecast_data list ——————————


### PR DESCRIPTION
### Motivation
- Make the definition of "on order" explicit: items are counted only if `date_expected` is in the future and `date_arrived` is null, rather than relying on `Order.order_date` or arrival date comparisons to a month-end. 
- Include `OrderItem` rows that are not attached to an `Order` when computing on-order metrics and forecasts. 

### Description
- Add a helper ` _on_order_items_queryset(today: Optional[date] = None)` that returns `OrderItem` rows with `date_expected__gt=today` and `date_arrived__isnull=True`.
- Update `_get_monthly_inventory_data` to compute `incoming` using the new helper and update docstrings/comments to reflect the new "on order" semantics.
- Change `inventory_snapshots` to use the new helper for `order_qs` so forecast generation includes unassigned `OrderItem`s and uses the same on-order definition.
- Modify and add unit tests in `inventory/tests.py`: adjust an existing `test_on_order_calculation` to use future expected dates, and add `test_on_order_calculation_includes_unassigned_order_items` and `test_on_order_calculation_excludes_past_expected_items` to cover unassigned items and exclude past expected deliveries.

### Testing
- Ran the inventory test module via `python manage.py test inventory` which includes the updated `SalesDataInventoryTests` and `SalesViewTests`, and the tests completed successfully. 
- Verified the new tests for unassigned and past-expected `OrderItem`s passed under the updated on-order logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77b41c310832cb260a73f425df0ca)