### PR TITLE
Compute on-order items from OrderItem expected/arrival dates and include unassigned items in forecasts

### DIFF
--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -932,8 +932,8 @@ class SalesDataInventoryTests(TestCase):
             product_variant=self.variant,
             quantity=5,
             item_cost_price=1,
-            date_expected=date(2024, 3, 20),
-            date_arrived=date(2024, 4, 5),
+            date_expected=date(2099, 3, 20),
+            date_arrived=None,
         )
         order2 = Order.objects.create(order_date=date(2024, 3, 5))
         OrderItem.objects.create(
@@ -942,14 +942,58 @@ class SalesDataInventoryTests(TestCase):
             quantity=3,
             item_cost_price=1,
             date_expected=date(2024, 3, 15),
-            date_arrived=date(2024, 3, 20),
+            date_arrived=None,
         )
         url = reverse("sales_data")
         res = self.client.get(url, {"year": 2024, "month": 3})
         data = res.json()
-        self.assertEqual(data["on_order_count"], 5)
+        self.assertEqual(data["on_order_count"], 5)  # only future-expected item counts
         self.assertFalse(data["snapshot_warning"])
         self.assertEqual(data["snapshot_date"], "2024-04-01")
+
+    def test_on_order_calculation_includes_unassigned_order_items(self):
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date(2024, 4, 1),
+            inventory_count=8,
+        )
+        OrderItem.objects.create(
+            order=None,
+            product_variant=self.variant,
+            quantity=4,
+            item_cost_price=2,
+            date_expected=date(2099, 3, 18),
+            date_arrived=None,
+        )
+
+        url = reverse("sales_data")
+        res = self.client.get(url, {"year": 2024, "month": 3})
+        data = res.json()
+
+        self.assertEqual(data["on_order_count"], 4)
+        self.assertEqual(data["on_order_value"], 8.0)
+
+    def test_on_order_calculation_excludes_past_expected_items(self):
+        InventorySnapshot.objects.create(
+            product_variant=self.variant,
+            date=date(2024, 4, 1),
+            inventory_count=8,
+        )
+        OrderItem.objects.create(
+            order=None,
+            product_variant=self.variant,
+            quantity=9,
+            item_cost_price=2,
+            date_expected=date(2024, 3, 18),
+            date_arrived=None,
+        )
+
+        url = reverse("sales_data")
+        res = self.client.get(url, {"year": 2024, "month": 3})
+        data = res.json()
+
+        self.assertEqual(data["on_order_count"], 0)
+
 
 
 class SalesViewTests(TestCase):

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -474,14 +474,27 @@ def _get_sales_insights_month(today: date) -> Tuple[date, date, bool]:
     return previous_start, previous_end, False
 
 
+
+
+def _on_order_items_queryset(today: Optional[date] = None):
+    """Return OrderItems considered currently on order.
+
+    On-order items are expected in the future and have no recorded arrival date.
+    """
+    today = today or date.today()
+    return OrderItem.objects.filter(
+        date_expected__gt=today,
+        date_arrived__isnull=True,
+    )
 def _get_monthly_inventory_data(end_of_month: date) -> dict:
     """Return inventory and on-order stats as of the given month end.
 
     Finds the InventorySnapshot closest to ``end_of_month`` (searching both
     before and after) and computes aggregate inventory metrics using that
-    snapshot date. Also calculates quantities that were still on order on the
-    specified date. Returns a dictionary containing the various totals along
-    with ``snapshot_warning`` and ``snapshot_date``.
+    snapshot date. Also calculates quantities currently considered "on order"
+    (expected delivery date in the future and no arrival date). Returns a
+    dictionary containing the various totals along with ``snapshot_warning``
+    and ``snapshot_date``.
     """
 
     # Locate the snapshot date nearest to the month end
@@ -573,10 +586,9 @@ def _get_monthly_inventory_data(end_of_month: date) -> dict:
         variants, _simplify_type
     )
 
-    # Orders still open at end_of_month
-    incoming = OrderItem.objects.filter(order__order_date__lte=end_of_month).filter(
-        Q(date_arrived__isnull=True) | Q(date_arrived__gt=end_of_month)
-    )
+    # "On order" means expected delivery in the future and no arrival date.
+    # Calculate directly from OrderItem records so unassigned items are included.
+    incoming = _on_order_items_queryset()
     on_order_count = incoming.aggregate(total=Sum("quantity"))["total"] or 0
     on_order_value = (
         incoming.aggregate(
@@ -5906,12 +5918,11 @@ def inventory_snapshots(request):
     # base querysets
     snap_qs = InventorySnapshot.objects.filter(date__lte=today)
     sale_qs = Sale.objects.filter(date__lte=today)
-    order_qs = OrderItem.objects.filter(date_arrived__isnull=True)
+
 
     if selected_types:
         snap_qs = snap_qs.filter(product_variant__product__type__in=selected_types)
         sale_qs = sale_qs.filter(variant__product__type__in=selected_types)
-        order_qs = order_qs.filter(product_variant__product__type__in=selected_types)
 
     def _normalize_group_name(name: str) -> str:
         return "".join(ch.lower() for ch in (name or "") if ch.isalnum())
@@ -6152,6 +6163,15 @@ def inventory_snapshots(request):
         last_snapshot_date = date.fromisoformat(actual_data[-1]["x"])
         last_inventory = actual_data[-1]["y"]
 
+    # Pending inbound items for forecasting from the last snapshot forward.
+    # Include overdue undelivered items as a same-day bump so they are not lost.
+    order_qs = OrderItem.objects.filter(
+        date_arrived__isnull=True,
+        date_expected__gt=last_snapshot_date,
+    )
+    if selected_types:
+        order_qs = order_qs.filter(product_variant__product__type__in=selected_types)
+
     # ——— 2) Compute average monthly sales over past 6 months ————————
     six_mo_ago = today - relativedelta(months=6)
     total_sold = (
@@ -6187,9 +6207,10 @@ def inventory_snapshots(request):
         mo = cursor.replace(day=1)
         events[mo] += -avg_monthly
 
-    # 3c) Restock bumps on their exact date_expected
-    for oi in order_qs.filter(date_expected__gt=last_snapshot_date):
-        events[oi.date_expected] += oi.quantity
+    # 3c) Restock bumps from pending inbound order items.
+    for oi in order_qs:
+        bump_date = oi.date_expected if oi.date_expected > today else today
+        events[bump_date] += oi.quantity
 
     # ——— 4) Turn events into a sorted forecast_data list ——————————
     forecast_data = [{"x": last_snapshot_date.isoformat(), "y": round(last_inventory)}]


### PR DESCRIPTION
### Motivation
- Ensure on-order inventory counts are based on whether an `OrderItem` is still expected in the future and hasn't arrived, rather than relying on linked `Order` dates so unassigned items are included.
- Make forecasting from snapshots include pending inbound items and treat overdue undelivered items as same-day bumps so inventory forecasts do not lose those quantities.

### Description
- Add helper `_on_order_items_queryset` that returns `OrderItem` rows with `date_expected > today` and `date_arrived__isnull=True` and use it for monthly on-order calculations in `_get_monthly_inventory_data` so unassigned items are included.
- Change `incoming` calculation in `_get_monthly_inventory_data` to use the new helper and compute `on_order_count`, `on_order_value`, and `on_order_on_paper_value` from that queryset.
- Update `inventory_snapshots` forecasting to build `order_qs` from `OrderItem.objects.filter(date_arrived__isnull=True, date_expected__gt=last_snapshot_date)` and apply `selected_types` filtering when present.
- When constructing forecast `events`, use `bump_date = oi.date_expected if oi.date_expected > today else today` so overdue undelivered items are applied as a same-day bump rather than being dropped.
- Add tests in `inventory/tests.py` to verify that unassigned `OrderItem`s are counted in on-order calculations and that past-expected items are excluded, and adjust an existing test to reflect the new date/arrival semantics.

### Testing
- Ran the inventory unit tests with the Django test runner via `./manage.py test inventory`, including the new `test_on_order_calculation_includes_unassigned_order_items` and `test_on_order_calculation_excludes_past_expected_items` tests, and they passed.
- Existing sales and snapshot-related tests were executed as part of the suite and passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77b41c310832cb260a73f425df0ca)