### PR TITLE
Add toggleable Filters toolbar, active-filters strip, and related JS/CSS for product list

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -431,15 +431,59 @@
     }
   </style>
   {% if filter_controls %}
+  <style>
+    .products-toolbar {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: nowrap;
+    }
+    .products-toolbar .btn,
+    .products-toolbar .btn-flat {
+      margin: 0;
+    }
+    .products-toolbar__filters-btn {
+      background: #fff;
+      color: #263238;
+      border: 1px solid #dfe5e8;
+    }
+    .products-toolbar__filters-btn:hover,
+    .products-toolbar__filters-btn:focus {
+      background: #fff;
+    }
+    .filters-strip {
+      margin: 8px 0 14px;
+      padding: 8px 12px;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      background: #fafafa;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+    }
+    .filters-strip[hidden] { display: none; }
+    .filters-strip__label { font-size: 12px; color: #607d8b; font-weight: 700; }
+    [data-filters-panel][hidden],
+    [data-filter-apply-container][hidden] {
+      display: none !important;
+    }
+  </style>
 
   <div class="row">
     <div class="col l10">
       <h3 class="page-title">Products <span class="filter-showing small-text grey-text"> / {{ showing_summary }}</span></h3>
     </div>
-    <div class="col l2 right-align">
+    <div class="col l2 right-align products-toolbar">
+      <button type="button" class="btn btn-compact products-toolbar__filters-btn" data-filters-toggle aria-expanded="false">Filters</button>
       <a class="btn btn-compact add-product-trigger modal-trigger" href="#add-product-modal">Add Product</a>
     </div>
 
+  </div>
+  <div class="filters-strip" data-active-filters-strip hidden>
+    <span class="filters-strip__label">Active filters</span>
+    <div class="chip-set" data-active-filters-chips></div>
   </div>
 
   <div class="filter-divider"></div>
@@ -455,7 +499,7 @@
       {% if search_query %}
         <input type="hidden" name="product_search" value="{{ search_query }}">
       {% endif %}
-      <div class="filter-bar">
+      <div class="filter-bar" data-filters-panel hidden>
         {% if category_filter %}
           <div
             class="card-panel grey lighten-5 filter-card filter-card--tiered"
@@ -471,10 +515,7 @@
                   <span class="chip__placeholder" data-placeholder>None selected</span>
                 </div>
               </div>
-              <button type="button" class="btn-flat filter-card__toggle" aria-expanded="false">
-                <span class="filter-card__toggle-symbol blue">+</span>
-              </button>
-            </div>
+              </div>
 
             <div class="filter-card__options" hidden data-tiered-options>
               <div class="tiered-section" data-style-section>
@@ -524,9 +565,6 @@
                     {% endif %}
                   </div>
                 </div>
-                <button type="button" class="btn-flat filter-card__toggle" aria-expanded="false" aria-controls="{{ option_id }}">
-                  <span class="filter-card__toggle-symbol blue">+</span>
-                </button>
               </div>
 
               <div id="{{ option_id }}" class="filter-card__options" hidden>
@@ -556,7 +594,7 @@
 
       </div>
 
-      <div class="card-panel">
+      <div class="card-panel" data-filter-apply-container hidden>
         <button type="submit" class="btn filter-apply-button" disabled>
           Apply
         </button>
@@ -857,6 +895,10 @@
       const filterControllers = [];
       const applyButton = document.querySelector('.filter-apply-button');
       const applyContainer = document.querySelector('[data-filter-apply-container]');
+      const filtersPanel = document.querySelector('[data-filters-panel]');
+      const filtersToggle = document.querySelector('[data-filters-toggle]');
+      const activeFiltersStrip = document.querySelector('[data-active-filters-strip]');
+      const activeFiltersChips = document.querySelector('[data-active-filters-chips]');
 
       const selectionsDiffer = (a, b) => {
         if (a.length !== b.length) return true;
@@ -878,8 +920,21 @@
 
       const rebuildApplyVisibility = () => {
         if (!applyContainer) return;
-        const hasExpandedFilter = filterControllers.some((controller) => controller.isExpanded());
-        applyContainer.hidden = !hasExpandedFilter;
+        applyContainer.hidden = !(filtersPanel && !filtersPanel.hidden);
+      };
+
+      const rebuildActiveFiltersStrip = () => {
+        if (!activeFiltersStrip || !activeFiltersChips) return;
+        activeFiltersChips.innerHTML = '';
+        document.querySelectorAll('.chip-set [data-selected-value]').forEach((chip) => {
+          const label = chip.querySelector('.chip__label');
+          if (!label) return;
+          const stripChip = document.createElement('span');
+          stripChip.className = 'chip chip--selected';
+          stripChip.textContent = label.textContent.trim();
+          activeFiltersChips.appendChild(stripChip);
+        });
+        activeFiltersStrip.hidden = !activeFiltersChips.children.length;
       };
 
       const parseJsonScript = (id, fallback = []) => {
@@ -928,6 +983,7 @@
 
         const notifyChange = () => {
           rebuildApplyState();
+          rebuildActiveFiltersStrip();
         };
 
         let selectedStyles = new Set(
@@ -1217,6 +1273,7 @@
 
         const notifyChange = () => {
           rebuildApplyState();
+          rebuildActiveFiltersStrip();
         };
 
         const getSelection = () => {
@@ -1346,23 +1403,26 @@
       });
 
       rebuildApplyState();
+      rebuildActiveFiltersStrip();
       rebuildApplyVisibility();
 
-      const setAllExpanded = (expanded) => {
+      const setFiltersExpanded = (expanded) => {
+        if (filtersPanel) {
+          filtersPanel.hidden = !expanded;
+        }
         filterControllers.forEach((controller) => controller.setExpanded(expanded));
+        if (filtersToggle) {
+          filtersToggle.setAttribute('aria-expanded', expanded);
+        }
+        rebuildApplyVisibility();
       };
 
-      filterControllers.forEach((controller) => {
-        controller.toggleButtons.forEach((btn) => {
-          btn.addEventListener('click', (event) => {
-            event.preventDefault();
-            const allExpanded = filterControllers.every((c) => c.isExpanded());
-            const newState = !allExpanded;
-            setAllExpanded(newState);
-            rebuildApplyVisibility();
-          });
+      setFiltersExpanded(false);
+      if (filtersToggle) {
+        filtersToggle.addEventListener('click', () => {
+          setFiltersExpanded(filtersPanel ? filtersPanel.hidden : true);
         });
-      });
+      }
 
       const labels = {{ quarterly_labels|safe }};
       const dataPoints = {{ quarterly_sales|safe }};


### PR DESCRIPTION
### Motivation
- Centralize and simplify product filter controls by exposing a single toolbar toggle for filters and surfacing active filter chips so users can more easily discover and manage applied filters.

### Description
- Add a products toolbar with a `Filters` toggle and `Add Product` button along with new CSS rules for the toolbar and active filters strip (`.products-toolbar`, `.filters-strip`).
- Convert per-card expand toggles into a single collapsible filter panel marked with `data-filters-panel` and hide the per-card toggle buttons, and hide the filter apply container by default using `data-filter-apply-container`.
- Add an active filters strip (`data-active-filters-strip`) that is populated by new JS function `rebuildActiveFiltersStrip` which collects selected chips and shows/hides the strip accordingly.
- Update JavaScript to manage filter-panel open/close state, to recompute apply button enablement (`rebuildApplyState`) and visibility (`rebuildApplyVisibility`), to wire the `Filters` toggle, and to ensure aria attributes reflect the panel state; also parse injected category JSON scripts and keep category filter behavior integrated with the new UI.

### Testing
- Ran the project's Django automated test suite with `./manage.py test` and it passed.
- Ran the frontend static checks (linter) and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7898de324832c8ab977aa44357352)