### PR TITLE
Restyle Products filters button and active filter chips to pill UI

### DIFF
--- a/inventory/templates/inventory/product_filtered_list.html
+++ b/inventory/templates/inventory/product_filtered_list.html
@@ -444,27 +444,58 @@
       margin: 0;
     }
     .products-toolbar__filters-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 48px;
+      padding: 0 20px;
+      border-radius: 999px;
+      border: 1px solid #d5dade;
       background: #fff;
-      color: #263238;
-      border: 1px solid #dfe5e8;
+      color: #111;
+      font-weight: 600;
+      text-transform: none;
+      box-shadow: none;
     }
     .products-toolbar__filters-btn:hover,
     .products-toolbar__filters-btn:focus {
       background: #fff;
+      box-shadow: none;
+    }
+    .products-toolbar__filters-btn .material-icons {
+      font-size: 20px;
+      line-height: 1;
     }
     .filters-strip {
-      margin: 8px 0 14px;
-      padding: 8px 12px;
-      border: 1px solid #e0e0e0;
-      border-radius: 8px;
-      background: #fafafa;
+      margin: 14px 0 14px;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .filters-strip .chip-set {
       display: flex;
       flex-wrap: wrap;
+      justify-content: flex-end;
       align-items: center;
-      gap: 8px;
+      gap: 10px;
     }
+    .filters-strip .chip {
+      margin: 0;
+      padding: 0 14px;
+      min-height: 42px;
+      border: 1px solid #d5dade;
+      border-radius: 999px;
+      background: #fff;
+      color: #52575c;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 18px;
+    }
+    .filters-strip .chip .chip__remove { font-size: 26px; line-height: 1; }
     .filters-strip[hidden] { display: none; }
-    .filters-strip__label { font-size: 12px; color: #607d8b; font-weight: 700; }
     [data-filters-panel][hidden],
     [data-filter-apply-container][hidden] {
       display: none !important;
@@ -485,7 +516,6 @@
   <div class="filter-divider"></div>
 
   <div class="filters-strip" data-active-filters-strip hidden>
-    <span class="filters-strip__label">Active filters</span>
     <div class="chip-set" data-active-filters-chips></div>
   </div>
 


### PR DESCRIPTION
### Motivation
- Make the Products page filters toggle and the selected-filters strip match the provided pill-style screenshot and improve visual hierarchy. 
- Ensure the selected filters strip remains hidden when no filters are selected by relying on the existing `hidden` state and JS population logic.

### Description
- Restyled the filters toggle by updating `.products-toolbar__filters-btn` to an inline-flex rounded pill with increased height, padding, subtle border, non-uppercase text, and adjusted icon sizing via `.material-icons`.
- Reworked the active filters strip layout via `.filters-strip` to right-align chips and use flex layout with spacing and wrap support.
- Introduced pill styling for individual chips with `border-radius`, padding, min-height, border color, font sizing, and adjusted the chip remove control sizing via `.chip__remove`.
- Removed the textual `Active filters` label from the strip markup so only chips are shown when active, while leaving the `data-active-filters-strip` `hidden` behavior unchanged.

### Testing
- No automated tests were run for this change because it is a UI/CSS-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78e1ec3d4832c9d1b323569df1c23)