### PR TITLE
Compact product filters behind single toolbar toggle

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -431,15 +431,42 @@
     }
   </style>
   {% if filter_controls %}
+  <style>
+    .products-toolbar {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .filters-strip {
+      margin: 8px 0 14px;
+      padding: 8px 12px;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      background: #fafafa;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+    }
+    .filters-strip[hidden] { display: none; }
+    .filters-strip__label { font-size: 12px; color: #607d8b; font-weight: 700; }
+  </style>
 
   <div class="row">
     <div class="col l10">
       <h3 class="page-title">Products <span class="filter-showing small-text grey-text"> / {{ showing_summary }}</span></h3>
     </div>
-    <div class="col l2 right-align">
+    <div class="col l2 right-align products-toolbar">
+      <button type="button" class="btn-flat" data-filters-toggle aria-expanded="false">Filters</button>
       <a class="btn btn-compact add-product-trigger modal-trigger" href="#add-product-modal">Add Product</a>
     </div>
 
+  </div>
+  <div class="filters-strip" data-active-filters-strip hidden>
+    <span class="filters-strip__label">Active filters</span>
+    <div class="chip-set" data-active-filters-chips></div>
   </div>
 
   <div class="filter-divider"></div>
@@ -455,7 +482,7 @@
       {% if search_query %}
         <input type="hidden" name="product_search" value="{{ search_query }}">
       {% endif %}
-      <div class="filter-bar">
+      <div class="filter-bar" data-filters-panel hidden>
         {% if category_filter %}
           <div
             class="card-panel grey lighten-5 filter-card filter-card--tiered"
@@ -471,10 +498,7 @@
                   <span class="chip__placeholder" data-placeholder>None selected</span>
                 </div>
               </div>
-              <button type="button" class="btn-flat filter-card__toggle" aria-expanded="false">
-                <span class="filter-card__toggle-symbol blue">+</span>
-              </button>
-            </div>
+              </div>
 
             <div class="filter-card__options" hidden data-tiered-options>
               <div class="tiered-section" data-style-section>
@@ -524,9 +548,6 @@
                     {% endif %}
                   </div>
                 </div>
-                <button type="button" class="btn-flat filter-card__toggle" aria-expanded="false" aria-controls="{{ option_id }}">
-                  <span class="filter-card__toggle-symbol blue">+</span>
-                </button>
               </div>
 
               <div id="{{ option_id }}" class="filter-card__options" hidden>
@@ -556,7 +577,7 @@
 
       </div>
 
-      <div class="card-panel">
+      <div class="card-panel" data-filter-apply-container hidden>
         <button type="submit" class="btn filter-apply-button" disabled>
           Apply
         </button>
@@ -857,6 +878,10 @@
       const filterControllers = [];
       const applyButton = document.querySelector('.filter-apply-button');
       const applyContainer = document.querySelector('[data-filter-apply-container]');
+      const filtersPanel = document.querySelector('[data-filters-panel]');
+      const filtersToggle = document.querySelector('[data-filters-toggle]');
+      const activeFiltersStrip = document.querySelector('[data-active-filters-strip]');
+      const activeFiltersChips = document.querySelector('[data-active-filters-chips]');
 
       const selectionsDiffer = (a, b) => {
         if (a.length !== b.length) return true;
@@ -878,8 +903,21 @@
 
       const rebuildApplyVisibility = () => {
         if (!applyContainer) return;
-        const hasExpandedFilter = filterControllers.some((controller) => controller.isExpanded());
-        applyContainer.hidden = !hasExpandedFilter;
+        applyContainer.hidden = !(filtersPanel && !filtersPanel.hidden);
+      };
+
+      const rebuildActiveFiltersStrip = () => {
+        if (!activeFiltersStrip || !activeFiltersChips) return;
+        activeFiltersChips.innerHTML = '';
+        document.querySelectorAll('.chip-set [data-selected-value]').forEach((chip) => {
+          const label = chip.querySelector('.chip__label');
+          if (!label) return;
+          const stripChip = document.createElement('span');
+          stripChip.className = 'chip chip--selected';
+          stripChip.textContent = label.textContent.trim();
+          activeFiltersChips.appendChild(stripChip);
+        });
+        activeFiltersStrip.hidden = !activeFiltersChips.children.length;
       };
 
       const parseJsonScript = (id, fallback = []) => {
@@ -928,6 +966,7 @@
 
         const notifyChange = () => {
           rebuildApplyState();
+          rebuildActiveFiltersStrip();
         };
 
         let selectedStyles = new Set(
@@ -1217,6 +1256,7 @@
 
         const notifyChange = () => {
           rebuildApplyState();
+          rebuildActiveFiltersStrip();
         };
 
         const getSelection = () => {
@@ -1346,23 +1386,26 @@
       });
 
       rebuildApplyState();
+      rebuildActiveFiltersStrip();
       rebuildApplyVisibility();
 
-      const setAllExpanded = (expanded) => {
+      const setFiltersExpanded = (expanded) => {
+        if (filtersPanel) {
+          filtersPanel.hidden = !expanded;
+        }
         filterControllers.forEach((controller) => controller.setExpanded(expanded));
+        if (filtersToggle) {
+          filtersToggle.setAttribute('aria-expanded', expanded);
+        }
+        rebuildApplyVisibility();
       };
 
-      filterControllers.forEach((controller) => {
-        controller.toggleButtons.forEach((btn) => {
-          btn.addEventListener('click', (event) => {
-            event.preventDefault();
-            const allExpanded = filterControllers.every((c) => c.isExpanded());
-            const newState = !allExpanded;
-            setAllExpanded(newState);
-            rebuildApplyVisibility();
-          });
+      setFiltersExpanded(false);
+      if (filtersToggle) {
+        filtersToggle.addEventListener('click', () => {
+          setFiltersExpanded(filtersPanel ? filtersPanel.hidden : true);
         });
-      });
+      }
 
       const labels = {{ quarterly_labels|safe }};
       const dataPoints = {{ quarterly_sales|safe }};


### PR DESCRIPTION
### Motivation
- Reduce visual clutter by collapsing per-card expand/collapse controls into a single, compact header control.
- Surface selected filters in a thin, contextual strip under the page title so users can see active filters at a glance.
- Keep the filter `Apply` control behaviour coherent by tying it to the global filters panel state.

### Description
- Added a header `Filters` button next to the `Add Product` button and moved the full filter UI behind a single panel controlled by `data-filters-toggle` and `data-filters-panel` in `inventory/templates/inventory/product_filtered_list.html`.
- Removed per-card +/- toggle buttons from the template and made each card’s option panels controlled by the global expand/collapse state.
- Added an active-filters strip (`data-active-filters-strip` / `data-active-filters-chips`) that renders selected chips beneath the page title and is hidden when no filters are selected.
- Updated the inline JS to introduce `rebuildActiveFiltersStrip()`, wire it into existing change/notify flows, change apply-panel visibility to depend on the global panel, and add `setFiltersExpanded()` to manage global toggle state.
- Included small CSS for the toolbar and active-filters strip to match the compact layout.

### Testing
- Ran `python manage.py check` in the environment; the command failed due to `ModuleNotFoundError: No module named 'django'`, so framework checks could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7898de324832c8ab977aa44357352)